### PR TITLE
Automatic releases: every merge to main publishes installable builds

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,64 @@
+name: Auto Release
+
+# Every push to main that touches plugin or app code automatically gets a
+# version tag and a published release with installable builds.
+#
+# Version bumping (from the merge/commit message):
+#   default            -> patch  (v0.2.0 -> v0.2.1)
+#   contains "#minor"  -> minor  (v0.2.1 -> v0.3.0)
+#   contains "#major"  -> major  (v0.3.0 -> v1.0.0)
+#   contains "[skip release]" -> no release
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "obs-plugin/**"
+      - "ios-app/**"
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Tag next version
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip release]')"
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and push tag
+        id: bump
+        env:
+          MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          latest=${latest:-v0.1.0}
+          version=${latest#v}
+          IFS=. read -r major minor patch <<< "$version"
+
+          if grep -q '#major' <<< "$MESSAGE"; then
+            major=$((major + 1)); minor=0; patch=0
+          elif grep -q '#minor' <<< "$MESSAGE"; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          tag="v$major.$minor.$patch"
+          echo "Releasing $tag (previous: $latest)"
+          git tag "$tag"
+          git push origin "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Build & publish
+    needs: version
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.version.outputs.tag }}
+    permissions:
+      contents: write

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,37 @@
+name: Auto-merge
+
+# Arms GitHub's native auto-merge on every non-draft PR: the PR then
+# merges by itself the moment all REQUIRED checks pass.
+#
+# One-time repo setup this depends on (Settings):
+#   1. General -> "Allow auto-merge" (checked)
+#   2. Branch protection rule (or ruleset) for `main` requiring the three
+#      Build checks — without required checks, auto-merge would merge
+#      immediately, before CI finishes.
+#
+# Token note: if armed with the default GITHUB_TOKEN, the eventual merge
+# is performed by github-actions, and pushes by that token do NOT trigger
+# other workflows — which would silently skip the auto-release. Add a
+# fine-grained PAT (contents+pull-requests read/write) as the
+# AUTOMERGE_TOKEN secret so the merge counts as you and the release
+# pipeline fires.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  arm:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: "!github.event.pull_request.draft"
+    steps:
+      - name: Arm auto-merge (merge commit)
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN != '' && secrets.AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge --auto --merge \
+            "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "Existing tag to publish the release under"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -140,7 +146,7 @@ jobs:
     name: Publish release
     needs: [plugin-linux, plugin-windows, ios-app]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -149,6 +155,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           generate_release_notes: true
           files: |
             dist/ios-camera-source-windows-x64.zip

--- a/README.md
+++ b/README.md
@@ -117,9 +117,21 @@ Wi-Fi jitter.
 
 ## Releases
 
-Pushing a version tag publishes a GitHub Release with ready-to-install
-builds (Windows plugin zip, Linux plugin tarball, unsigned IPA) via
-[`.github/workflows/release.yml`](.github/workflows/release.yml):
+Releases are **automatic**: every push to `main` that touches
+`obs-plugin/` or `ios-app/` gets a version tag and a published GitHub
+Release with ready-to-install builds (Windows plugin zip, Linux plugin
+tarball, unsigned IPA).
+
+Version bumps are controlled by the merge-commit message:
+
+| Message contains  | Bump   | Example           |
+|-------------------|--------|-------------------|
+| *(nothing special)* | patch | v0.2.0 → v0.2.1 |
+| `#minor`          | minor  | v0.2.1 → v0.3.0   |
+| `#major`          | major  | v0.3.0 → v1.0.0   |
+| `[skip release]`  | none   | no release        |
+
+Manual releases still work too — push any `v*` tag:
 
 ```bash
 git tag v0.3.0 && git push origin v0.3.0

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Manual releases still work too — push any `v*` tag:
 git tag v0.3.0 && git push origin v0.3.0
 ```
 
+PRs auto-merge once all required checks pass
+([`automerge.yml`](.github/workflows/automerge.yml)). This requires two
+one-time repository settings: **Allow auto-merge** (Settings → General)
+and a branch protection rule on `main` with the three Build checks marked
+required. Adding a fine-grained PAT as the `AUTOMERGE_TOKEN` secret makes
+the merge count as you, so the auto-release pipeline fires (merges by the
+default Actions token don't trigger downstream workflows).
+
 ## Continuous integration
 
 Every push/PR runs [`.github/workflows/build.yml`](.github/workflows/build.yml):


### PR DESCRIPTION
Merging a PR now *is* shipping a release — no manual tagging required.

## How it works
- A new `auto-release.yml` workflow fires on every push to `main` that touches `obs-plugin/**` or `ios-app/**` (docs-only changes don't release).
- It computes the next version from the latest `v*` tag, pushes the tag, and calls the release workflow (now `workflow_call`-able with a `tag_name` input) to build and attach the Windows zip, Linux tarball, and unsigned IPA.

## Controlling the version bump (via the merge-commit message)
| Message contains | Bump | Example |
|---|---|---|
| *(default)* | patch | v0.2.0 → v0.2.1 |
| `#minor` | minor | v0.2.1 → v0.3.0 |
| `#major` | major | v0.3.0 → v1.0.0 |
| `[skip release]` | none | no release |

Manual `v*` tag pushes still publish a release as before. README's Releases section documents all of this.

Note: if no `v*` tag exists yet when this first runs, versioning starts from v0.1.0 → v0.1.1 — so it's worth creating the `v0.2.0` release first (or just letting the first auto-release establish the baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_