### PR TITLE
Full-code review fixes: robustness, thread safety, efficiency, CI cost

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,6 +21,13 @@ on:
 permissions:
   contents: write
 
+# Two merges in quick succession must version sequentially: without this,
+# both runs read the same latest tag, compute the same next version, and
+# the loser's release is silently lost when its tag push fails.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
 jobs:
   version:
     name: Tag next version
@@ -38,6 +45,9 @@ jobs:
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.event.after }}
         run: |
+          # Refresh tags at the last moment: a queued run's checkout can
+          # predate the previous run's tag push.
+          git fetch origin --tags --quiet
           latest=$(git tag --list 'v*' --sort=-v:refname | head -1)
           latest=${latest:-v0.1.0}
           version=${latest#v}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,44 @@ name: Build
 # CI validation runs on PRs only. A push to main is already validated (the
 # PR built the identical code), and the release workflow rebuilds + ships
 # the artifacts — so building again on the main push would be pure waste.
+#
+# Docs-only PRs skip the builds: a cheap `changes` job diffs the PR and the
+# build jobs are if-gated on it. (A `paths:` filter would be simpler but
+# breaks required checks — the workflow never runs, so the checks sit
+# "expected" forever and the PR can't merge. Skipped jobs count as passing.)
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Diff against base
+        id: diff
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+        run: |
+          if [ -z "$BASE" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"   # workflow_dispatch: build everything
+            exit 0
+          fi
+          git fetch --depth=1 origin "$BASE"
+          if git diff --name-only "$BASE" HEAD | \
+             grep -qE '^(obs-plugin/|ios-app/|\.github/workflows/build\.yml)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
   obs-plugin-linux:
     name: OBS plugin (Linux)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +69,8 @@ jobs:
 
   obs-plugin-windows:
     name: OBS plugin (Windows)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: windows-2022
     env:
       # Keep in sync with the OBS release users run: the plugin links the
@@ -48,13 +81,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No submodules here: cache-hit runs only need in-tree headers
+      # (libobs/, deps/w32-pthreads/). The recursive fetch is minutes of
+      # overhead, so it moves into the cache-miss build step below.
       - name: Checkout obs-studio (for libobs)
         uses: actions/checkout@v4
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
           path: obs-studio
-          submodules: recursive
 
       - name: Download OBS prebuilt dependencies (FFmpeg)
         run: |
@@ -71,6 +106,7 @@ jobs:
       - name: Build libobs
         if: steps.cache-libobs.outputs.cache-hit != 'true'
         run: |
+          git -C obs-studio submodule update --init --recursive
           cmake -S obs-studio -B obs-build -G "Visual Studio 17 2022" -A x64 `
             -DCMAKE_PREFIX_PATH="${{ github.workspace }}\obs-deps" `
             -DENABLE_UI=OFF -DENABLE_FRONTEND=OFF -DENABLE_PLUGINS=OFF `
@@ -103,6 +139,8 @@ jobs:
 
   ios-app:
     name: iOS app (LensLink)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     # Needs Xcode 16+: current XcodeGen emits project format 77, which
     # Xcode 15 (macos-14 runners) cannot open.
     runs-on: macos-15
@@ -116,23 +154,11 @@ jobs:
         run: xcodegen generate
         working-directory: ios-app
 
-      # Builds for the iOS Simulator so no signing certificates are needed.
-      # This validates that all Swift sources compile; producing an
-      # installable device build requires an Apple Developer signing
-      # identity (see README notes on releases).
-      - name: Build (Simulator, unsigned)
-        run: |
-          set -o pipefail
-          xcodebuild build \
-            -project LensLink.xcodeproj \
-            -scheme LensLink \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO
-        working-directory: ios-app
-
-      # Unsigned device build packaged as an .ipa. It cannot be installed
-      # as-is: sideload it with a tool that re-signs with your Apple ID
-      # (Sideloadly / AltStore on Windows or macOS).
+      # Unsigned device build packaged as an .ipa: proves every Swift
+      # source compiles for the real platform, so a separate Simulator
+      # build would just double the (10x-billed) macOS minutes. The .ipa
+      # can't be installed as-is: sideload it with a tool that re-signs
+      # with your Apple ID (Sideloadly / AltStore).
       - name: Build unsigned device IPA
         run: |
           set -o pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,14 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # tag_name is required here too: without it a branch dispatch would run
+  # all three builds and then skip publish (the gate below needs a tag).
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Existing tag to publish the release under"
+        required: true
+        type: string
   workflow_call:
     inputs:
       tag_name:
@@ -56,13 +63,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No submodules here: cache-hit runs only need in-tree headers
+      # (libobs/, deps/w32-pthreads/); the recursive fetch runs only on a
+      # cache miss, inside the build step.
       - name: Checkout obs-studio (for libobs)
         uses: actions/checkout@v4
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
           path: obs-studio
-          submodules: recursive
 
       - name: Download OBS prebuilt dependencies (FFmpeg)
         run: |
@@ -79,6 +88,7 @@ jobs:
       - name: Build libobs
         if: steps.cache-libobs.outputs.cache-hit != 'true'
         run: |
+          git -C obs-studio submodule update --init --recursive
           cmake -S obs-studio -B obs-build -G "Visual Studio 17 2022" -A x64 `
             -DCMAKE_PREFIX_PATH="${{ github.workspace }}\obs-deps" `
             -DENABLE_UI=OFF -DENABLE_FRONTEND=OFF -DENABLE_PLUGINS=OFF `

--- a/ios-app/Sources/AudioReference.swift
+++ b/ios-app/Sources/AudioReference.swift
@@ -15,6 +15,7 @@ final class AudioReference {
     private var converter: AVAudioConverter?
     private let targetFormat: AVAudioFormat
     private var timebase = mach_timebase_info_data_t()
+    private var observer: NSObjectProtocol?
 
     init() {
         targetFormat = AVAudioFormat(
@@ -23,6 +24,12 @@ final class AudioReference {
             channels: AVAudioChannelCount(OBSCProtocol.audioChannels),
             interleaved: true)!
         mach_timebase_info(&timebase)
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     static func requestPermission() async -> Bool {
@@ -57,9 +64,34 @@ final class AudioReference {
         }
         engine.prepare()
         try engine.start()
+
+        // A route change (Bluetooth headset connecting, wired mic
+        // unplugged) reconfigures the engine and kills the tap; without
+        // this the lip-sync reference silently dies for the session.
+        if observer == nil {
+            observer = NotificationCenter.default.addObserver(
+                forName: .AVAudioEngineConfigurationChange,
+                object: engine, queue: .main) { [weak self] _ in
+                self?.restart()
+            }
+        }
+    }
+
+    private func restart() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        do {
+            try start()
+        } catch {
+            print("Audio reference restart failed: \(error.localizedDescription)")
+        }
     }
 
     func stop() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         try? AVAudioSession.sharedInstance().setActive(false)

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -32,7 +32,21 @@ final class CameraManager: NSObject {
     }
 
     let session = AVCaptureSession()
-    var onSampleBuffer: ((CMSampleBuffer) -> Void)?
+
+    /// Set on the main thread, read per frame on the capture queue —
+    /// hence the lock (a bare closure var is a data race at stop time).
+    var onSampleBuffer: ((CMSampleBuffer) -> Void)? {
+        get { callbackLock.lock(); defer { callbackLock.unlock() }
+              return _onSampleBuffer }
+        set { callbackLock.lock(); defer { callbackLock.unlock() }
+              _onSampleBuffer = newValue }
+    }
+    private var _onSampleBuffer: ((CMSampleBuffer) -> Void)?
+    private let callbackLock = NSLock()
+
+    /// Capture was interrupted (phone call, Camera app, Split View) or
+    /// resumed. Delivered on the main queue.
+    var onInterruption: ((Bool) -> Void)?
 
     /// The device currently feeding the session; camera controls act on it.
     private(set) var activeDevice: AVCaptureDevice?
@@ -40,6 +54,37 @@ final class CameraManager: NSObject {
     private let sessionQueue = DispatchQueue(label: "obscam.session")
     private let videoQueue = DispatchQueue(label: "obscam.video")
     private var videoOutput: AVCaptureVideoDataOutput?
+
+    override init() {
+        super.init()
+        // Without these observers a phone call or the Camera app grabbing
+        // the hardware stops capture permanently while the UI says "Live".
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(sessionInterrupted),
+                           name: .AVCaptureSessionWasInterrupted,
+                           object: session)
+        center.addObserver(self, selector: #selector(sessionResumed),
+                           name: .AVCaptureSessionInterruptionEnded,
+                           object: session)
+        center.addObserver(self, selector: #selector(sessionRuntimeError),
+                           name: .AVCaptureSessionRuntimeError,
+                           object: session)
+    }
+
+    @objc private func sessionInterrupted(_ note: Notification) {
+        DispatchQueue.main.async { self.onInterruption?(true) }
+    }
+
+    @objc private func sessionResumed(_ note: Notification) {
+        start() // the session does not restart itself
+        DispatchQueue.main.async { self.onInterruption?(false) }
+    }
+
+    @objc private func sessionRuntimeError(_ note: Notification) {
+        // Media services reset and similar: restarting the session is the
+        // documented recovery.
+        start()
+    }
 
     static func requestPermission() async -> Bool {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
@@ -132,9 +177,21 @@ final class CameraManager: NSObject {
         return format(for: device, resolution: resolution, fps: fps) != nil
     }
 
+    /// AVCaptureSession requires serialized access; start/stop run on
+    /// `sessionQueue`, so configuration hops there too (synchronously, to
+    /// keep the throwing API).
     func configure(lens: Lens,
                    resolution: Resolution,
                    fps: Int32) throws {
+        try sessionQueue.sync {
+            try configureOnQueue(lens: lens, resolution: resolution,
+                                 fps: fps)
+        }
+    }
+
+    private func configureOnQueue(lens: Lens,
+                                  resolution: Resolution,
+                                  fps: Int32) throws {
         let position = lens.position
         session.beginConfiguration()
         defer { session.commitConfiguration() }

--- a/ios-app/Sources/CameraPreviewView.swift
+++ b/ios-app/Sources/CameraPreviewView.swift
@@ -7,7 +7,13 @@ struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
     var videoGravity: AVLayerVideoGravity = .resizeAspect
     var onTapAtDevicePoint: ((CGPoint) -> Void)?
-    var onPinchZoom: ((_ scale: CGFloat, _ ended: Bool) -> Void)?
+    var onPinchZoom: ((_ phase: PinchPhase, _ scale: CGFloat) -> Void)?
+
+    enum PinchPhase {
+        case began
+        case changed
+        case ended
+    }
 
     final class PreviewView: UIView {
         override static var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
@@ -30,9 +36,16 @@ struct CameraPreviewView: UIViewRepresentable {
         }
 
         @objc func handlePinch(_ recognizer: UIPinchGestureRecognizer) {
-            let ended = recognizer.state == .ended
-                || recognizer.state == .cancelled
-            parent.onPinchZoom?(recognizer.scale, ended)
+            let phase: PinchPhase
+            switch recognizer.state {
+            case .began:
+                phase = .began
+            case .ended, .cancelled, .failed:
+                phase = .ended
+            default:
+                phase = .changed
+            }
+            parent.onPinchZoom?(phase, recognizer.scale)
         }
     }
 

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var streamer: Streamer
 
+    // Cached per change, not per render: a Form body re-evaluates on any
+    // published change, and these hit AVCaptureDevice discovery/format
+    // scans (capability checks) or getifaddrs (the IP) each time.
+    @State private var wifiIP: String?
+    @State private var availableResolutions: [CameraManager.Resolution] = []
+    @State private var availableFrameRates: [Int] = []
+
     var body: some View {
         if streamer.isStreaming {
             StreamingView()
@@ -25,6 +32,31 @@ struct ContentView: View {
         }
         .navigationViewStyle(.stack)
         .tint(Theme.accent)
+        .onAppear {
+            wifiIP = NetworkInfo.wifiIPAddress()
+            refreshCapabilities()
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.willEnterForegroundNotification)) { _ in
+            wifiIP = NetworkInfo.wifiIPAddress()
+        }
+        .onChange(of: streamer.selectedLens) { _ in refreshCapabilities() }
+        .onChange(of: streamer.resolution) { _ in
+            streamer.clampCaptureSettings()
+            refreshCapabilities()
+        }
+    }
+
+    private func refreshCapabilities() {
+        availableResolutions = CameraManager.Resolution.allCases.filter {
+            CameraManager.supports(resolution: $0, fps: 30,
+                                   lens: streamer.selectedLens)
+        }
+        availableFrameRates = [30, 60].filter {
+            CameraManager.supports(resolution: streamer.resolution,
+                                   fps: Int32($0),
+                                   lens: streamer.selectedLens)
+        }
     }
 
     private var optionsSection: some View {
@@ -57,7 +89,7 @@ struct ContentView: View {
 
     private var receiveSection: some View {
         Section("How to connect") {
-            if let ip = NetworkInfo.wifiIPAddress() {
+            if let ip = wifiIP {
                 HStack {
                     Image(systemName: "wifi")
                     VStack(alignment: .leading, spacing: 2) {
@@ -87,23 +119,6 @@ struct ContentView: View {
         }
     }
 
-    /// Only resolutions this lens actually supports (at any frame rate).
-    private var availableResolutions: [CameraManager.Resolution] {
-        CameraManager.Resolution.allCases.filter {
-            CameraManager.supports(resolution: $0, fps: 30,
-                                   lens: streamer.selectedLens)
-        }
-    }
-
-    /// Only frame rates this lens supports at the chosen resolution.
-    private var availableFrameRates: [Int] {
-        [30, 60].filter {
-            CameraManager.supports(resolution: streamer.resolution,
-                                   fps: Int32($0),
-                                   lens: streamer.selectedLens)
-        }
-    }
-
     private var cameraSection: some View {
         Section("Camera") {
             Picker("Lens", selection: $streamer.selectedLens) {
@@ -116,9 +131,6 @@ struct ContentView: View {
                 ForEach(availableResolutions) { resolution in
                     Text(resolution.rawValue).tag(resolution)
                 }
-            }
-            .onChange(of: streamer.resolution) { _ in
-                streamer.clampCaptureSettings()
             }
 
             Picker("Frame rate", selection: $streamer.fps) {

--- a/ios-app/Sources/StreamClient.swift
+++ b/ios-app/Sources/StreamClient.swift
@@ -39,32 +39,44 @@ final class StreamClient {
     private var receiveBuffer = Data()
 
     // MARK: - Lifecycle
+    //
+    // Every mutable property (connection, listener, pingTimer, counters,
+    // buffers, state) is confined to `queue`: the NW handlers already run
+    // there, so the public entry points hop onto it too instead of racing
+    // them from the main thread.
 
     func start(port: UInt16) {
-        // Clean up any previous transport *silently* — a state change
-        // here would look like a fresh drop to the Streamer.
-        teardownConnection()
-        teardownListener()
-        listen(on: port)
+        queue.async { [weak self] in
+            guard let self else { return }
+            // Clean up any previous transport *silently* — a state change
+            // here would look like a fresh drop to the Streamer.
+            self.teardownConnection()
+            self.teardownListener()
+            self.listen(on: port)
+        }
     }
 
     func disconnect() {
-        teardownConnection()
-        teardownListener()
-        state = .disconnected
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.teardownConnection()
+            self.teardownListener()
+            self.state = .disconnected
+        }
     }
 
+    /// Queue-confined.
     private func teardownConnection() {
         pingTimer?.cancel()
         pingTimer = nil
         connection?.cancel()
         connection = nil
-        queue.async { [weak self] in
-            self?.inFlightFrames = 0
-            self?.waitingForKeyframe = false
-        }
+        inFlightFrames = 0
+        waitingForKeyframe = false
+        receiveBuffer.removeAll(keepingCapacity: false)
     }
 
+    /// Queue-confined.
     private func teardownListener() {
         listener?.cancel()
         listener = nil
@@ -77,6 +89,12 @@ final class StreamClient {
         if let tcpOptions = params.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
             tcpOptions.noDelay = true
             tcpOptions.connectionTimeout = 5
+            // Without keepalive a silently dead link (Wi-Fi drop, no RST)
+            // looks "Live" for minutes while sends pile into the kernel.
+            tcpOptions.enableKeepalive = true
+            tcpOptions.keepaliveIdle = 5
+            tcpOptions.keepaliveInterval = 5
+            tcpOptions.keepaliveCount = 2
         }
         return params
     }
@@ -146,10 +164,9 @@ final class StreamClient {
     }
 
     /// The active connection dropped; the listener stays up so the
-    /// plugin can dial back in.
+    /// plugin can dial back in. Queue-confined.
     private func connectionEnded(failure: String?) {
         teardownConnection()
-        receiveBuffer.removeAll()
         state = listener != nil ? .connecting : .disconnected
     }
 
@@ -173,9 +190,12 @@ final class StreamClient {
     private func processIncoming() {
         while receiveBuffer.count >= OBSCProtocol.headerSize {
             let bytes = [UInt8](receiveBuffer.prefix(OBSCProtocol.headerSize))
+            // Bad magic means the stream is byte-misaligned; discarding
+            // the buffer and carrying on would keep parsing garbage
+            // headers silently. Only a reconnect re-frames the stream.
             guard Array(bytes[0..<4]) == OBSCProtocol.magic,
                   bytes[4] == OBSCProtocol.version else {
-                receiveBuffer.removeAll()
+                connectionEnded(failure: "protocol desync")
                 return
             }
 
@@ -183,7 +203,7 @@ final class StreamClient {
             let pts = bytes[8..<16].reduce(UInt64(0)) { $0 << 8 | UInt64($1) }
             let payloadSize = bytes[16..<20].reduce(UInt32(0)) { $0 << 8 | UInt32($1) }
             guard payloadSize < 1 << 20 else {
-                receiveBuffer.removeAll()
+                connectionEnded(failure: "oversized packet")
                 return
             }
 
@@ -242,6 +262,14 @@ final class StreamClient {
         let enqueuedAt = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
         connection.send(content: data, completion: .contentProcessed { [weak self, weak connection] error in
             guard let self else { return }
+            // Ignore results from connections we've already abandoned, and
+            // our own cancellations — reacting to those poisons the next
+            // connection attempt. This must come *before* the counter
+            // updates: a burst of stale completions right after reconnect
+            // would drain the new connection's in-flight count (weakening
+            // backpressure) and log bogus send delays that make adaptive
+            // bitrate cut the rate on a healthy link.
+            guard let connection, self.connection === connection else { return }
             if isVideoFrame {
                 if self.inFlightFrames > 0 {
                     self.inFlightFrames -= 1
@@ -251,10 +279,6 @@ final class StreamClient {
                     self.maxSendDelayNs = delay
                 }
             }
-            // Ignore results from connections we've already abandoned, and
-            // our own cancellations — reacting to those poisons the next
-            // connection attempt.
-            guard let connection, self.connection === connection else { return }
             if let error, !Self.isCancellation(error) {
                 self.connectionEnded(failure: error.localizedDescription)
             }
@@ -332,14 +356,21 @@ final class StreamClient {
     func sendVideoFrame(_ frame: VideoEncoder.EncodedFrame) {
         queue.async { [weak self] in
             guard let self, self.connection != nil else { return }
+            // The cap applies to keyframes too. Exempting them looks
+            // harmless but is an unbounded-memory bug: every drop requests
+            // a keyframe, so during a long stall the exempt keyframes
+            // would be enqueued into the dead connection without limit.
+            if self.inFlightFrames >= Self.maxInFlightFrames {
+                self.droppedFrames += 1
+                self.waitingForKeyframe = true
+                return
+            }
             if frame.isKeyframe {
                 self.waitingForKeyframe = false
             } else if self.waitingForKeyframe {
-                return
-            }
-            if self.inFlightFrames >= Self.maxInFlightFrames && !frame.isKeyframe {
-                self.droppedFrames += 1
-                self.waitingForKeyframe = true
+                // Broken reference chain: skip this frame, and — now that
+                // there's room to actually send one — ask the encoder for
+                // the keyframe that restarts the stream.
                 self.onFrameDropped?()
                 return
             }

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -47,18 +47,68 @@ final class Streamer: ObservableObject {
     @Published var selectedLens: CameraManager.Lens {
         didSet {
             UserDefaults.standard.set(selectedLens.id, forKey: "selectedLens")
+            let oldResolution = resolution
+            let oldFps = fps
             clampCaptureSettings()
             // Live lens switch: reconfigure capture under the running
-            // encoder and connection.
+            // connection. If clamping changed resolution/fps, the encoder
+            // (fixed dimensions) must be rebuilt and OBS re-configured —
+            // feeding differently-sized buffers into the old session
+            // breaks the stream.
             if isStreaming {
-                try? camera.configure(lens: selectedLens,
-                                      resolution: resolution,
-                                      fps: Int32(fps))
-                resetCameraControls()
-                encoder?.requestKeyframe()
-                scheduleStateSend()
+                reconfigureLiveCapture(
+                    formatChanged: resolution != oldResolution
+                        || fps != oldFps)
             }
         }
+    }
+
+    private func reconfigureLiveCapture(formatChanged: Bool) {
+        do {
+            try camera.configure(lens: selectedLens,
+                                 resolution: resolution,
+                                 fps: Int32(fps))
+        } catch {
+            // Never swallow this: a failed reconfigure leaves the session
+            // without input/output — a black stream labelled "Live".
+            status = .error(error.localizedDescription)
+            stopKeepingError()
+            return
+        }
+        resetCameraControls()
+
+        if formatChanged, let oldEncoder = encoder {
+            let activeCodec = oldEncoder.codec
+            oldEncoder.stop()
+            let size = resolution.size
+            let newEncoder = VideoEncoder(
+                codec: activeCodec,
+                width: size.width, height: size.height,
+                fps: Int32(fps),
+                bitrate: resolution.bitrate(for: activeCodec))
+            do {
+                try newEncoder.start()
+            } catch {
+                status = .error(error.localizedDescription)
+                stopKeepingError()
+                return
+            }
+            newEncoder.onEncodedFrame = { [weak self] frame in
+                self?.client.sendVideoFrame(frame)
+            }
+            camera.onSampleBuffer = { [weak newEncoder] sampleBuffer in
+                newEncoder?.encode(sampleBuffer)
+            }
+            encoder = newEncoder
+            client.sendVideoConfig(codec: activeCodec,
+                                   width: size.width, height: size.height,
+                                   fps: Int32(fps))
+            startAdaptiveBitrate(
+                target: resolution.bitrate(for: activeCodec))
+        }
+
+        encoder?.requestKeyframe()
+        scheduleStateSend()
     }
     @Published var codec: VideoCodec {
         didSet { UserDefaults.standard.set(codec.rawValue, forKey: "videoCodec") }
@@ -220,6 +270,21 @@ final class Streamer: ObservableObject {
                 self?.encoder?.requestKeyframe()
             }
         }
+        camera.onInterruption = { [weak self] interrupted in
+            Task { @MainActor [weak self] in
+                guard let self, self.isStreaming else { return }
+                if interrupted {
+                    self.status = .error(
+                        "Camera paused — in use by another app")
+                } else {
+                    // Capture restarted; OBS needs a fresh keyframe to
+                    // pick the stream back up.
+                    self.status = self.lastClientState == .connected
+                        ? .streaming : .connecting
+                    self.encoder?.requestKeyframe()
+                }
+            }
+        }
     }
 
     // MARK: - Remote control (from the OBS plugin / web panel)
@@ -230,18 +295,23 @@ final class Streamer: ObservableObject {
               let command = object as? [String: Any],
               let cmd = command["cmd"] as? String else { return }
 
+        // Clamp remote values before storing: the camera clamps for
+        // itself, but an out-of-range @Published value would put sliders
+        // out of range and misreport state to the web panel.
         switch cmd {
         case "zoom":
             if let value = command["value"] as? Double {
-                zoom = CGFloat(value)
+                zoom = min(max(CGFloat(value), 1), camera.maxZoomFactor)
             }
         case "exposure_bias":
             if let value = command["value"] as? Double {
-                exposureBias = Float(value)
+                let range = camera.exposureBiasRange
+                exposureBias = min(max(Float(value), range.lowerBound),
+                                   range.upperBound)
             }
         case "focus":
             if let position = command["lensPosition"] as? Double {
-                lensPosition = Float(position)
+                lensPosition = min(max(Float(position), 0), 1)
             }
             focusSetting = (command["mode"] as? String) == "locked" ? .locked : .auto
         case "flashlight":
@@ -278,8 +348,15 @@ final class Streamer: ObservableObject {
 
     // MARK: - Streaming lifecycle
 
+    /// Set synchronously before the first await: `guard !isStreaming`
+    /// alone lets a second tap re-enter during the permission prompt and
+    /// leak a live encoder.
+    private var isStarting = false
+
     func start() async {
-        guard !isStreaming else { return }
+        guard !isStreaming, !isStarting else { return }
+        isStarting = true
+        defer { isStarting = false }
 
         guard await CameraManager.requestPermission() else {
             cameraPermissionDenied = true
@@ -403,7 +480,12 @@ final class Streamer: ObservableObject {
         audioReference = nil
     }
 
+    /// Last state reported by the client (client.state itself is confined
+    /// to the network queue).
+    private var lastClientState: StreamClient.State = .disconnected
+
     private func handleClientState(_ state: StreamClient.State) {
+        lastClientState = state
         guard isStreaming else { return }
         switch state {
         case .connected:

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -25,12 +25,17 @@ struct StreamingView: View {
                     touched()
                     streamer.camera.focusAndExpose(at: point)
                 },
-                onPinchZoom: { scale, ended in
+                onPinchZoom: { phase, scale in
                     touched()
-                    streamer.zoom = pinchBaseZoom * scale
-                    if ended {
+                    // Re-anchor at gesture start: zoom may have moved via
+                    // the slider or a remote command since the last pinch,
+                    // and a stale base makes the next pinch jump.
+                    if phase == .began {
                         pinchBaseZoom = streamer.zoom
                     }
+                    streamer.zoom = min(
+                        max(pinchBaseZoom * scale, 1),
+                        streamer.camera.maxZoomFactor)
                 }
             )
             .ignoresSafeArea()

--- a/ios-app/Sources/VideoEncoder.swift
+++ b/ios-app/Sources/VideoEncoder.swift
@@ -28,6 +28,11 @@ final class VideoEncoder {
 
     let codec: VideoCodec
 
+    /// Guards `session` and `forceNextKeyframe`: `encode()` runs on the
+    /// capture queue while `stop()`/`setBitrate()`/`requestKeyframe()`
+    /// arrive from the main thread. Holding it across the encode call
+    /// means `stop()` can never invalidate a session mid-frame.
+    private let lock = NSLock()
     private var session: VTCompressionSession?
     private let width: Int32
     private let height: Int32
@@ -45,13 +50,18 @@ final class VideoEncoder {
     }
 
     /// Whether this device can hardware-encode the codec (HEVC needs A10+).
+    /// Cached: the probe creates a real hardware encoder session, far too
+    /// expensive to run per SwiftUI render of the codec picker.
     static func isSupported(_ codec: VideoCodec) -> Bool {
-        if codec == .h264 { return true }
+        codec == .h264 || hevcSupported
+    }
+
+    private static let hevcSupported: Bool = {
         var session: VTCompressionSession?
         let status = VTCompressionSessionCreate(
             allocator: kCFAllocatorDefault,
             width: 1280, height: 720,
-            codecType: codec.vtCodecType,
+            codecType: VideoCodec.hevc.vtCodecType,
             encoderSpecification: nil,
             imageBufferAttributes: nil,
             compressedDataAllocator: nil,
@@ -61,7 +71,7 @@ final class VideoEncoder {
             VTCompressionSessionInvalidate(session)
         }
         return status == noErr
-    }
+    }()
 
     func start() throws {
         var session: VTCompressionSession?
@@ -106,11 +116,15 @@ final class VideoEncoder {
                              value: NSNumber(value: 2))
 
         VTCompressionSessionPrepareToEncodeFrames(session)
+        lock.lock()
         self.session = session
+        lock.unlock()
     }
 
     /// Adjusts the target bitrate mid-stream (adaptive bitrate).
     func setBitrate(_ bitsPerSecond: Int) {
+        lock.lock()
+        defer { lock.unlock() }
         guard let session else { return }
         Self.applyBitrate(bitsPerSecond, to: session)
     }
@@ -131,6 +145,8 @@ final class VideoEncoder {
     }
 
     func stop() {
+        lock.lock()
+        defer { lock.unlock() }
         guard let session else { return }
         VTCompressionSessionCompleteFrames(session, untilPresentationTimeStamp: .invalid)
         VTCompressionSessionInvalidate(session)
@@ -141,12 +157,17 @@ final class VideoEncoder {
     /// connection is established mid-stream).
     private var forceNextKeyframe = false
     func requestKeyframe() {
+        lock.lock()
         forceNextKeyframe = true
+        lock.unlock()
     }
 
     func encode(_ sampleBuffer: CMSampleBuffer) {
-        guard let session,
-              let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard let session else { return }
 
         let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         let duration = CMSampleBufferGetDuration(sampleBuffer)
@@ -233,6 +254,9 @@ final class VideoEncoder {
     private func annexBData(from sampleBuffer: CMSampleBuffer,
                             includeParameterSets: Bool) -> Data? {
         var result = Data()
+        // One allocation up front: growing a Data to keyframe size in
+        // repeated appends reallocates several times per frame.
+        result.reserveCapacity(CMSampleBufferGetTotalSampleSize(sampleBuffer) + 256)
 
         if includeParameterSets,
            let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) {

--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.16...3.30)
+# 3.18+: find_path/find_library REQUIRED (used for the FFmpeg lookups)
+# is silently misparsed as a search path on older CMake.
+cmake_minimum_required(VERSION 3.18...3.30)
 
 project(lenslink VERSION 0.1.0 LANGUAGES C)
 

--- a/obs-plugin/data/locale/en-US.ini
+++ b/obs-plugin/data/locale/en-US.ini
@@ -21,5 +21,6 @@ Status.WaitingUSB="Waiting for iPhone on USB (open the LensLink app and tap Star
 Status.Dialing="Trying to reach the phone at"
 Status.NoHost="Enter the phone's IP address (shown in the LensLink app)"
 Status.DeviceBusy="This device is already used by another LensLink Camera source"
+Status.DecoderFailed="Connected, but this OBS build can't decode the stream — try H.264 in the app"
 Status.WaitingPinned="Waiting for the selected USB device to be connected"
 HelpText="Open the LensLink app on your iPhone/iPad and tap Start. Then either enter the phone's IP address (shown in the app) above with Connection set to Wi-Fi, or plug the phone in with a USB cable and set Connection to USB (needs iTunes on Windows)."

--- a/obs-plugin/src/h264-decoder.c
+++ b/obs-plugin/src/h264-decoder.c
@@ -191,6 +191,12 @@ static bool avframe_to_obs(const AVFrame *frame, struct obs_source_frame *out)
 	else if (frame->colorspace == AVCOL_SPC_SMPTE170M ||
 		 frame->colorspace == AVCOL_SPC_BT470BG)
 		cs = VIDEO_CS_601;
+	else if (frame->colorspace == AVCOL_SPC_BT2020_NCL)
+		/* HDR from newer iPhones: pick the right transfer so OBS
+		 * doesn't tone-map 10-bit video as if it were SDR 709. */
+		cs = frame->color_trc == AVCOL_TRC_ARIB_STD_B67
+			     ? VIDEO_CS_2100_HLG
+			     : VIDEO_CS_2100_PQ;
 
 	out->full_range = range == VIDEO_RANGE_FULL;
 	video_format_get_parameters(cs, range, out->color_matrix,
@@ -208,7 +214,8 @@ bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
 	dec->pkt->dts = (int64_t)pts_ns;
 
 	int ret = avcodec_send_packet(dec->ctx, dec->pkt);
-	if (ret < 0 && ret != AVERROR(EAGAIN)) {
+	bool resend = ret == AVERROR(EAGAIN); /* drain below, then retry */
+	if (ret < 0 && !resend) {
 		blog(LOG_WARNING, "[lenslink] avcodec_send_packet: %d", ret);
 		return ret != AVERROR_INVALIDDATA ? false : true;
 	}
@@ -255,6 +262,17 @@ bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
 
 		obs_source_output_video(source, &out);
 		av_frame_unref(dec->frame);
+	}
+
+	/* The decoder was full before draining: the packet was never
+	 * consumed, and silently dropping it corrupts the stream until the
+	 * next keyframe. With the queue now drained, one retry succeeds. */
+	if (resend) {
+		ret = avcodec_send_packet(dec->ctx, dec->pkt);
+		if (ret < 0 && ret != AVERROR(EAGAIN))
+			blog(LOG_WARNING,
+			     "[lenslink] avcodec_send_packet (retry): %d",
+			     ret);
 	}
 
 	return true;

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -173,8 +173,8 @@ static void recv_buf_free(struct recv_buf *b)
 	memset(b, 0, sizeof(*b));
 }
 
-static void recv_buf_append(struct recv_buf *b, const uint8_t *data,
-			    size_t size)
+/* Makes room for `size` more bytes after the current contents. */
+static void recv_buf_reserve(struct recv_buf *b, size_t size)
 {
 	if (b->len + size > b->cap) {
 		size_t new_cap = b->cap ? b->cap : RECV_CHUNK;
@@ -183,18 +183,29 @@ static void recv_buf_append(struct recv_buf *b, const uint8_t *data,
 		b->data = brealloc(b->data, new_cap);
 		b->cap = new_cap;
 	}
-	memcpy(b->data + b->len, data, size);
-	b->len += size;
 }
 
+/* Discards the first `size` bytes. Called once per recv cycle (not per
+ * packet) so the memmove of the tail isn't O(packets x bytes). A large
+ * keyframe can balloon the buffer to many MB; shrink once it drains so a
+ * spike doesn't pin that memory for the rest of the connection. */
 static void recv_buf_consume(struct recv_buf *b, size_t size)
 {
-	if (size >= b->len) {
+	if (size >= b->len)
 		b->len = 0;
-		return;
+	else {
+		memmove(b->data, b->data + size, b->len - size);
+		b->len -= size;
 	}
-	memmove(b->data, b->data + size, b->len - size);
-	b->len -= size;
+
+	if (b->cap > 2 * RECV_CHUNK && b->len < RECV_CHUNK) {
+		size_t new_cap = 2 * RECV_CHUNK;
+		uint8_t *shrunk = bmalloc(new_cap);
+		memcpy(shrunk, b->data, b->len);
+		bfree(b->data);
+		b->data = shrunk;
+		b->cap = new_cap;
+	}
 }
 
 /* ------------------------------------------------------------------ */
@@ -262,15 +273,102 @@ static void latency_on_frame(struct latency_tracker *t, uint64_t pts_phone_ns,
 		t->window_start = now_ns;
 }
 
+/* Outbound bytes the non-blocking socket wouldn't take yet. A packet must
+ * never be abandoned part-way: a truncated frame desyncs the app's parser
+ * until reconnect. If the peer stalls long enough to accumulate this much
+ * un-sent control/timesync data, the connection is dead — drop it. */
+#define SEND_BUF_MAX (256 * 1024)
+
+struct send_buf {
+	uint8_t *data;
+	size_t len;
+	size_t cap;
+	bool failed; /* hard send error: connection must be dropped */
+};
+
 struct client_state {
 	socket_t sock;
 	struct recv_buf buf;
+	struct send_buf out;
 	struct h264_decoder *decoder;
 	bool hw_failed; /* GPU decode failed once: stay on software */
+	uint64_t next_decoder_attempt; /* cooldown after create failure */
 	enum AVCodecID codec_id;
 	char name[128];
 	struct latency_tracker lat;
 };
+
+static void send_buf_free(struct send_buf *b)
+{
+	bfree(b->data);
+	memset(b, 0, sizeof(*b));
+}
+
+/* Flushes queued bytes as far as the socket allows. Sets `failed` on a
+ * hard error; EWOULDBLOCK just leaves the remainder queued. */
+static void client_flush(struct client_state *c)
+{
+	struct send_buf *b = &c->out;
+	while (b->len > 0 && !b->failed) {
+		int n = (int)send(c->sock, (const char *)b->data,
+				  (int)b->len, 0);
+		if (n > 0) {
+			memmove(b->data, b->data + n, b->len - (size_t)n);
+			b->len -= (size_t)n;
+		} else if (n < 0 && net_would_block()) {
+			return;
+		} else {
+			b->failed = true;
+		}
+	}
+}
+
+/* Queues (and opportunistically sends) a complete packet. Never sends
+ * part of `data` without queuing the rest, so framing stays intact. */
+static void client_send(struct client_state *c, const void *data, size_t len)
+{
+	struct send_buf *b = &c->out;
+	const uint8_t *p = data;
+
+	if (b->failed)
+		return;
+
+	/* Nothing queued: push as much as the socket takes right now. */
+	if (b->len == 0) {
+		while (len > 0) {
+			int n = (int)send(c->sock, (const char *)p, (int)len,
+					  0);
+			if (n > 0) {
+				p += n;
+				len -= (size_t)n;
+			} else if (n < 0 && net_would_block()) {
+				break;
+			} else {
+				b->failed = true;
+				return;
+			}
+		}
+		if (len == 0)
+			return;
+	}
+
+	if (b->len + len > SEND_BUF_MAX) {
+		blog(LOG_WARNING,
+		     "[lenslink] peer not draining control channel, "
+		     "dropping connection");
+		b->failed = true;
+		return;
+	}
+	if (b->len + len > b->cap) {
+		size_t new_cap = b->cap ? b->cap : 4096;
+		while (new_cap < b->len + len)
+			new_cap *= 2;
+		b->data = brealloc(b->data, new_cap);
+		b->cap = new_cap;
+	}
+	memcpy(b->data + b->len, p, len);
+	b->len += len;
+}
 
 /* ------------------------------------------------------------------ */
 /* Auto lip-sync: tap the chosen mic source and cross-correlate it with the
@@ -394,12 +492,16 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	if (!enabled || !name[0])
 		return;
 
+	/* Hold the mutex only for a snapshot: the correlation is ~1.8M
+	 * multiply-adds, and the OBS audio callback blocks on this lock. */
 	int64_t mic_delay = 0;
 	double conf = 0;
 	pthread_mutex_lock(&s->lipsync_mutex);
-	bool ok = s->lipsync &&
-		  lipsync_estimate(s->lipsync, &mic_delay, &conf);
+	struct lipsync *snap = s->lipsync ? lipsync_clone(s->lipsync) : NULL;
 	pthread_mutex_unlock(&s->lipsync_mutex);
+
+	bool ok = snap && lipsync_estimate(snap, &mic_delay, &conf);
+	lipsync_destroy(snap);
 
 	if (!ok) {
 		blog(LOG_INFO,
@@ -565,19 +667,7 @@ static void control_tick(struct ios_camera_source *s, struct client_state *c)
 				  (uint32_t)len);
 		memcpy(packet + OBSC_HEADER_SIZE, pending[i], len);
 
-		size_t sent = 0;
-		int spins = 0;
-		while (sent < total && spins < 100) {
-			int n = (int)send(c->sock,
-					  (const char *)packet + sent,
-					  (int)(total - sent), 0);
-			if (n > 0) {
-				sent += (size_t)n;
-			} else {
-				os_sleep_ms(1);
-				spins++;
-			}
-		}
+		client_send(c, packet, total);
 
 		bfree(packet);
 		bfree(pending[i]);
@@ -594,9 +684,7 @@ static void latency_tick(struct ios_camera_source *s, struct client_state *c)
 		t->last_sync_send = now;
 		uint8_t hdr[OBSC_HEADER_SIZE];
 		obsc_build_header(hdr, OBSC_PKT_TIMESYNC_REQ, 0, now, 0);
-		/* Best effort; a 20-byte send into an open socket either
-		 * fully succeeds or the connection is toast anyway. */
-		send(c->sock, (const char *)hdr, OBSC_HEADER_SIZE, 0);
+		client_send(c, hdr, OBSC_HEADER_SIZE);
 	}
 
 	if (t->count && t->window_start &&
@@ -647,6 +735,7 @@ static void client_disconnect(struct ios_camera_source *s,
 		c->sock = OBSC_INVALID_SOCKET;
 	}
 	recv_buf_free(&c->buf);
+	send_buf_free(&c->out);
 	h264_decoder_destroy(c->decoder);
 	c->decoder = NULL;
 	c->name[0] = 0;
@@ -707,8 +796,13 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 		break;
 	}
 	case OBSC_PKT_VIDEO_CONFIG: {
-		blog(LOG_INFO, "[lenslink] video config: %.*s",
-		     (int)hdr->payload_size, (const char *)payload);
+		/* Clamp: payload_size can legally be up to 16 MB, and a
+		 * malformed packet must not dump that into the log. */
+		int log_len = hdr->payload_size < 256
+				      ? (int)hdr->payload_size
+				      : 256;
+		blog(LOG_INFO, "[lenslink] video config: %.*s", log_len,
+		     (const char *)payload);
 
 		char json[512] = {0};
 		size_t n = hdr->payload_size < sizeof(json) - 1
@@ -733,13 +827,27 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 			/* Join on a keyframe so the decoder starts clean. */
 			if (!(hdr->flags & OBSC_FLAG_KEYFRAME))
 				break;
+			/* Creation can fail persistently (e.g. no HEVC
+			 * decoder in this FFmpeg build). Dropping the
+			 * connection would just reconnect-churn as fast as
+			 * the LAN allows; keep the link and retry with a
+			 * cooldown instead. */
+			uint64_t now = os_gettime_ns();
+			if (now < c->next_decoder_attempt)
+				break;
 			c->decoder = h264_decoder_create(
 				c->codec_id != AV_CODEC_ID_NONE
 					? c->codec_id
 					: AV_CODEC_ID_H264,
 				s->hw_decode && !c->hw_failed);
-			if (!c->decoder)
-				return false;
+			if (!c->decoder) {
+				c->next_decoder_attempt =
+					now + 5000000000ULL;
+				set_status(s, "%s",
+					   T_("Status.DecoderFailed"));
+				break;
+			}
+			c->next_decoder_attempt = 0;
 		}
 		if (!h264_decoder_decode(c->decoder, s->source, payload,
 					 hdr->payload_size, hdr->pts_ns)) {
@@ -811,8 +919,11 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 
 static bool client_read(struct ios_camera_source *s, struct client_state *c)
 {
-	uint8_t chunk[RECV_CHUNK];
-	int n = (int)recv(c->sock, (char *)chunk, sizeof(chunk), 0);
+	/* Receive straight into the buffer tail (no bounce copy), then
+	 * parse in place with an offset and compact once at the end. */
+	recv_buf_reserve(&c->buf, RECV_CHUNK);
+	int n = (int)recv(c->sock, (char *)c->buf.data + c->buf.len,
+			  RECV_CHUNK, 0);
 	if (n == 0) {
 		blog(LOG_INFO, "[lenslink] connection closed by device");
 		return false;
@@ -821,54 +932,69 @@ static bool client_read(struct ios_camera_source *s, struct client_state *c)
 		blog(LOG_INFO, "[lenslink] recv error %d", net_last_error());
 		return false;
 	}
+	c->buf.len += (size_t)n;
 
-	recv_buf_append(&c->buf, chunk, (size_t)n);
-
-	while (c->buf.len >= OBSC_HEADER_SIZE) {
+	size_t off = 0;
+	bool ok = true;
+	while (c->buf.len - off >= OBSC_HEADER_SIZE) {
 		struct obsc_header hdr;
-		if (!obsc_parse_header(c->buf.data, &hdr)) {
+		if (!obsc_parse_header(c->buf.data + off, &hdr)) {
 			blog(LOG_WARNING,
 			     "[lenslink] bad packet header, dropping client");
-			return false;
+			ok = false;
+			break;
 		}
 
 		size_t total = OBSC_HEADER_SIZE + hdr.payload_size;
-		if (c->buf.len < total)
+		if (c->buf.len - off < total)
 			break;
 
 		if (!handle_packet(s, c, &hdr,
-				   c->buf.data + OBSC_HEADER_SIZE))
-			return false;
+				   c->buf.data + off + OBSC_HEADER_SIZE)) {
+			ok = false;
+			break;
+		}
 
-		recv_buf_consume(&c->buf, total);
+		off += total;
 	}
 
-	return true;
+	recv_buf_consume(&c->buf, off);
+	return ok;
 }
 
-/* TCP connect with a 3-second timeout; returns a non-blocking socket. */
-static socket_t tcp_dial(const char *host, uint16_t port)
+/* TCP connect with a 3-second timeout; returns a non-blocking socket.
+ * Checks `stop` so destroying the source (which joins this thread) isn't
+ * stuck behind the full connect wait. */
+static socket_t tcp_dial(const char *host, uint16_t port,
+			 volatile bool *stop)
 {
-	char port_str[16];
-	snprintf(port_str, sizeof(port_str), "%u", (unsigned)port);
+	struct sockaddr_in addr = {0};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(port);
 
-	struct addrinfo hints = {0};
-	struct addrinfo *res = NULL;
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_STREAM;
-	if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res)
-		return OBSC_INVALID_SOCKET;
-
-	socket_t s = socket(res->ai_family, res->ai_socktype,
-			    res->ai_protocol);
-	if (s == OBSC_INVALID_SOCKET) {
+	/* The app shows the phone's numeric IP, so this fast path is the
+	 * normal one — and it avoids getaddrinfo, whose DNS timeout can
+	 * block for tens of seconds with no way to interrupt it. */
+	if (inet_pton(AF_INET, host, &addr.sin_addr) != 1) {
+		char port_str[16];
+		snprintf(port_str, sizeof(port_str), "%u", (unsigned)port);
+		struct addrinfo hints = {0};
+		struct addrinfo *res = NULL;
+		hints.ai_family = AF_INET;
+		hints.ai_socktype = SOCK_STREAM;
+		if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res)
+			return OBSC_INVALID_SOCKET;
+		memcpy(&addr, res->ai_addr, sizeof(addr));
+		addr.sin_port = htons(port);
 		freeaddrinfo(res);
-		return OBSC_INVALID_SOCKET;
 	}
 
+	socket_t s = socket(AF_INET, SOCK_STREAM, 0);
+	if (s == OBSC_INVALID_SOCKET)
+		return OBSC_INVALID_SOCKET;
+
 	net_set_nonblocking(s);
-	int ret = connect(s, res->ai_addr, (int)res->ai_addrlen);
-	freeaddrinfo(res);
+	int ret = connect(s, (struct sockaddr *)&addr, sizeof(addr));
 
 	if (ret != 0) {
 #ifdef _WIN32
@@ -878,11 +1004,19 @@ static socket_t tcp_dial(const char *host, uint16_t port)
 		if (errno != EINPROGRESS)
 			goto fail;
 #endif
-		fd_set wfds;
-		FD_ZERO(&wfds);
-		FD_SET(s, &wfds);
-		struct timeval tv = {.tv_sec = 3, .tv_usec = 0};
-		if (select((int)s + 1, NULL, &wfds, NULL, &tv) != 1)
+		/* Wait in 100 ms slices so a stop request interrupts the
+		 * connect instead of the destroyer waiting out 3 s. */
+		bool writable = false;
+		for (int i = 0; i < 30 && !(stop && *stop); i++) {
+			int r = net_wait(s, NET_WAIT_WRITE, 100);
+			if (r < 0)
+				goto fail;
+			if (r & NET_WAIT_WRITE) {
+				writable = true;
+				break;
+			}
+		}
+		if (!writable)
 			goto fail;
 
 		int err = 0;
@@ -1069,7 +1203,7 @@ static void dial_loop(struct ios_camera_source *s)
 					 k);
 			}
 			set_status(s, "%s %s", T_("Status.Dialing"), s->host);
-			sock = tcp_dial(s->host, OBSC_USB_PORT);
+			sock = tcp_dial(s->host, OBSC_USB_PORT, &s->stop);
 		}
 
 		if (sock == OBSC_INVALID_SOCKET) {
@@ -1084,19 +1218,20 @@ static void dial_loop(struct ios_camera_source *s)
 		struct client_state client = {.sock = sock};
 
 		while (!s->stop) {
-			fd_set fds;
-			FD_ZERO(&fds);
-			FD_SET(sock, &fds);
-			struct timeval tv = {.tv_sec = 0,
-					     .tv_usec = 200 * 1000};
-			int ret = select((int)sock + 1, &fds, NULL, NULL, &tv);
+			int events = NET_WAIT_READ;
+			if (client.out.len > 0)
+				events |= NET_WAIT_WRITE;
+			int ret = net_wait(sock, events, 200);
 			if (ret < 0)
 				break;
+			if (client.out.len > 0)
+				client_flush(&client);
 			latency_tick(s, &client);
 			control_tick(s, &client);
-			if (ret == 0)
-				continue;
-			if (!client_read(s, &client))
+			if (client.out.failed)
+				break;
+			if ((ret & NET_WAIT_READ) &&
+			    !client_read(s, &client))
 				break;
 		}
 
@@ -1278,6 +1413,20 @@ static void ios_camera_destroy(void *data)
 	web_control_stop(s->web);
 	unhook_audio(s);
 	stop_thread(s);
+
+	/* Undo the sync offset we applied to the user's audio source; a
+	 * stale offset would silently persist after this source is gone.
+	 * (The auto video-delay filter lives on this source and dies with
+	 * it.) */
+	if (s->applied_audio_offset != 0 && s->audio_source[0]) {
+		obs_source_t *audio =
+			obs_get_source_by_name(s->audio_source);
+		if (audio) {
+			obs_source_set_sync_offset(audio, 0);
+			obs_source_release(audio);
+		}
+	}
+
 	for (int i = 0; i < s->control_count; i++)
 		bfree(s->control_queue[i]);
 	lipsync_destroy(s->lipsync);

--- a/obs-plugin/src/lipsync.c
+++ b/obs-plugin/src/lipsync.c
@@ -47,6 +47,14 @@ void lipsync_reset(struct lipsync *ls)
 	memset(ls, 0, sizeof(*ls));
 }
 
+struct lipsync *lipsync_clone(const struct lipsync *ls)
+{
+	struct lipsync *copy = malloc(sizeof(*copy));
+	if (copy)
+		memcpy(copy, ls, sizeof(*copy));
+	return copy;
+}
+
 static void stream_push(struct env_stream *s, int64_t frame, float energy)
 {
 	s->frame[s->head] = frame;

--- a/obs-plugin/src/lipsync.h
+++ b/obs-plugin/src/lipsync.h
@@ -23,6 +23,12 @@ struct lipsync *lipsync_create(void);
 void lipsync_destroy(struct lipsync *ls);
 void lipsync_reset(struct lipsync *ls);
 
+/* Heap copy of the current state (~74 KB memcpy). Lets the caller hold its
+ * mutex only for the copy and run the expensive lipsync_estimate() on the
+ * clone, unlocked — the OBS audio callback must never wait on the
+ * correlation. Free with lipsync_destroy(). */
+struct lipsync *lipsync_clone(const struct lipsync *ls);
+
 /* Phone reference PCM (mono), sample timestamps derived from start_time_ns
  * — already converted to the plugin's clock domain. */
 void lipsync_add_reference(struct lipsync *ls, const int16_t *pcm,

--- a/obs-plugin/src/net-compat.h
+++ b/obs-plugin/src/net-compat.h
@@ -68,6 +68,70 @@ static inline int net_last_error(void)
 #endif
 }
 
+#ifndef _WIN32
+#include <poll.h>
+#endif
+
+#define NET_WAIT_READ 1
+#define NET_WAIT_WRITE 2
+
+/*
+ * Waits until the socket is readable/writable or the timeout expires.
+ * Returns a bitmask of NET_WAIT_* (0 on timeout, -1 on error). POSIX uses
+ * poll(): select()'s fd_set is undefined behavior for fds >= FD_SETSIZE
+ * (1024), reachable in a big OBS setup. Windows select() has no such
+ * limit (fd_sets are arrays of handles), so it stays.
+ */
+static inline int net_wait(socket_t s, int events, int timeout_ms)
+{
+#ifdef _WIN32
+	fd_set rfds, wfds;
+	FD_ZERO(&rfds);
+	FD_ZERO(&wfds);
+	if (events & NET_WAIT_READ)
+		FD_SET(s, &rfds);
+	if (events & NET_WAIT_WRITE)
+		FD_SET(s, &wfds);
+	struct timeval tv = {.tv_sec = timeout_ms / 1000,
+			     .tv_usec = (timeout_ms % 1000) * 1000};
+	int r = select(0, (events & NET_WAIT_READ) ? &rfds : NULL,
+		       (events & NET_WAIT_WRITE) ? &wfds : NULL, NULL, &tv);
+	if (r <= 0)
+		return r;
+	int out = 0;
+	if (FD_ISSET(s, &rfds))
+		out |= NET_WAIT_READ;
+	if (FD_ISSET(s, &wfds))
+		out |= NET_WAIT_WRITE;
+	return out;
+#else
+	struct pollfd pfd = {.fd = s, .events = 0};
+	if (events & NET_WAIT_READ)
+		pfd.events |= POLLIN;
+	if (events & NET_WAIT_WRITE)
+		pfd.events |= POLLOUT;
+	int r = poll(&pfd, 1, timeout_ms);
+	if (r <= 0)
+		return r;
+	int out = 0;
+	if (pfd.revents & (POLLIN | POLLERR | POLLHUP))
+		out |= NET_WAIT_READ;
+	if (pfd.revents & (POLLOUT | POLLERR | POLLHUP))
+		out |= NET_WAIT_WRITE;
+	return out;
+#endif
+}
+
+/* True if the last send/recv failed only because it would block. */
+static inline bool net_would_block(void)
+{
+#ifdef _WIN32
+	return WSAGetLastError() == WSAEWOULDBLOCK;
+#else
+	return errno == EWOULDBLOCK || errno == EAGAIN;
+#endif
+}
+
 static inline bool net_set_nonblocking(socket_t s)
 {
 #ifdef _WIN32

--- a/obs-plugin/src/protocol.h
+++ b/obs-plugin/src/protocol.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #define OBSC_MAGIC 0x4F425343u /* "OBSC" */
 #define OBSC_PROTOCOL_VERSION 1

--- a/obs-plugin/src/usbmux.c
+++ b/obs-plugin/src/usbmux.c
@@ -124,7 +124,10 @@ static socket_t usbmuxd_open(void)
 		return OBSC_INVALID_SOCKET;
 	}
 #endif
-	set_timeouts(s, 3);
+	/* Local IPC to a service on this machine: 1 s is generous, and the
+	 * properties dialog enumerates devices on the UI thread — a wedged
+	 * Apple Mobile Device service must not freeze OBS for long. */
+	set_timeouts(s, 1);
 	return s;
 }
 

--- a/obs-plugin/src/web-control.c
+++ b/obs-plugin/src/web-control.c
@@ -151,8 +151,10 @@ static const char control_page[] =
 	"flashlightUI(!!st.flashlight);flashlightEl.style.display=st.hasFlashlight===false?'none':'';"
 	"if(Array.isArray(st.lenses)){"
 	"const want=st.lenses.join('|');"
+	/* textContent, not innerHTML: lens labels come from the device. */
 	"if(lensselEl.dataset.opts!==want){lensselEl.dataset.opts=want;"
-	"lensselEl.innerHTML=st.lenses.map(l=>'<option>'+l+'</option>').join('')}"
+	"lensselEl.replaceChildren(...st.lenses.map(l=>{"
+	"const o=document.createElement('option');o.textContent=l;return o}))}"
 	"if(st.lens)lensselEl.value=st.lens}"
 	"lensselEl.style.display=(st.lenses&&st.lenses.length>1)?'':'none'}"
 	"}catch(e){statusEl.textContent='plugin unreachable';dotEl.style.background=COL.grey}}"
@@ -243,6 +245,34 @@ static void json_escape(const char *in, char *out, size_t out_size)
 	out[o] = 0;
 }
 
+/* True if the header value (up to CR/LF) names a loopback host, e.g.
+ * "localhost:9980" or "127.0.0.1:9980" or "http://localhost:9980". */
+static bool value_is_local(const char *v)
+{
+	while (*v == ' ' || *v == '\t')
+		v++;
+	if (strncmp(v, "http://", 7) == 0)
+		v += 7;
+	return strncmp(v, "localhost", 9) == 0 ||
+	       strncmp(v, "127.0.0.1", 9) == 0;
+}
+
+/* The listener binds to loopback, but that alone doesn't stop DNS
+ * rebinding (Host: attacker.com resolving to 127.0.0.1) or cross-site
+ * POSTs from web pages the streamer happens to visit (a text/plain POST
+ * is a "simple request" — no CORS preflight). Require a loopback Host,
+ * and a loopback Origin whenever the browser sends one. */
+static bool request_is_local(const char *request)
+{
+	const char *host = find_header(request, "Host");
+	if (!host || !value_is_local(host))
+		return false;
+	const char *origin = find_header(request, "Origin");
+	if (origin && !value_is_local(origin))
+		return false;
+	return true;
+}
+
 static void handle_client(struct web_control *wc, socket_t client)
 {
 	char request[MAX_REQUEST + 1];
@@ -270,6 +300,11 @@ static void handle_client(struct web_control *wc, socket_t client)
 	}
 	if (!body)
 		return;
+
+	if (!request_is_local(request)) {
+		respond(client, "403 Forbidden", "text/plain", "forbidden");
+		return;
+	}
 
 	if (strncmp(request, "GET / ", 6) == 0) {
 		respond(client, "200 OK", "text/html; charset=utf-8",
@@ -315,6 +350,14 @@ static void handle_client(struct web_control *wc, socket_t client)
 			have += (size_t)n;
 			request[have] = 0;
 		}
+		/* The refill loop can also exit because the buffer is full
+		 * (headers padded near MAX_REQUEST); enqueuing then would
+		 * read past the received bytes — off the end of `request`. */
+		if (have - body_offset < content_length) {
+			respond(client, "400 Bad Request", "text/plain",
+				"truncated body");
+			return;
+		}
 
 		ios_camera_enqueue_control(wc->source, request + body_offset,
 					   content_length);
@@ -332,11 +375,7 @@ static void *web_thread(void *data)
 	os_set_thread_name("ios-camera-web");
 
 	while (!wc->stop) {
-		fd_set fds;
-		FD_ZERO(&fds);
-		FD_SET(wc->listener, &fds);
-		struct timeval tv = {.tv_sec = 0, .tv_usec = 200 * 1000};
-		int ret = select((int)wc->listener + 1, &fds, NULL, NULL, &tv);
+		int ret = net_wait(wc->listener, NET_WAIT_READ, 200);
 		if (ret < 0)
 			break;
 		if (ret == 0)


### PR DESCRIPTION
Fixes every finding from the full-codebase review (3 parallel reviewers over the plugin C, the iOS app, and protocol/CI/build, findings verified before fixing).

## Highlights — things testers would have hit

- **Stalled connection no longer grows app memory without bound.** The in-flight cap exempted keyframes while every drop requested one, so a stall queued keyframes into the dead connection until iOS killed the app. The cap now applies to everything, keyframe requests wait for headroom, and TCP keepalive detects silently dead links instead of showing "Live" for minutes.
- **Control channel can no longer desync the protocol.** Control/timesync packets used to be abandoned mid-send after a 100ms spin; a truncated packet garbled everything after it until reconnect. Sends now go through a buffered writer flushed via the select loop, and the app treats desync as fatal (clean reconnect) rather than silently eating the buffer.
- **Live lens switches are safe.** If the new lens forces a resolution/fps clamp, the encoder is rebuilt and OBS gets a fresh video config (previously: wrong-size decode or a black stream behind a "Live" badge, with configure errors swallowed).
- **Camera interruptions recover.** A phone call or the Camera app grabbing the hardware used to kill capture permanently; the session now restarts and requests a keyframe. Same for audio route changes killing the lip-sync reference.
- **Web panel hardened**: out-of-bounds body read fixed, loopback Host/Origin required (DNS rebinding / cross-site control POSTs), device-supplied lens labels no longer hit `innerHTML`.

## Also fixed

- Thread safety: StreamClient state queue-confined; encoder session/keyframe flag locked; capture configure serialized on the session queue; stale send completions can't poison the new connection's backpressure; lip-sync correlation runs on a snapshot outside the OBS audio callback's mutex.
- Robustness: decoder-create failure retries with cooldown instead of reconnect-churn; decoder EAGAIN no longer drops an access unit; BT.2020/HDR colorspace mapped; sync offset restored on source destroy; start() reentrancy guard; VIDEO_CONFIG log clamped; `poll()` replaces `select()` on POSIX.
- Efficiency: receive path parses in place with one compaction per cycle (was O(packets × bytes) memmove) and shrinks after keyframe spikes; HEVC-support probe cached (was creating a hardware encoder session per SwiftUI render); capability lists and Wi-Fi IP cached per change; keyframe Data reserved up front; pinch zoom re-anchors at gesture start; remote values clamped.
- CI cost: docs-only PRs skip builds via a change-detection job (required checks still pass); redundant Simulator build removed; obs-studio submodules fetch only on libobs cache miss; auto-release serialized + tags refetched (two quick merges raced to the same tag); manual release dispatch now takes `tag_name`.

Plugin builds clean with `-Wall -Wextra -Werror`. No wire-format changes — old app + new plugin (and vice versa) stay compatible.

Tagged `Release-Bump: minor` → merging cuts v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_