### PR TITLE
CI: build only on PRs; robust version-bump via git trailer

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,11 +3,14 @@ name: Auto Release
 # Every push to main that touches plugin or app code automatically gets a
 # version tag and a published release with installable builds.
 #
-# Version bumping (from the merge/commit message):
-#   default            -> patch  (v0.2.0 -> v0.2.1)
-#   contains "#minor"  -> minor  (v0.2.1 -> v0.3.0)
-#   contains "#major"  -> major  (v0.3.0 -> v1.0.0)
-#   contains "[skip release]" -> no release
+# The bump is a deliberate **git trailer** — a line, in any commit of the
+# merged PR, that is EXACTLY one of these (case-insensitive):
+#   Release-Bump: minor   -> minor (v0.3.0 -> v0.4.0)
+#   Release-Bump: major   -> major (v0.3.0 -> v1.0.0)
+#   (none)                -> patch (v0.3.0 -> v0.3.1)
+#   Release-Skip: true    -> no release
+# A trailer must be its own line, so merely *writing about* the keywords in
+# prose can never trigger a bump (that mistake shipped v1.0.0 once).
 on:
   push:
     branches: ["main"]
@@ -22,7 +25,6 @@ jobs:
   version:
     name: Tag next version
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip release]')"
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
     steps:
@@ -41,18 +43,25 @@ jobs:
           version=${latest#v}
           IFS=. read -r major minor patch <<< "$version"
 
-          # Scan every commit newly pushed to main (the merge commit AND the
-          # PR's own commits), so a '#minor'/'#major' keyword in a PR commit
-          # message counts — the merge commit rarely carries it.
+          # Every commit newly pushed to main (the merge commit AND the PR's
+          # own commits), so a trailer in any PR commit counts.
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             messages=$(git log -1 --format=%B "$AFTER")
           else
             messages=$(git log --format=%B "$BEFORE..$AFTER")
           fi
 
-          if grep -q '#major' <<< "$messages"; then
+          # Trailers only match on their own line (^…$), so prose that
+          # merely mentions the keywords is ignored.
+          if grep -qiE '^Release-Skip:[[:space:]]*true[[:space:]]*$' <<< "$messages"; then
+            echo "Release-Skip trailer found — no release."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if grep -qiE '^Release-Bump:[[:space:]]*major[[:space:]]*$' <<< "$messages"; then
             major=$((major + 1)); minor=0; patch=0
-          elif grep -q '#minor' <<< "$messages"; then
+          elif grep -qiE '^Release-Bump:[[:space:]]*minor[[:space:]]*$' <<< "$messages"; then
             minor=$((minor + 1)); patch=0
           else
             patch=$((patch + 1))
@@ -67,6 +76,7 @@ jobs:
   release:
     name: Build & publish
     needs: version
+    if: needs.version.outputs.tag != ''
     uses: ./.github/workflows/release.yml
     with:
       tag_name: ${{ needs.version.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
 name: Build
 
+# CI validation runs on PRs only. A push to main is already validated (the
+# PR built the identical code), and the release workflow rebuilds + ships
+# the artifacts — so building again on the main push would be pure waste.
 on:
-  push:
-    branches: ["main", "claude/**"]
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -129,14 +129,18 @@ Releases are **automatic**: every push to `main` that touches
 Release with ready-to-install builds (Windows plugin zip, Linux plugin
 tarball, unsigned IPA).
 
-Version bumps are controlled by the merge-commit message:
+Version bumps are controlled by a **git trailer** — a line by itself in
+any commit of the merged PR (case-insensitive):
 
-| Message contains  | Bump   | Example           |
-|-------------------|--------|-------------------|
-| *(nothing special)* | patch | v0.2.0 → v0.2.1 |
-| `#minor`          | minor  | v0.2.1 → v0.3.0   |
-| `#major`          | major  | v0.3.0 → v1.0.0   |
-| `[skip release]`  | none   | no release        |
+| Trailer line          | Bump   | Example           |
+|-----------------------|--------|-------------------|
+| *(none)*              | patch  | v0.3.0 → v0.3.1   |
+| `Release-Bump: minor` | minor  | v0.3.0 → v0.4.0   |
+| `Release-Bump: major` | major  | v0.3.0 → v1.0.0   |
+| `Release-Skip: true`  | none   | no release        |
+
+A trailer must be on its own line, so merely mentioning the keywords in
+prose can't trigger a bump.
 
 Manual releases still work too — push any `v*` tag:
 


### PR DESCRIPTION
Fixes the two CI issues you spotted.

## Redundant builds
`build.yml` was triggering on push-to-main **and** push-to-`claude/**` **and** pull_request — so each change built up to three times (branch push + PR + main push), and the release workflow rebuilds artifacts on top. It now runs on **pull_request only**: one build validates the PR, one build ships the release. No more redundant main/branch builds.

## v1.0.0 was wrong
The bump detector scanned commit bodies for the token `#major` **anywhere** — and PR #6's commit literally explained "the version bump keyword (#minor/#major)", so it self-triggered a major release.

The bump is now a **git trailer** matched anchored to its own line:

| Trailer (own line, case-insensitive) | Bump |
|---|---|
| *(none)* | patch |
| `Release-Bump: minor` | minor |
| `Release-Bump: major` | major |
| `Release-Skip: true` | no release |

Prose can never match it. README updated to match.

This PR touches only `.github/` + README, so the path filter means **it won't cut a release** — safe to merge without producing another version.

### About the stray v1.0.0
It's still published. To get back onto the 0.x line, delete the **v1.0.0** release and its tag in the GitHub UI (Releases → v1.0.0 → delete release; then Tags → v1.0.0 → delete). After that, the latest tag is v0.3.0 and the next code merge bumps correctly. I can walk you through cutting a clean **v0.4.0** of the current code whenever you want — just say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_