### PR TITLE
Add OBS iOS camera plugin and SwiftUI companion app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
 
   ios-app:
     name: iOS app (OBSCam)
-    runs-on: macos-14
+    # Needs Xcode 16+: current XcodeGen emits project format 77, which
+    # Xcode 15 (macos-14 runners) cannot open.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  push:
+    branches: ["main", "claude/**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  obs-plugin-linux:
+    name: OBS plugin (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config libobs-dev \
+            libavcodec-dev libavutil-dev
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror"
+        working-directory: obs-plugin
+
+      - name: Build
+        run: cmake --build build
+        working-directory: obs-plugin
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-camera-source-linux-x86_64
+          path: |
+            obs-plugin/build/ios-camera-source.so
+            obs-plugin/data/
+
+  ios-app:
+    name: iOS app (OBSCam)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+        working-directory: ios-app
+
+      # Builds for the iOS Simulator so no signing certificates are needed.
+      # This validates that all Swift sources compile; producing an
+      # installable device build requires an Apple Developer signing
+      # identity (see README notes on releases).
+      - name: Build (Simulator, unsigned)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project OBSCam.xcodeproj \
+            -scheme OBSCam \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO
+        working-directory: ios-app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Build output
+obs-plugin/build*/
+
+# Xcode / XcodeGen
+ios-app/*.xcodeproj
+ios-app/OBSCam.xcodeproj
+xcuserdata/
+DerivedData/
+*.xcworkspace
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# OBSplugin
+# OBS iOS Camera
+
+Use your iPhone or iPad camera as a webcam **directly inside OBS Studio** —
+no virtual camera drivers, no RTMP server, just your local network.
+
+Two components:
+
+| Component | Path | What it does |
+|-----------|------|--------------|
+| **OBS plugin** (`iOS Camera` source) | [`obs-plugin/`](obs-plugin/) | Listens on TCP port 9977, decodes the incoming H.264 stream with FFmpeg, and renders it as a normal OBS video source. Also answers LAN discovery probes on UDP 9978. |
+| **iOS app** (`OBSCam`) | [`ios-app/`](ios-app/) | Captures the camera with AVFoundation, hardware-encodes to H.264 with VideoToolbox, and streams it to the plugin over TCP. |
+
+```
+┌─────────────── iPhone ───────────────┐        ┌──────────── Computer ────────────┐
+│ AVCaptureSession → VideoToolbox H.264 │  TCP   │ TCP server → libavcodec decode → │
+│ → Annex B framing → NWConnection      │ ─────▶ │ obs_source_output_video()        │
+└──────────────────────────────────────┘  :9977  └──────────────────────────────────┘
+                     ▲  UDP broadcast discovery (:9978)  │
+                     └───────────────────────────────────┘
+```
+
+## Quick start
+
+1. **Build & install the plugin** — see [`obs-plugin/BUILDING.md`](obs-plugin/BUILDING.md).
+2. **Build & run the iOS app** — see [`ios-app/BUILDING.md`](ios-app/BUILDING.md).
+3. In OBS: *Sources → + → iOS Camera*. Leave the port at 9977.
+4. On the phone (same Wi-Fi): open OBSCam, tap your computer in the
+   discovered list (or type its IP), pick camera/resolution/frame rate, and
+   tap **Start streaming to OBS**.
+
+The video appears in the OBS source within a second or two. Disconnecting
+(or backgrounding the app) blanks the source.
+
+## Features
+
+- 720p / 1080p at 30 or 60 fps, hardware-encoded (low battery/CPU cost)
+- Front or back camera, mirrored front-camera preview
+- Automatic OBS discovery on the LAN (UDP broadcast), with manual IP fallback
+- Reconnect-friendly: keyframes every 2 s carry SPS/PPS, so OBS can join or
+  recover mid-stream
+- Cross-platform plugin (Linux / macOS / Windows), plain C against libobs +
+  FFmpeg
+
+## Repository layout
+
+```
+obs-plugin/            C plugin for OBS Studio (CMake)
+  src/protocol.h       wire-protocol constants + header parsing
+  src/ios-camera-source.c   the OBS source: TCP server, discovery, packet loop
+  src/h264-decoder.c   libavcodec H.264 → obs_source_frame
+ios-app/               SwiftUI companion app (XcodeGen project)
+  Sources/H264Encoder.swift   VideoToolbox encode + AVCC→Annex B
+  Sources/StreamClient.swift  Network.framework TCP client + framing
+  Sources/DiscoveryClient.swift  UDP broadcast discovery
+docs/PROTOCOL.md       wire protocol specification (version 1)
+```
+
+## Protocol
+
+A tiny length-prefixed packet protocol over one TCP connection (video is
+H.264 Annex B access units; timestamps in nanoseconds). Full spec in
+[`docs/PROTOCOL.md`](docs/PROTOCOL.md).
+
+## Limitations & roadmap
+
+- Video only — microphone audio is a natural next step (`OBSC_PKT_AUDIO`).
+- One connected device per source (add multiple sources on different ports
+  for multiple phones).
+- The stream is unencrypted on your LAN; intended for trusted home/studio
+  networks.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ A tiny length-prefixed packet protocol over one TCP connection (video is
 H.264 Annex B access units; timestamps in nanoseconds). Full spec in
 [`docs/PROTOCOL.md`](docs/PROTOCOL.md).
 
+## Continuous integration
+
+Every push/PR runs [`.github/workflows/build.yml`](.github/workflows/build.yml):
+
+- **OBS plugin** — built on Ubuntu against libobs + FFmpeg with
+  `-Wall -Wextra -Werror`; the compiled `ios-camera-source.so` (plus its
+  `data/` folder) is uploaded as a downloadable artifact on each run.
+- **iOS app** — the Xcode project is generated with XcodeGen and compiled
+  for the iOS Simulator on a macOS runner. This validates the Swift code but
+  does not produce an installable app: iOS device builds must be signed, so
+  installing on your phone still goes through Xcode with your Apple ID (see
+  `ios-app/BUILDING.md`). To ship signed builds from CI later, add an Apple
+  signing certificate + provisioning profile as repo secrets and a
+  `fastlane`/`xcodebuild -exportArchive` step.
+
 ## Limitations & roadmap
 
 - Video only — microphone audio is a natural next step (`OBSC_PKT_AUDIO`).

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,0 +1,74 @@
+# OBS iOS Camera — Wire Protocol (version 1)
+
+The iOS app is the **client**; the OBS plugin is the **server**. Transport is a
+single TCP connection on the plugin's configured port (default **9977**).
+
+All multi-byte integers are **big-endian** (network byte order).
+
+## Packet framing
+
+Every packet starts with a fixed 20-byte header, immediately followed by
+`payload_size` bytes of payload:
+
+| Offset | Size | Field          | Notes                                    |
+|--------|------|----------------|------------------------------------------|
+| 0      | 4    | magic          | ASCII `OBSC` (0x4F 0x42 0x53 0x43)       |
+| 4      | 1    | version        | `1`                                      |
+| 5      | 1    | type           | see packet types below                   |
+| 6      | 2    | flags          | bit 0 (`0x0001`) = keyframe (video only) |
+| 8      | 8    | pts            | presentation timestamp, **nanoseconds**  |
+| 16     | 4    | payload_size   | max 16 MiB (`16 * 1024 * 1024`)          |
+
+A receiver that sees a bad magic, an unknown version, or an oversized
+`payload_size` must drop the connection.
+
+## Packet types
+
+### 1 — HELLO
+Sent once by the client right after the TCP connection is established.
+Payload: UTF-8 JSON, e.g.
+
+```json
+{ "name": "Emma's iPhone", "app": "OBSCam", "protocol": 1 }
+```
+
+### 2 — VIDEO_CONFIG
+Sent after HELLO and again whenever the capture format changes.
+Payload: UTF-8 JSON, e.g.
+
+```json
+{ "codec": "h264", "width": 1280, "height": 720, "fps": 30 }
+```
+
+The plugin treats this as informational; the authoritative dimensions come
+from the H.264 bitstream (SPS).
+
+### 3 — VIDEO
+Payload: one H.264 **access unit in Annex B format** (start-code delimited
+NAL units). Keyframe packets must set the keyframe flag and must be
+self-contained: SPS and PPS NAL units are prepended before the IDR slice so a
+decoder can join mid-stream.
+
+`pts` is the capture presentation timestamp in nanoseconds. It only needs to
+be monotonic; OBS re-bases async timestamps itself.
+
+### 4 — PING
+Optional keep-alive, empty payload, sent by the client every ~2 s while idle.
+The server ignores it.
+
+## Discovery (optional)
+
+The plugin listens for UDP datagrams on port **9978** (discovery port =
+video port + 1). A client broadcasts the ASCII string:
+
+```
+OBSC_DISCOVER
+```
+
+to `255.255.255.255:9978`. Each plugin instance replies to the sender with:
+
+```
+OBSC_HERE:<tcp_port>:<host_name>
+```
+
+Discovery is best-effort; manual host/port entry always works.

--- a/ios-app/BUILDING.md
+++ b/ios-app/BUILDING.md
@@ -1,0 +1,34 @@
+# Building the iOS app (OBSCam)
+
+Requirements: macOS with Xcode 15+, an iPhone/iPad running iOS 15+, and a
+free or paid Apple Developer account for on-device signing.
+
+The Xcode project is generated with [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+so no `.xcodeproj` is checked in:
+
+```bash
+brew install xcodegen
+cd ios-app
+xcodegen generate
+open OBSCam.xcodeproj
+```
+
+In Xcode:
+
+1. Select the **OBSCam** target → *Signing & Capabilities* → pick your team
+   (or set `DEVELOPMENT_TEAM` in `project.yml` before generating).
+2. Optionally change the bundle identifier prefix in `project.yml`
+   (`com.example` by default).
+3. Select your device and **Run**.
+
+On first launch iOS will ask for **camera** and **local network** permission —
+both are required.
+
+## Notes
+
+- The app stops streaming when backgrounded (iOS suspends camera capture);
+  keep it in the foreground while live. The screen is kept awake
+  automatically while streaming.
+- Discovery uses a UDP broadcast on port 9978. If your network blocks
+  broadcasts (some corporate/guest Wi-Fi), enter the computer's IP manually —
+  OBS shows it under Settings, or run `ipconfig` / `ip addr` on the computer.

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -1,0 +1,135 @@
+import Foundation
+import AVFoundation
+import UIKit
+
+/// Owns the AVCaptureSession and delivers raw camera frames.
+final class CameraManager: NSObject {
+    enum Resolution: String, CaseIterable, Identifiable {
+        case hd720 = "720p"
+        case hd1080 = "1080p"
+
+        var id: String { rawValue }
+
+        var preset: AVCaptureSession.Preset {
+            switch self {
+            case .hd720: return .hd1280x720
+            case .hd1080: return .hd1920x1080
+            }
+        }
+
+        var size: (width: Int32, height: Int32) {
+            switch self {
+            case .hd720: return (1280, 720)
+            case .hd1080: return (1920, 1080)
+            }
+        }
+
+        var defaultBitrate: Int {
+            switch self {
+            case .hd720: return 4_000_000
+            case .hd1080: return 8_000_000
+            }
+        }
+    }
+
+    let session = AVCaptureSession()
+    var onSampleBuffer: ((CMSampleBuffer) -> Void)?
+
+    private let sessionQueue = DispatchQueue(label: "obscam.session")
+    private let videoQueue = DispatchQueue(label: "obscam.video")
+    private var videoOutput: AVCaptureVideoDataOutput?
+
+    static func requestPermission() async -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await AVCaptureDevice.requestAccess(for: .video)
+        default:
+            return false
+        }
+    }
+
+    func configure(position: AVCaptureDevice.Position,
+                   resolution: Resolution,
+                   fps: Int32) throws {
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
+
+        session.inputs.forEach(session.removeInput)
+        session.outputs.forEach(session.removeOutput)
+
+        session.sessionPreset = resolution.preset
+
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera,
+                                                   for: .video,
+                                                   position: position) else {
+            throw NSError(domain: "CameraManager", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Camera not available"])
+        }
+
+        let input = try AVCaptureDeviceInput(device: device)
+        guard session.canAddInput(input) else {
+            throw NSError(domain: "CameraManager", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot add camera input"])
+        }
+        session.addInput(input)
+
+        try device.lockForConfiguration()
+        let frameDuration = CMTime(value: 1, timescale: fps)
+        if device.activeFormat.videoSupportedFrameRateRanges
+            .contains(where: { $0.maxFrameRate >= Double(fps) }) {
+            device.activeVideoMinFrameDuration = frameDuration
+            device.activeVideoMaxFrameDuration = frameDuration
+        }
+        device.unlockForConfiguration()
+
+        let output = AVCaptureVideoDataOutput()
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String:
+                kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        ]
+        output.alwaysDiscardsLateVideoFrames = true
+        output.setSampleBufferDelegate(self, queue: videoQueue)
+
+        guard session.canAddOutput(output) else {
+            throw NSError(domain: "CameraManager", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot add video output"])
+        }
+        session.addOutput(output)
+        videoOutput = output
+
+        if let connection = output.connection(with: .video) {
+            if connection.isVideoOrientationSupported {
+                connection.videoOrientation = .landscapeRight
+            }
+            if position == .front, connection.isVideoMirroringSupported {
+                connection.isVideoMirrored = true
+            }
+        }
+    }
+
+    func start() {
+        sessionQueue.async { [session] in
+            if !session.isRunning {
+                session.startRunning()
+            }
+        }
+    }
+
+    func stop() {
+        sessionQueue.async { [session] in
+            if session.isRunning {
+                session.stopRunning()
+            }
+        }
+    }
+}
+
+extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput,
+                       didOutput sampleBuffer: CMSampleBuffer,
+                       from connection: AVCaptureConnection) {
+        onSampleBuffer?(sampleBuffer)
+    }
+}

--- a/ios-app/Sources/CameraPreviewView.swift
+++ b/ios-app/Sources/CameraPreviewView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import AVFoundation
+
+/// Live camera preview backed by AVCaptureVideoPreviewLayer.
+struct CameraPreviewView: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    final class PreviewView: UIView {
+        override static var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+    }
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.previewLayer.session = session
+        view.previewLayer.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {}
+}

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var streamer: Streamer
+
+    var body: some View {
+        NavigationView {
+            Form {
+                previewSection
+                statusSection
+
+                if !streamer.isStreaming {
+                    connectionSection
+                    cameraSection
+                }
+
+                actionSection
+            }
+            .navigationTitle("OBSCam")
+            .onAppear { streamer.refreshServers() }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    private var previewSection: some View {
+        Section {
+            CameraPreviewView(session: streamer.camera.session)
+                .aspectRatio(16 / 9, contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .background(Color.black)
+                .cornerRadius(8)
+                .listRowInsets(EdgeInsets())
+                .overlay {
+                    if !streamer.isStreaming {
+                        Text("Preview starts with streaming")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                }
+        }
+    }
+
+    private var statusSection: some View {
+        Section {
+            HStack {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 10, height: 10)
+                Text(streamer.status.label)
+                    .font(.callout)
+            }
+        }
+    }
+
+    private var statusColor: Color {
+        switch streamer.status {
+        case .idle: return .gray
+        case .connecting: return .yellow
+        case .streaming: return .green
+        case .error: return .red
+        }
+    }
+
+    private var connectionSection: some View {
+        Section("OBS Connection") {
+            if !streamer.discoveredServers.isEmpty {
+                ForEach(streamer.discoveredServers) { server in
+                    Button {
+                        streamer.select(server)
+                    } label: {
+                        HStack {
+                            Image(systemName: "desktopcomputer")
+                            VStack(alignment: .leading) {
+                                Text(server.name)
+                                Text("\(server.host):\(String(server.port))")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            if streamer.host == server.host {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                    }
+                    .foregroundColor(.primary)
+                }
+            }
+
+            TextField("Computer IP (e.g. 192.168.1.20)", text: $streamer.host)
+                .keyboardType(.numbersAndPunctuation)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+            TextField("Port", text: $streamer.portText)
+                .keyboardType(.numberPad)
+
+            Button {
+                streamer.refreshServers()
+            } label: {
+                Label("Scan for OBS on this network", systemImage: "arrow.clockwise")
+            }
+        }
+    }
+
+    private var cameraSection: some View {
+        Section("Camera") {
+            Toggle("Front camera", isOn: $streamer.useFrontCamera)
+
+            Picker("Resolution", selection: $streamer.resolution) {
+                ForEach(CameraManager.Resolution.allCases) { resolution in
+                    Text(resolution.rawValue).tag(resolution)
+                }
+            }
+
+            Picker("Frame rate", selection: $streamer.fps) {
+                Text("30 fps").tag(30)
+                Text("60 fps").tag(60)
+            }
+        }
+    }
+
+    private var actionSection: some View {
+        Section {
+            if streamer.isStreaming {
+                Button(role: .destructive) {
+                    streamer.stop()
+                } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .frame(maxWidth: .infinity)
+                }
+            } else {
+                Button {
+                    Task { await streamer.start() }
+                } label: {
+                    Label("Start streaming to OBS", systemImage: "video.fill")
+                        .frame(maxWidth: .infinity)
+                }
+            }
+
+            if streamer.cameraPermissionDenied {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ios-app/Sources/DiscoveryClient.swift
+++ b/ios-app/Sources/DiscoveryClient.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Darwin
+
+/// Finds OBS instances on the LAN by UDP-broadcasting a probe and collecting
+/// "OBSC_HERE:<port>:<name>" replies from the plugin's discovery responder.
+final class DiscoveryClient {
+    struct Server: Identifiable, Equatable {
+        let host: String
+        let port: UInt16
+        let name: String
+        var id: String { "\(host):\(port)" }
+    }
+
+    var onServersChanged: (([Server]) -> Void)?
+
+    private let queue = DispatchQueue(label: "obscam.discovery")
+    private var socketFD: Int32 = -1
+    private var running = false
+    private var servers: [Server] = []
+
+    func start() {
+        queue.async { [weak self] in
+            self?.run()
+        }
+    }
+
+    func stop() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.running = false
+            if self.socketFD >= 0 {
+                close(self.socketFD)
+                self.socketFD = -1
+            }
+        }
+    }
+
+    private func run() {
+        guard !running else { return }
+
+        let fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard fd >= 0 else { return }
+        socketFD = fd
+        running = true
+        servers = []
+
+        var enable: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &enable, socklen_t(MemoryLayout<Int32>.size))
+
+        var timeout = timeval(tv_sec: 1, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        let discoveryPort = OBSCProtocol.defaultPort + OBSCProtocol.discoveryPortOffset
+        var broadcastAddr = sockaddr_in()
+        broadcastAddr.sin_family = sa_family_t(AF_INET)
+        broadcastAddr.sin_port = discoveryPort.bigEndian
+        broadcastAddr.sin_addr.s_addr = INADDR_BROADCAST
+
+        let probe = Array(OBSCProtocol.discoverRequest.utf8)
+
+        // Probe a few times, listening for replies in between.
+        for _ in 0..<5 where running {
+            probe.withUnsafeBytes { bytes in
+                _ = withUnsafePointer(to: &broadcastAddr) { addr in
+                    addr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                        sendto(fd, bytes.baseAddress, bytes.count, 0, sa,
+                               socklen_t(MemoryLayout<sockaddr_in>.size))
+                    }
+                }
+            }
+            receiveReplies(fd)
+        }
+
+        if socketFD >= 0 {
+            close(socketFD)
+            socketFD = -1
+        }
+        running = false
+    }
+
+    private func receiveReplies(_ fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 512)
+        var from = sockaddr_in()
+        var fromLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+
+        let received = withUnsafeMutablePointer(to: &from) { addr in
+            addr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                recvfrom(fd, &buffer, buffer.count, 0, sa, &fromLen)
+            }
+        }
+        guard received > 0,
+              let reply = String(bytes: buffer[0..<received], encoding: .utf8),
+              reply.hasPrefix(OBSCProtocol.discoverReplyPrefix) else { return }
+
+        // Reply format: OBSC_HERE:<port>:<name>
+        let parts = reply.dropFirst(OBSCProtocol.discoverReplyPrefix.count)
+            .split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let port = UInt16(parts.first ?? "") else { return }
+        let name = parts.count > 1 ? String(parts[1]) : "OBS"
+
+        var hostBuffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        var addr = from.sin_addr
+        inet_ntop(AF_INET, &addr, &hostBuffer, socklen_t(INET_ADDRSTRLEN))
+        let host = String(cString: hostBuffer)
+
+        let server = Server(host: host, port: port, name: name)
+        if !servers.contains(server) {
+            servers.append(server)
+            let snapshot = servers
+            DispatchQueue.main.async { [weak self] in
+                self?.onServersChanged?(snapshot)
+            }
+        }
+    }
+}

--- a/ios-app/Sources/H264Encoder.swift
+++ b/ios-app/Sources/H264Encoder.swift
@@ -1,0 +1,186 @@
+import Foundation
+import VideoToolbox
+import CoreMedia
+
+/// Hardware H.264 encoder (VideoToolbox). Emits Annex B access units;
+/// keyframes are self-contained (SPS/PPS prepended) so the OBS plugin can
+/// join the stream at any keyframe.
+final class H264Encoder {
+    struct EncodedFrame {
+        let data: Data
+        let ptsNanoseconds: UInt64
+        let isKeyframe: Bool
+    }
+
+    var onEncodedFrame: ((EncodedFrame) -> Void)?
+
+    private var session: VTCompressionSession?
+    private let width: Int32
+    private let height: Int32
+    private let fps: Int32
+    private let bitrate: Int
+
+    private static let startCode = Data([0x00, 0x00, 0x00, 0x01])
+
+    init(width: Int32, height: Int32, fps: Int32, bitrate: Int) {
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.bitrate = bitrate
+    }
+
+    func start() throws {
+        var session: VTCompressionSession?
+        let status = VTCompressionSessionCreate(
+            allocator: kCFAllocatorDefault,
+            width: width,
+            height: height,
+            codecType: kCMVideoCodecType_H264,
+            encoderSpecification: nil,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &session)
+
+        guard status == noErr, let session else {
+            throw NSError(domain: "H264Encoder", code: Int(status),
+                          userInfo: [NSLocalizedDescriptionKey: "VTCompressionSessionCreate failed (\(status))"])
+        }
+
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_RealTime,
+                             value: kCFBooleanTrue)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ProfileLevel,
+                             value: kVTProfileLevel_H264_Main_AutoLevel)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AllowFrameReordering,
+                             value: kCFBooleanFalse)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AverageBitRate,
+                             value: NSNumber(value: bitrate))
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ExpectedFrameRate,
+                             value: NSNumber(value: fps))
+        // Keyframe at least every 2 seconds so joins/recoveries are quick.
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameInterval,
+                             value: NSNumber(value: fps * 2))
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration,
+                             value: NSNumber(value: 2))
+
+        VTCompressionSessionPrepareToEncodeFrames(session)
+        self.session = session
+    }
+
+    func stop() {
+        guard let session else { return }
+        VTCompressionSessionCompleteFrames(session, untilPresentationTimeStamp: .invalid)
+        VTCompressionSessionInvalidate(session)
+        self.session = nil
+    }
+
+    /// Request that the next encoded frame is a keyframe (e.g. when a new
+    /// connection is established mid-stream).
+    private var forceNextKeyframe = false
+    func requestKeyframe() {
+        forceNextKeyframe = true
+    }
+
+    func encode(_ sampleBuffer: CMSampleBuffer) {
+        guard let session,
+              let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let duration = CMSampleBufferGetDuration(sampleBuffer)
+
+        var frameProperties: CFDictionary?
+        if forceNextKeyframe {
+            forceNextKeyframe = false
+            frameProperties = [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue!] as CFDictionary
+        }
+
+        VTCompressionSessionEncodeFrame(
+            session,
+            imageBuffer: imageBuffer,
+            presentationTimeStamp: pts,
+            duration: duration,
+            frameProperties: frameProperties,
+            infoFlagsOut: nil
+        ) { [weak self] status, _, sampleBuffer in
+            guard status == noErr, let sampleBuffer else { return }
+            self?.emit(sampleBuffer)
+        }
+    }
+
+    private func emit(_ sampleBuffer: CMSampleBuffer) {
+        guard CMSampleBufferDataIsReady(sampleBuffer) else { return }
+
+        let isKeyframe = !sampleBufferIsNotSync(sampleBuffer)
+        guard let annexB = Self.annexBData(from: sampleBuffer, includeParameterSets: isKeyframe) else { return }
+
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let ptsNs = UInt64(max(0, CMTimeGetSeconds(pts)) * 1_000_000_000)
+
+        onEncodedFrame?(EncodedFrame(data: annexB, ptsNanoseconds: ptsNs, isKeyframe: isKeyframe))
+    }
+
+    private func sampleBufferIsNotSync(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[CFString: Any]],
+              let first = attachments.first else {
+            return false
+        }
+        return (first[kCMSampleAttachmentKey_NotSync] as? Bool) ?? false
+    }
+
+    /// Converts an AVCC (length-prefixed) sample buffer into Annex B,
+    /// optionally prepending SPS/PPS from the format description.
+    private static func annexBData(from sampleBuffer: CMSampleBuffer,
+                                   includeParameterSets: Bool) -> Data? {
+        var result = Data()
+
+        if includeParameterSets,
+           let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) {
+            var parameterSetCount = 0
+            CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                formatDescription, parameterSetIndex: 0,
+                parameterSetPointerOut: nil, parameterSetSizeOut: nil,
+                parameterSetCountOut: &parameterSetCount, nalUnitHeaderLengthOut: nil)
+
+            for index in 0..<parameterSetCount {
+                var pointer: UnsafePointer<UInt8>?
+                var size = 0
+                let status = CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                    formatDescription, parameterSetIndex: index,
+                    parameterSetPointerOut: &pointer, parameterSetSizeOut: &size,
+                    parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil)
+                guard status == noErr, let pointer else { return nil }
+                result.append(startCode)
+                result.append(pointer, count: size)
+            }
+        }
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return nil }
+
+        var totalLength = 0
+        var dataPointer: UnsafeMutablePointer<CChar>?
+        let status = CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0, lengthAtOffsetOut: nil,
+            totalLengthOut: &totalLength, dataPointerOut: &dataPointer)
+        guard status == kCMBlockBufferNoErr, let dataPointer else { return nil }
+
+        // Walk the AVCC buffer: [4-byte BE length][NAL] ... → start codes.
+        var offset = 0
+        let lengthPrefixSize = 4
+        dataPointer.withMemoryRebound(to: UInt8.self, capacity: totalLength) { bytes in
+            while offset + lengthPrefixSize <= totalLength {
+                let nalLength = Int(bytes[offset]) << 24
+                    | Int(bytes[offset + 1]) << 16
+                    | Int(bytes[offset + 2]) << 8
+                    | Int(bytes[offset + 3])
+                offset += lengthPrefixSize
+                guard nalLength > 0, offset + nalLength <= totalLength else { break }
+                result.append(startCode)
+                result.append(bytes + offset, count: nalLength)
+                offset += nalLength
+            }
+        }
+
+        return result.isEmpty ? nil : result
+    }
+}

--- a/ios-app/Sources/OBSCamApp.swift
+++ b/ios-app/Sources/OBSCamApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct OBSCamApp: App {
+    @StateObject private var streamer = Streamer()
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(streamer)
+        }
+        .onChange(of: scenePhase) { phase in
+            // The camera can't capture in the background; stop cleanly so
+            // OBS shows a blank source instead of a frozen frame.
+            if phase == .background {
+                streamer.stop()
+            }
+        }
+    }
+}

--- a/ios-app/Sources/Protocol.swift
+++ b/ios-app/Sources/Protocol.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Wire protocol shared with the OBS plugin. See docs/PROTOCOL.md.
+enum OBSCProtocol {
+    static let magic: [UInt8] = [0x4F, 0x42, 0x53, 0x43] // "OBSC"
+    static let version: UInt8 = 1
+    static let headerSize = 20
+    static let defaultPort: UInt16 = 9977
+    static let discoveryPortOffset: UInt16 = 1
+    static let discoverRequest = "OBSC_DISCOVER"
+    static let discoverReplyPrefix = "OBSC_HERE:"
+
+    enum PacketType: UInt8 {
+        case hello = 1
+        case videoConfig = 2
+        case video = 3
+        case ping = 4
+    }
+
+    struct Flags: OptionSet {
+        let rawValue: UInt16
+        static let keyframe = Flags(rawValue: 0x0001)
+    }
+
+    /// Builds a framed packet: 20-byte big-endian header + payload.
+    static func packet(type: PacketType,
+                       flags: Flags = [],
+                       ptsNanoseconds: UInt64 = 0,
+                       payload: Data) -> Data {
+        var data = Data(capacity: headerSize + payload.count)
+        data.append(contentsOf: magic)
+        data.append(version)
+        data.append(type.rawValue)
+        appendBigEndian(&data, flags.rawValue)
+        appendBigEndian(&data, ptsNanoseconds)
+        appendBigEndian(&data, UInt32(payload.count))
+        data.append(payload)
+        return data
+    }
+
+    private static func appendBigEndian<T: FixedWidthInteger>(_ data: inout Data, _ value: T) {
+        withUnsafeBytes(of: value.bigEndian) { data.append(contentsOf: $0) }
+    }
+}

--- a/ios-app/Sources/StreamClient.swift
+++ b/ios-app/Sources/StreamClient.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Network
+import UIKit
+
+/// TCP client that frames and sends protocol packets to the OBS plugin.
+final class StreamClient {
+    enum State: Equatable {
+        case disconnected
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    var onStateChange: ((State) -> Void)?
+
+    private(set) var state: State = .disconnected {
+        didSet { onStateChange?(state) }
+    }
+
+    private var connection: NWConnection?
+    private let queue = DispatchQueue(label: "obscam.network")
+    private var pingTimer: DispatchSourceTimer?
+
+    func connect(host: String, port: UInt16) {
+        disconnect()
+
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            state = .failed("Invalid port")
+            return
+        }
+
+        let params = NWParameters.tcp
+        if let tcpOptions = params.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
+            tcpOptions.noDelay = true
+            tcpOptions.connectionTimeout = 5
+        }
+
+        let connection = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: params)
+        self.connection = connection
+        state = .connecting
+
+        connection.stateUpdateHandler = { [weak self] newState in
+            guard let self else { return }
+            switch newState {
+            case .ready:
+                self.state = .connected
+                self.sendHello()
+                self.startPing()
+            case .failed(let error):
+                self.state = .failed(error.localizedDescription)
+                self.teardown()
+            case .cancelled:
+                self.state = .disconnected
+            default:
+                break
+            }
+        }
+
+        // Drain (and ignore) anything the server might send; also detects EOF.
+        receiveLoop(on: connection)
+        connection.start(queue: queue)
+    }
+
+    func disconnect() {
+        teardown()
+        state = .disconnected
+    }
+
+    private func teardown() {
+        pingTimer?.cancel()
+        pingTimer = nil
+        connection?.cancel()
+        connection = nil
+    }
+
+    private func receiveLoop(on connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self, weak connection] _, _, isComplete, error in
+            guard let self, let connection, self.connection === connection else { return }
+            if isComplete || error != nil {
+                self.state = .disconnected
+                self.teardown()
+                return
+            }
+            self.receiveLoop(on: connection)
+        }
+    }
+
+    // MARK: - Sending
+
+    private func send(_ data: Data) {
+        connection?.send(content: data, completion: .contentProcessed { [weak self] error in
+            if let error {
+                self?.state = .failed(error.localizedDescription)
+                self?.teardown()
+            }
+        })
+    }
+
+    private func sendHello() {
+        let hello: [String: Any] = [
+            "name": UIDevice.current.name,
+            "app": "OBSCam",
+            "protocol": Int(OBSCProtocol.version),
+        ]
+        guard let payload = try? JSONSerialization.data(withJSONObject: hello) else { return }
+        send(OBSCProtocol.packet(type: .hello, payload: payload))
+    }
+
+    func sendVideoConfig(width: Int32, height: Int32, fps: Int32) {
+        let config: [String: Any] = [
+            "codec": "h264",
+            "width": Int(width),
+            "height": Int(height),
+            "fps": Int(fps),
+        ]
+        guard let payload = try? JSONSerialization.data(withJSONObject: config) else { return }
+        send(OBSCProtocol.packet(type: .videoConfig, payload: payload))
+    }
+
+    func sendVideoFrame(_ frame: H264Encoder.EncodedFrame) {
+        let flags: OBSCProtocol.Flags = frame.isKeyframe ? [.keyframe] : []
+        send(OBSCProtocol.packet(type: .video,
+                                 flags: flags,
+                                 ptsNanoseconds: frame.ptsNanoseconds,
+                                 payload: frame.data))
+    }
+
+    private func startPing() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 2, repeating: 2)
+        timer.setEventHandler { [weak self] in
+            self?.send(OBSCProtocol.packet(type: .ping, payload: Data()))
+        }
+        timer.resume()
+        pingTimer = timer
+    }
+}

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -1,0 +1,177 @@
+import Foundation
+import AVFoundation
+import Combine
+import SwiftUI
+
+/// Glues camera → encoder → network together and exposes state for SwiftUI.
+@MainActor
+final class Streamer: ObservableObject {
+    enum Status: Equatable {
+        case idle
+        case connecting
+        case streaming
+        case error(String)
+
+        var label: String {
+            switch self {
+            case .idle: return "Not connected"
+            case .connecting: return "Connecting…"
+            case .streaming: return "Streaming to OBS"
+            case .error(let message): return message
+            }
+        }
+    }
+
+    // Settings (persisted to UserDefaults)
+    @Published var host: String {
+        didSet { UserDefaults.standard.set(host, forKey: "host") }
+    }
+    @Published var portText: String {
+        didSet { UserDefaults.standard.set(portText, forKey: "port") }
+    }
+    @Published var resolution: CameraManager.Resolution {
+        didSet { UserDefaults.standard.set(resolution.rawValue, forKey: "resolution") }
+    }
+    @Published var fps: Int {
+        didSet { UserDefaults.standard.set(fps, forKey: "fps") }
+    }
+    @Published var useFrontCamera: Bool {
+        didSet { UserDefaults.standard.set(useFrontCamera, forKey: "useFrontCamera") }
+    }
+
+    // State
+    @Published private(set) var status: Status = .idle
+    @Published private(set) var isStreaming = false
+    @Published var discoveredServers: [DiscoveryClient.Server] = []
+    @Published var cameraPermissionDenied = false
+
+    let camera = CameraManager()
+    private var encoder: H264Encoder?
+    private let client = StreamClient()
+    private let discovery = DiscoveryClient()
+
+    init() {
+        let defaults = UserDefaults.standard
+        host = defaults.string(forKey: "host") ?? ""
+        portText = defaults.string(forKey: "port") ?? "\(OBSCProtocol.defaultPort)"
+        resolution = CameraManager.Resolution(
+            rawValue: defaults.string(forKey: "resolution") ?? "") ?? .hd720
+        let storedFps = defaults.integer(forKey: "fps")
+        fps = storedFps > 0 ? storedFps : 30
+        useFrontCamera = defaults.bool(forKey: "useFrontCamera")
+
+        client.onStateChange = { [weak self] state in
+            Task { @MainActor [weak self] in
+                self?.handleClientState(state)
+            }
+        }
+        discovery.onServersChanged = { [weak self] servers in
+            Task { @MainActor [weak self] in
+                self?.discoveredServers = servers
+            }
+        }
+    }
+
+    // MARK: - Discovery
+
+    func refreshServers() {
+        discoveredServers = []
+        discovery.start()
+    }
+
+    func select(_ server: DiscoveryClient.Server) {
+        host = server.host
+        portText = "\(server.port)"
+    }
+
+    // MARK: - Streaming lifecycle
+
+    func start() async {
+        guard !isStreaming else { return }
+
+        guard await CameraManager.requestPermission() else {
+            cameraPermissionDenied = true
+            status = .error("Camera access denied — enable it in Settings")
+            return
+        }
+
+        let trimmedHost = host.trimmingCharacters(in: .whitespaces)
+        guard !trimmedHost.isEmpty else {
+            status = .error("Enter the IP address of the computer running OBS")
+            return
+        }
+        guard let port = UInt16(portText), port >= 1024 else {
+            status = .error("Invalid port")
+            return
+        }
+
+        let size = resolution.size
+        let encoder = H264Encoder(width: size.width, height: size.height,
+                                  fps: Int32(fps),
+                                  bitrate: resolution.defaultBitrate)
+        do {
+            try camera.configure(position: useFrontCamera ? .front : .back,
+                                 resolution: resolution,
+                                 fps: Int32(fps))
+            try encoder.start()
+        } catch {
+            status = .error(error.localizedDescription)
+            return
+        }
+
+        encoder.onEncodedFrame = { [weak self] frame in
+            self?.client.sendVideoFrame(frame)
+        }
+        camera.onSampleBuffer = { [weak encoder] sampleBuffer in
+            encoder?.encode(sampleBuffer)
+        }
+        self.encoder = encoder
+
+        isStreaming = true
+        status = .connecting
+        UIApplication.shared.isIdleTimerDisabled = true
+
+        camera.start()
+        client.connect(host: trimmedHost, port: port)
+    }
+
+    func stop() {
+        guard isStreaming else { return }
+        isStreaming = false
+        status = .idle
+        UIApplication.shared.isIdleTimerDisabled = false
+
+        client.disconnect()
+        camera.stop()
+        camera.onSampleBuffer = nil
+        encoder?.stop()
+        encoder = nil
+    }
+
+    private func handleClientState(_ state: StreamClient.State) {
+        guard isStreaming else { return }
+        switch state {
+        case .connected:
+            status = .streaming
+            let size = resolution.size
+            client.sendVideoConfig(width: size.width, height: size.height,
+                                   fps: Int32(fps))
+            // Fresh connection: make sure OBS gets a decodable frame ASAP.
+            encoder?.requestKeyframe()
+        case .failed(let message):
+            status = .error(message)
+            stopKeepingError()
+        case .disconnected:
+            status = .error("Disconnected from OBS")
+            stopKeepingError()
+        case .connecting:
+            status = .connecting
+        }
+    }
+
+    private func stopKeepingError() {
+        let currentStatus = status
+        stop()
+        status = currentStatus
+    }
+}

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -1,0 +1,36 @@
+# XcodeGen project definition — run `xcodegen generate` in this directory
+# to produce OBSCam.xcodeproj. See BUILDING.md.
+name: OBSCam
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "15.0"
+  createIntermediateGroups: true
+
+targets:
+  OBSCam:
+    type: application
+    platform: iOS
+    sources:
+      - Sources
+    info:
+      path: Sources/Info.plist
+      properties:
+        CFBundleDisplayName: OBSCam
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        NSCameraUsageDescription: >-
+          OBSCam streams your camera to OBS on your computer.
+        NSLocalNetworkUsageDescription: >-
+          OBSCam connects to OBS Studio on your local network to send the
+          camera feed.
+    settings:
+      base:
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SWIFT_VERSION: "5.9"
+        CODE_SIGN_STYLE: Automatic
+        # Set your Apple Developer team to run on a device:
+        # DEVELOPMENT_TEAM: XXXXXXXXXX

--- a/obs-plugin/BUILDING.md
+++ b/obs-plugin/BUILDING.md
@@ -1,0 +1,76 @@
+# Building the OBS plugin
+
+The plugin is plain C and depends on **libobs** and **FFmpeg**
+(`libavcodec`, `libavutil`) — the same FFmpeg OBS itself ships with.
+
+## Linux
+
+```bash
+sudo apt install cmake build-essential pkg-config \
+     libobs-dev libavcodec-dev libavutil-dev   # Debian/Ubuntu
+
+cd obs-plugin
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build   # installs to /usr/local/lib/obs-plugins
+```
+
+If OBS was installed from the distro repos, you may need
+`-DCMAKE_INSTALL_PREFIX=/usr` so the module lands next to the stock plugins.
+Alternatively install per-user by copying manually:
+
+```bash
+mkdir -p ~/.config/obs-studio/plugins/ios-camera-source/bin/64bit \
+         ~/.config/obs-studio/plugins/ios-camera-source/data
+cp build/ios-camera-source.so ~/.config/obs-studio/plugins/ios-camera-source/bin/64bit/
+cp -r data/* ~/.config/obs-studio/plugins/ios-camera-source/data/
+```
+
+## macOS
+
+Build against an obs-studio checkout (Homebrew's `obs` does not ship dev
+headers). With FFmpeg from Homebrew:
+
+```bash
+brew install cmake pkg-config ffmpeg
+cd obs-plugin
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+      -Dlibobs_DIR=/path/to/obs-studio/build/libobs   # exported package
+cmake --build build
+```
+
+Then copy into the app bundle / user plugin dir:
+
+```bash
+mkdir -p ~/Library/Application\ Support/obs-studio/plugins/ios-camera-source/bin
+cp build/ios-camera-source.so ~/Library/Application\ Support/obs-studio/plugins/ios-camera-source/bin/
+mkdir -p ~/Library/Application\ Support/obs-studio/plugins/ios-camera-source/data
+cp -r data/* ~/Library/Application\ Support/obs-studio/plugins/ios-camera-source/data/
+```
+
+## Windows
+
+Use the obs-studio dependency bundle (contains FFmpeg) and a built or
+installed obs-studio tree:
+
+```powershell
+cmake -B build -G "Visual Studio 17 2022" -A x64 `
+  -Dlibobs_DIR=C:\obs-studio\build\libobs `
+  -DFFMPEG_INCLUDE_DIR=C:\obs-deps\include `
+  -DAVCODEC_LIBRARY=C:\obs-deps\lib\avcodec.lib `
+  -DAVUTIL_LIBRARY=C:\obs-deps\lib\avutil.lib
+cmake --build build --config Release
+```
+
+Copy `build\Release\ios-camera-source.dll` to
+`C:\Program Files\obs-studio\obs-plugins\64bit\` and the `data\` folder to
+`C:\Program Files\obs-studio\data\obs-plugins\ios-camera-source\`.
+
+## Verifying
+
+Start OBS → *Sources* → **+** → **iOS Camera**. The properties dialog shows
+the listen port (default 9977) and connection status. Check the OBS log for
+`[ios-camera] listening on port 9977`.
+
+Firewall note: the plugin listens on TCP 9977 and UDP 9978 (discovery) —
+allow OBS through the firewall for the local network.

--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.16...3.30)
+
+project(ios-camera-source VERSION 0.1.0 LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# --- libobs ----------------------------------------------------------------
+# Prefer an installed libobs CMake package (obs-studio >= 27 installs one);
+# fall back to pkg-config for distro packages.
+find_package(libobs QUIET)
+if(NOT TARGET OBS::libobs)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LIBOBS REQUIRED IMPORTED_TARGET GLOBAL libobs)
+  add_library(OBS::libobs ALIAS PkgConfig::LIBOBS)
+endif()
+
+# --- FFmpeg (libavcodec / libavutil) ---------------------------------------
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(FFMPEG IMPORTED_TARGET GLOBAL libavcodec libavutil)
+endif()
+if(TARGET PkgConfig::FFMPEG)
+  set(FFMPEG_TARGET PkgConfig::FFMPEG)
+else()
+  # Manual fallback (e.g. Windows with the obs-studio dependency bundle):
+  # pass -DFFMPEG_INCLUDE_DIR=... -DAVCODEC_LIBRARY=... -DAVUTIL_LIBRARY=...
+  find_path(FFMPEG_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
+  find_library(AVCODEC_LIBRARY avcodec REQUIRED)
+  find_library(AVUTIL_LIBRARY avutil REQUIRED)
+  add_library(ffmpeg-manual INTERFACE)
+  target_include_directories(ffmpeg-manual INTERFACE ${FFMPEG_INCLUDE_DIR})
+  target_link_libraries(ffmpeg-manual INTERFACE ${AVCODEC_LIBRARY} ${AVUTIL_LIBRARY})
+  set(FFMPEG_TARGET ffmpeg-manual)
+endif()
+
+# --- plugin ----------------------------------------------------------------
+add_library(${PROJECT_NAME} MODULE
+  src/plugin-main.c
+  src/ios-camera-source.c
+  src/h264-decoder.c
+  src/protocol.h
+  src/net-compat.h
+  src/h264-decoder.h
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE OBS::libobs ${FFMPEG_TARGET})
+
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
+endif()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+
+# --- install ---------------------------------------------------------------
+# Default layout matches a Linux system-wide OBS install; override
+# CMAKE_INSTALL_PREFIX / the two dirs below for other layouts, or just copy
+# the built module + data/ into your OBS plugin folder (see BUILDING.md).
+include(GNUInstallDirs)
+
+if(NOT OBS_PLUGIN_DESTINATION)
+  set(OBS_PLUGIN_DESTINATION "${CMAKE_INSTALL_LIBDIR}/obs-plugins")
+endif()
+if(NOT OBS_DATA_DESTINATION)
+  set(OBS_DATA_DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins")
+endif()
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${OBS_PLUGIN_DESTINATION}")
+install(DIRECTORY data/ DESTINATION "${OBS_DATA_DESTINATION}/${PROJECT_NAME}")

--- a/obs-plugin/data/locale/en-US.ini
+++ b/obs-plugin/data/locale/en-US.ini
@@ -1,0 +1,7 @@
+IOSCameraSource="iOS Camera"
+Port="Listen Port"
+Status="Status"
+Status.Listening="Waiting for iOS device on port"
+Status.Connected="Connected:"
+Status.PortError="Could not open port"
+HelpText="Open the OBSCam app on your iPhone/iPad (same Wi-Fi network), pick this computer from the list or enter its IP address and the port above, then tap Start."

--- a/obs-plugin/src/h264-decoder.c
+++ b/obs-plugin/src/h264-decoder.c
@@ -1,0 +1,144 @@
+#include "h264-decoder.h"
+
+#include <libavcodec/avcodec.h>
+#include <libavutil/avutil.h>
+#include <libavutil/pixfmt.h>
+
+#include <media-io/video-io.h>
+#include <util/platform.h>
+
+struct h264_decoder {
+	AVCodecContext *ctx;
+	AVPacket *pkt;
+	AVFrame *frame;
+};
+
+struct h264_decoder *h264_decoder_create(void)
+{
+	const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+	if (!codec) {
+		blog(LOG_ERROR, "[ios-camera] H.264 decoder not available");
+		return NULL;
+	}
+
+	struct h264_decoder *dec = bzalloc(sizeof(*dec));
+
+	dec->ctx = avcodec_alloc_context3(codec);
+	dec->pkt = av_packet_alloc();
+	dec->frame = av_frame_alloc();
+	if (!dec->ctx || !dec->pkt || !dec->frame)
+		goto fail;
+
+	dec->ctx->flags |= AV_CODEC_FLAG_LOW_DELAY;
+	dec->ctx->flags2 |= AV_CODEC_FLAG2_CHUNKS;
+
+	if (avcodec_open2(dec->ctx, codec, NULL) < 0) {
+		blog(LOG_ERROR, "[ios-camera] failed to open H.264 decoder");
+		goto fail;
+	}
+
+	return dec;
+
+fail:
+	h264_decoder_destroy(dec);
+	return NULL;
+}
+
+void h264_decoder_destroy(struct h264_decoder *dec)
+{
+	if (!dec)
+		return;
+
+	avcodec_free_context(&dec->ctx);
+	av_packet_free(&dec->pkt);
+	av_frame_free(&dec->frame);
+	bfree(dec);
+}
+
+static bool avframe_to_obs(const AVFrame *frame, struct obs_source_frame *out)
+{
+	switch (frame->format) {
+	case AV_PIX_FMT_YUV420P:
+	case AV_PIX_FMT_YUVJ420P:
+		out->format = VIDEO_FORMAT_I420;
+		break;
+	case AV_PIX_FMT_NV12:
+		out->format = VIDEO_FORMAT_NV12;
+		break;
+	case AV_PIX_FMT_YUV422P:
+		out->format = VIDEO_FORMAT_I422;
+		break;
+	default:
+		return false;
+	}
+
+	out->width = (uint32_t)frame->width;
+	out->height = (uint32_t)frame->height;
+
+	for (int i = 0; i < AV_NUM_DATA_POINTERS && frame->data[i]; i++) {
+		out->data[i] = frame->data[i];
+		out->linesize[i] = (uint32_t)frame->linesize[i];
+	}
+
+	bool full = frame->color_range == AVCOL_RANGE_JPEG ||
+		    frame->format == AV_PIX_FMT_YUVJ420P;
+	enum video_range_type range =
+		full ? VIDEO_RANGE_FULL : VIDEO_RANGE_PARTIAL;
+	enum video_colorspace cs = frame->height > 720 ? VIDEO_CS_709
+						       : VIDEO_CS_601;
+	if (frame->colorspace == AVCOL_SPC_BT709)
+		cs = VIDEO_CS_709;
+	else if (frame->colorspace == AVCOL_SPC_SMPTE170M ||
+		 frame->colorspace == AVCOL_SPC_BT470BG)
+		cs = VIDEO_CS_601;
+
+	out->full_range = range == VIDEO_RANGE_FULL;
+	video_format_get_parameters(cs, range, out->color_matrix,
+				    out->color_range_min,
+				    out->color_range_max);
+	return true;
+}
+
+bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
+			 const uint8_t *data, size_t size, uint64_t pts_ns)
+{
+	dec->pkt->data = (uint8_t *)data;
+	dec->pkt->size = (int)size;
+	dec->pkt->pts = (int64_t)pts_ns;
+	dec->pkt->dts = (int64_t)pts_ns;
+
+	int ret = avcodec_send_packet(dec->ctx, dec->pkt);
+	if (ret < 0 && ret != AVERROR(EAGAIN)) {
+		blog(LOG_WARNING, "[ios-camera] avcodec_send_packet: %d", ret);
+		return ret != AVERROR_INVALIDDATA ? false : true;
+	}
+
+	for (;;) {
+		ret = avcodec_receive_frame(dec->ctx, dec->frame);
+		if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+			break;
+		if (ret < 0) {
+			blog(LOG_WARNING,
+			     "[ios-camera] avcodec_receive_frame: %d", ret);
+			return false;
+		}
+
+		struct obs_source_frame out = {0};
+		if (!avframe_to_obs(dec->frame, &out)) {
+			blog(LOG_WARNING,
+			     "[ios-camera] unsupported pixel format %d",
+			     dec->frame->format);
+			av_frame_unref(dec->frame);
+			continue;
+		}
+
+		out.timestamp = dec->frame->pts != AV_NOPTS_VALUE
+					? (uint64_t)dec->frame->pts
+					: os_gettime_ns();
+
+		obs_source_output_video(source, &out);
+		av_frame_unref(dec->frame);
+	}
+
+	return true;
+}

--- a/obs-plugin/src/h264-decoder.h
+++ b/obs-plugin/src/h264-decoder.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <obs-module.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+struct h264_decoder;
+
+struct h264_decoder *h264_decoder_create(void);
+void h264_decoder_destroy(struct h264_decoder *dec);
+
+/*
+ * Decodes one Annex B access unit and pushes any resulting frames to the
+ * source via obs_source_output_video(). Returns false on a hard decoder
+ * error (caller should recreate the decoder and wait for a keyframe).
+ */
+bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
+			 const uint8_t *data, size_t size, uint64_t pts_ns);

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -1,0 +1,491 @@
+/*
+ * "iOS Camera" async video source.
+ *
+ * Runs a small TCP server on a background thread. The iOS companion app
+ * connects and streams H.264 access units (Annex B) which are decoded with
+ * libavcodec and handed to OBS via obs_source_output_video(). A UDP
+ * responder on port+1 answers LAN discovery probes from the app.
+ */
+
+#include <obs-module.h>
+#include <util/platform.h>
+#include <util/threading.h>
+#include <util/bmem.h>
+#include <util/dstr.h>
+
+#include <string.h>
+#include <stdio.h>
+
+#include "net-compat.h"
+#include "protocol.h"
+#include "h264-decoder.h"
+
+#define S_PORT "port"
+#define T_(s) obs_module_text(s)
+
+#define RECV_CHUNK 65536
+
+struct recv_buf {
+	uint8_t *data;
+	size_t len;
+	size_t cap;
+};
+
+struct ios_camera_source {
+	obs_source_t *source;
+
+	pthread_t thread;
+	bool thread_active;
+	volatile bool stop;
+
+	int port;
+
+	pthread_mutex_t status_mutex;
+	struct dstr status;
+};
+
+/* ------------------------------------------------------------------ */
+
+static void set_status(struct ios_camera_source *s, const char *fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+
+	pthread_mutex_lock(&s->status_mutex);
+	dstr_vprintf(&s->status, fmt, args);
+	pthread_mutex_unlock(&s->status_mutex);
+
+	va_end(args);
+}
+
+static void recv_buf_free(struct recv_buf *b)
+{
+	bfree(b->data);
+	memset(b, 0, sizeof(*b));
+}
+
+static void recv_buf_append(struct recv_buf *b, const uint8_t *data,
+			    size_t size)
+{
+	if (b->len + size > b->cap) {
+		size_t new_cap = b->cap ? b->cap : RECV_CHUNK;
+		while (new_cap < b->len + size)
+			new_cap *= 2;
+		b->data = brealloc(b->data, new_cap);
+		b->cap = new_cap;
+	}
+	memcpy(b->data + b->len, data, size);
+	b->len += size;
+}
+
+static void recv_buf_consume(struct recv_buf *b, size_t size)
+{
+	if (size >= b->len) {
+		b->len = 0;
+		return;
+	}
+	memmove(b->data, b->data + size, b->len - size);
+	b->len -= size;
+}
+
+/* ------------------------------------------------------------------ */
+
+static socket_t open_tcp_listener(int port)
+{
+	socket_t sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock == OBSC_INVALID_SOCKET)
+		return sock;
+
+	int yes = 1;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes,
+		   sizeof(yes));
+
+	struct sockaddr_in addr = {0};
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	addr.sin_port = htons((uint16_t)port);
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0 ||
+	    listen(sock, 1) != 0) {
+		net_close(sock);
+		return OBSC_INVALID_SOCKET;
+	}
+
+	net_set_nonblocking(sock);
+	return sock;
+}
+
+static socket_t open_discovery_socket(int port)
+{
+	socket_t sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock == OBSC_INVALID_SOCKET)
+		return sock;
+
+	int yes = 1;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes,
+		   sizeof(yes));
+
+	struct sockaddr_in addr = {0};
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	addr.sin_port = htons((uint16_t)(port + OBSC_DISCOVERY_PORT_OFFSET));
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+		net_close(sock);
+		return OBSC_INVALID_SOCKET;
+	}
+
+	net_set_nonblocking(sock);
+	return sock;
+}
+
+static void answer_discovery(socket_t sock, int tcp_port)
+{
+	char probe[64];
+	struct sockaddr_in from = {0};
+	socklen_t from_len = sizeof(from);
+
+	int n = (int)recvfrom(sock, probe, sizeof(probe) - 1, 0,
+			      (struct sockaddr *)&from, &from_len);
+	if (n <= 0)
+		return;
+	probe[n] = 0;
+
+	if (strncmp(probe, OBSC_DISCOVER_REQUEST,
+		    strlen(OBSC_DISCOVER_REQUEST)) != 0)
+		return;
+
+	char host[128] = "OBS";
+	gethostname(host, sizeof(host) - 1);
+	host[sizeof(host) - 1] = 0;
+
+	char reply[192];
+	snprintf(reply, sizeof(reply), OBSC_DISCOVER_REPLY_PREFIX "%d:%s",
+		 tcp_port, host);
+
+	sendto(sock, reply, (int)strlen(reply), 0, (struct sockaddr *)&from,
+	       from_len);
+}
+
+/* ------------------------------------------------------------------ */
+
+struct client_state {
+	socket_t sock;
+	struct recv_buf buf;
+	struct h264_decoder *decoder;
+	char name[128];
+};
+
+static void client_disconnect(struct ios_camera_source *s,
+			      struct client_state *c)
+{
+	if (c->sock != OBSC_INVALID_SOCKET) {
+		net_close(c->sock);
+		c->sock = OBSC_INVALID_SOCKET;
+	}
+	recv_buf_free(&c->buf);
+	h264_decoder_destroy(c->decoder);
+	c->decoder = NULL;
+	c->name[0] = 0;
+
+	/* Clear the last frame so the source goes blank when the phone
+	 * disconnects instead of freezing on a stale image. */
+	obs_source_output_video(s->source, NULL);
+	set_status(s, "%s (%d)", T_("Status.Listening"), s->port);
+}
+
+static void extract_json_string(const char *json, const char *key, char *out,
+				size_t out_size)
+{
+	/* Tiny best-effort extraction of "key":"value" — enough for the
+	 * HELLO payload without pulling in a JSON dependency. */
+	char pattern[64];
+	snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+
+	const char *p = strstr(json, pattern);
+	if (!p)
+		return;
+	p = strchr(p + strlen(pattern), ':');
+	if (!p)
+		return;
+	p++;
+	while (*p == ' ' || *p == '\t')
+		p++;
+	if (*p != '"')
+		return;
+	p++;
+
+	size_t i = 0;
+	while (*p && *p != '"' && i + 1 < out_size)
+		out[i++] = *p++;
+	out[i] = 0;
+}
+
+static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
+			  const struct obsc_header *hdr,
+			  const uint8_t *payload)
+{
+	switch (hdr->type) {
+	case OBSC_PKT_HELLO: {
+		char json[512] = {0};
+		size_t n = hdr->payload_size < sizeof(json) - 1
+				   ? hdr->payload_size
+				   : sizeof(json) - 1;
+		memcpy(json, payload, n);
+		extract_json_string(json, "name", c->name, sizeof(c->name));
+		blog(LOG_INFO, "[ios-camera] client connected: %s",
+		     c->name[0] ? c->name : "(unnamed)");
+		set_status(s, "%s %s", T_("Status.Connected"),
+			   c->name[0] ? c->name : "iOS device");
+		break;
+	}
+	case OBSC_PKT_VIDEO_CONFIG:
+		blog(LOG_INFO, "[ios-camera] video config: %.*s",
+		     (int)hdr->payload_size, (const char *)payload);
+		break;
+	case OBSC_PKT_VIDEO:
+		if (!c->decoder) {
+			/* Join on a keyframe so the decoder starts clean. */
+			if (!(hdr->flags & OBSC_FLAG_KEYFRAME))
+				break;
+			c->decoder = h264_decoder_create();
+			if (!c->decoder)
+				return false;
+		}
+		if (!h264_decoder_decode(c->decoder, s->source, payload,
+					 hdr->payload_size, hdr->pts_ns)) {
+			blog(LOG_WARNING,
+			     "[ios-camera] decoder error, resetting");
+			h264_decoder_destroy(c->decoder);
+			c->decoder = NULL;
+		}
+		break;
+	case OBSC_PKT_PING:
+		break;
+	default:
+		blog(LOG_WARNING, "[ios-camera] unknown packet type %d",
+		     hdr->type);
+		break;
+	}
+	return true;
+}
+
+static bool client_read(struct ios_camera_source *s, struct client_state *c)
+{
+	uint8_t chunk[RECV_CHUNK];
+	int n = (int)recv(c->sock, (char *)chunk, sizeof(chunk), 0);
+	if (n <= 0)
+		return false;
+
+	recv_buf_append(&c->buf, chunk, (size_t)n);
+
+	while (c->buf.len >= OBSC_HEADER_SIZE) {
+		struct obsc_header hdr;
+		if (!obsc_parse_header(c->buf.data, &hdr)) {
+			blog(LOG_WARNING,
+			     "[ios-camera] bad packet header, dropping client");
+			return false;
+		}
+
+		size_t total = OBSC_HEADER_SIZE + hdr.payload_size;
+		if (c->buf.len < total)
+			break;
+
+		if (!handle_packet(s, c, &hdr,
+				   c->buf.data + OBSC_HEADER_SIZE))
+			return false;
+
+		recv_buf_consume(&c->buf, total);
+	}
+
+	return true;
+}
+
+static void *server_thread(void *data)
+{
+	struct ios_camera_source *s = data;
+
+	os_set_thread_name("ios-camera-server");
+
+	socket_t listener = open_tcp_listener(s->port);
+	socket_t discovery = open_discovery_socket(s->port);
+	struct client_state client = {.sock = OBSC_INVALID_SOCKET};
+
+	if (listener == OBSC_INVALID_SOCKET) {
+		blog(LOG_ERROR, "[ios-camera] failed to listen on port %d",
+		     s->port);
+		set_status(s, "%s (%d)", T_("Status.PortError"), s->port);
+	} else {
+		blog(LOG_INFO, "[ios-camera] listening on port %d", s->port);
+		set_status(s, "%s (%d)", T_("Status.Listening"), s->port);
+	}
+
+	while (!s->stop && listener != OBSC_INVALID_SOCKET) {
+		fd_set fds;
+		FD_ZERO(&fds);
+		FD_SET(listener, &fds);
+		socket_t max_fd = listener;
+
+		if (discovery != OBSC_INVALID_SOCKET) {
+			FD_SET(discovery, &fds);
+			if (discovery > max_fd)
+				max_fd = discovery;
+		}
+		if (client.sock != OBSC_INVALID_SOCKET) {
+			FD_SET(client.sock, &fds);
+			if (client.sock > max_fd)
+				max_fd = client.sock;
+		}
+
+		struct timeval tv = {.tv_sec = 0, .tv_usec = 200 * 1000};
+		int ret = select((int)max_fd + 1, &fds, NULL, NULL, &tv);
+		if (ret < 0)
+			break;
+		if (ret == 0)
+			continue;
+
+		if (discovery != OBSC_INVALID_SOCKET &&
+		    FD_ISSET(discovery, &fds))
+			answer_discovery(discovery, s->port);
+
+		if (FD_ISSET(listener, &fds)) {
+			struct sockaddr_in from;
+			socklen_t from_len = sizeof(from);
+			socket_t accepted = accept(
+				listener, (struct sockaddr *)&from, &from_len);
+			if (accepted != OBSC_INVALID_SOCKET) {
+				/* Newest connection wins; drop the old one. */
+				if (client.sock != OBSC_INVALID_SOCKET)
+					client_disconnect(s, &client);
+				net_set_nonblocking(accepted);
+				int yes = 1;
+				setsockopt(accepted, IPPROTO_TCP, TCP_NODELAY,
+					   (const char *)&yes, sizeof(yes));
+				client.sock = accepted;
+				set_status(s, "%s", T_("Status.Connected"));
+			}
+		}
+
+		if (client.sock != OBSC_INVALID_SOCKET &&
+		    FD_ISSET(client.sock, &fds)) {
+			if (!client_read(s, &client)) {
+				blog(LOG_INFO,
+				     "[ios-camera] client disconnected");
+				client_disconnect(s, &client);
+			}
+		}
+	}
+
+	if (client.sock != OBSC_INVALID_SOCKET)
+		client_disconnect(s, &client);
+	if (listener != OBSC_INVALID_SOCKET)
+		net_close(listener);
+	if (discovery != OBSC_INVALID_SOCKET)
+		net_close(discovery);
+
+	return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void stop_thread(struct ios_camera_source *s)
+{
+	if (!s->thread_active)
+		return;
+	s->stop = true;
+	pthread_join(s->thread, NULL);
+	s->thread_active = false;
+	s->stop = false;
+}
+
+static void start_thread(struct ios_camera_source *s)
+{
+	if (s->thread_active)
+		return;
+	if (pthread_create(&s->thread, NULL, server_thread, s) == 0)
+		s->thread_active = true;
+	else
+		blog(LOG_ERROR, "[ios-camera] failed to start server thread");
+}
+
+static const char *ios_camera_get_name(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+	return T_("IOSCameraSource");
+}
+
+static void ios_camera_update(void *data, obs_data_t *settings)
+{
+	struct ios_camera_source *s = data;
+	int port = (int)obs_data_get_int(settings, S_PORT);
+
+	if (port != s->port) {
+		stop_thread(s);
+		s->port = port;
+		start_thread(s);
+	}
+}
+
+static void *ios_camera_create(obs_data_t *settings, obs_source_t *source)
+{
+	struct ios_camera_source *s = bzalloc(sizeof(*s));
+	s->source = source;
+	s->port = (int)obs_data_get_int(settings, S_PORT);
+
+	pthread_mutex_init(&s->status_mutex, NULL);
+	dstr_init(&s->status);
+
+	start_thread(s);
+	return s;
+}
+
+static void ios_camera_destroy(void *data)
+{
+	struct ios_camera_source *s = data;
+
+	stop_thread(s);
+	dstr_free(&s->status);
+	pthread_mutex_destroy(&s->status_mutex);
+	bfree(s);
+}
+
+static void ios_camera_get_defaults(obs_data_t *settings)
+{
+	obs_data_set_default_int(settings, S_PORT, OBSC_DEFAULT_PORT);
+}
+
+static obs_properties_t *ios_camera_get_properties(void *data)
+{
+	struct ios_camera_source *s = data;
+
+	obs_properties_t *props = obs_properties_create();
+
+	obs_properties_add_int(props, S_PORT, T_("Port"), 1024, 65535, 1);
+
+	obs_property_t *status = obs_properties_add_text(
+		props, "status_info", T_("Status"), OBS_TEXT_INFO);
+	if (s) {
+		pthread_mutex_lock(&s->status_mutex);
+		obs_property_set_long_description(
+			status, s->status.array ? s->status.array : "");
+		pthread_mutex_unlock(&s->status_mutex);
+	}
+
+	obs_properties_add_text(props, "help_info", T_("HelpText"),
+				OBS_TEXT_INFO);
+
+	return props;
+}
+
+struct obs_source_info ios_camera_source_info = {
+	.id = "ios_camera_source",
+	.type = OBS_SOURCE_TYPE_INPUT,
+	.output_flags = OBS_SOURCE_ASYNC_VIDEO | OBS_SOURCE_DO_NOT_DUPLICATE,
+	.get_name = ios_camera_get_name,
+	.create = ios_camera_create,
+	.destroy = ios_camera_destroy,
+	.update = ios_camera_update,
+	.get_defaults = ios_camera_get_defaults,
+	.get_properties = ios_camera_get_properties,
+	.icon_type = OBS_ICON_TYPE_CAMERA,
+};

--- a/obs-plugin/src/net-compat.h
+++ b/obs-plugin/src/net-compat.h
@@ -1,0 +1,72 @@
+/*
+ * Minimal cross-platform (POSIX / Winsock) socket compatibility layer.
+ */
+
+#pragma once
+
+#ifdef _WIN32
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+typedef SOCKET socket_t;
+#define OBSC_INVALID_SOCKET INVALID_SOCKET
+
+static inline void net_close(socket_t s)
+{
+	closesocket(s);
+}
+
+static inline bool net_init(void)
+{
+	WSADATA wsa;
+	return WSAStartup(MAKEWORD(2, 2), &wsa) == 0;
+}
+
+static inline void net_shutdown(void)
+{
+	WSACleanup();
+}
+
+#else /* POSIX */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+typedef int socket_t;
+#define OBSC_INVALID_SOCKET (-1)
+
+static inline void net_close(socket_t s)
+{
+	close(s);
+}
+
+static inline bool net_init(void)
+{
+	return true;
+}
+
+static inline void net_shutdown(void)
+{
+}
+
+#endif
+
+static inline bool net_set_nonblocking(socket_t s)
+{
+#ifdef _WIN32
+	u_long mode = 1;
+	return ioctlsocket(s, FIONBIO, &mode) == 0;
+#else
+	int flags = fcntl(s, F_GETFL, 0);
+	if (flags < 0)
+		return false;
+	return fcntl(s, F_SETFL, flags | O_NONBLOCK) == 0;
+#endif
+}

--- a/obs-plugin/src/plugin-main.c
+++ b/obs-plugin/src/plugin-main.c
@@ -1,0 +1,31 @@
+#include <obs-module.h>
+
+#include "net-compat.h"
+
+OBS_DECLARE_MODULE()
+OBS_MODULE_USE_DEFAULT_LOCALE("ios-camera-source", "en-US")
+
+MODULE_EXPORT const char *obs_module_description(void)
+{
+	return "Use an iOS device's camera as a video source over the local "
+	       "network (companion app required)";
+}
+
+extern struct obs_source_info ios_camera_source_info;
+
+bool obs_module_load(void)
+{
+	if (!net_init()) {
+		blog(LOG_ERROR, "[ios-camera] network init failed");
+		return false;
+	}
+
+	obs_register_source(&ios_camera_source_info);
+	blog(LOG_INFO, "[ios-camera] plugin loaded");
+	return true;
+}
+
+void obs_module_unload(void)
+{
+	net_shutdown();
+}

--- a/obs-plugin/src/protocol.h
+++ b/obs-plugin/src/protocol.h
@@ -1,0 +1,74 @@
+/*
+ * Wire protocol constants shared with the iOS companion app.
+ * See docs/PROTOCOL.md for the full specification.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define OBSC_MAGIC 0x4F425343u /* "OBSC" */
+#define OBSC_PROTOCOL_VERSION 1
+#define OBSC_HEADER_SIZE 20
+#define OBSC_MAX_PAYLOAD (16u * 1024u * 1024u)
+
+#define OBSC_DEFAULT_PORT 9977
+#define OBSC_DISCOVERY_PORT_OFFSET 1
+
+#define OBSC_DISCOVER_REQUEST "OBSC_DISCOVER"
+#define OBSC_DISCOVER_REPLY_PREFIX "OBSC_HERE:"
+
+enum obsc_packet_type {
+	OBSC_PKT_HELLO = 1,
+	OBSC_PKT_VIDEO_CONFIG = 2,
+	OBSC_PKT_VIDEO = 3,
+	OBSC_PKT_PING = 4,
+};
+
+#define OBSC_FLAG_KEYFRAME 0x0001
+
+struct obsc_header {
+	uint8_t version;
+	uint8_t type;
+	uint16_t flags;
+	uint64_t pts_ns;
+	uint32_t payload_size;
+};
+
+static inline uint16_t obsc_read_u16(const uint8_t *p)
+{
+	return (uint16_t)((uint16_t)p[0] << 8 | (uint16_t)p[1]);
+}
+
+static inline uint32_t obsc_read_u32(const uint8_t *p)
+{
+	return (uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 |
+	       (uint32_t)p[2] << 8 | (uint32_t)p[3];
+}
+
+static inline uint64_t obsc_read_u64(const uint8_t *p)
+{
+	return (uint64_t)obsc_read_u32(p) << 32 | obsc_read_u32(p + 4);
+}
+
+/* Parses a 20-byte header. Returns false on bad magic/version/size. */
+static inline bool obsc_parse_header(const uint8_t *buf,
+				     struct obsc_header *hdr)
+{
+	if (obsc_read_u32(buf) != OBSC_MAGIC)
+		return false;
+
+	hdr->version = buf[4];
+	hdr->type = buf[5];
+	hdr->flags = obsc_read_u16(buf + 6);
+	hdr->pts_ns = obsc_read_u64(buf + 8);
+	hdr->payload_size = obsc_read_u32(buf + 16);
+
+	if (hdr->version != OBSC_PROTOCOL_VERSION)
+		return false;
+	if (hdr->payload_size > OBSC_MAX_PAYLOAD)
+		return false;
+
+	return true;
+}


### PR DESCRIPTION
- obs-plugin/: C source plugin 'iOS Camera' — TCP server (port 9977)
  receiving H.264 Annex B, decoded via libavcodec into an async OBS
  video source; UDP LAN-discovery responder on port 9978; CMake build
  (verified against libobs 30 / FFmpeg 6 with -Wall -Wextra clean).
- ios-app/: OBSCam SwiftUI app — AVFoundation capture, VideoToolbox
  hardware H.264 encode with AVCC-to-Annex-B conversion, Network.framework
  TCP client, UDP broadcast discovery, XcodeGen project definition.
- docs/PROTOCOL.md: version-1 wire protocol spec shared by both sides.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR