### PR TITLE
Windows installer for the OBS plugin

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "obs-plugin/**"
       - "ios-app/**"
+      - "installer/**"
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           fi
           git fetch --depth=1 origin "$BASE"
           if git diff --name-only "$BASE" HEAD | \
-             grep -qE '^(obs-plugin/|ios-app/|\.github/workflows/build\.yml)'; then
+             grep -qE '^(obs-plugin/|ios-app/|installer/|\.github/workflows/build\.yml)'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
@@ -131,11 +131,22 @@ jobs:
           Copy-Item plugin-build\Release\lenslink.dll stage\obs-plugins\64bit\
           Copy-Item -Recurse obs-plugin\data\* stage\data\obs-plugins\lenslink\
 
+      # Compile the installer on PRs too, so a broken .iss can't reach a
+      # release build. Takes seconds.
+      - name: Build installer
+        run: |
+          if (-not (Get-Command iscc -ErrorAction SilentlyContinue)) {
+            choco install innosetup -y --no-progress
+          }
+          iscc /DAppVersion=0.0.0 installer\windows\lenslink.iss
+
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: lenslink-windows-x64
-          path: stage/
+          path: |
+            stage/
+            LensLink-installer-windows-x64.exe
 
   ios-app:
     name: iOS app (LensLink)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,23 @@ jobs:
           Copy-Item -Recurse obs-plugin\data\* stage\data\obs-plugins\lenslink\
           Compress-Archive -Path stage\* -DestinationPath lenslink-windows-x64.zip
 
+      # One-click alternative to the zip: detects the OBS folder from the
+      # registry and registers an uninstaller. Inno Setup is preinstalled
+      # on the runner image; the guard covers image changes.
+      - name: Build installer
+        run: |
+          if (-not (Get-Command iscc -ErrorAction SilentlyContinue)) {
+            choco install innosetup -y --no-progress
+          }
+          $version = "${{ inputs.tag_name || github.ref_name }}".TrimStart("v")
+          iscc /DAppVersion=$version installer\windows\lenslink.iss
+
       - uses: actions/upload-artifact@v4
         with:
           name: release-windows
-          path: lenslink-windows-x64.zip
+          path: |
+            lenslink-windows-x64.zip
+            LensLink-installer-windows-x64.exe
 
   ios-app:
     name: iOS app (unsigned IPA)
@@ -168,16 +181,18 @@ jobs:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           generate_release_notes: true
           files: |
+            dist/LensLink-installer-windows-x64.exe
             dist/lenslink-windows-x64.zip
             dist/lenslink-linux-x86_64.tar.gz
             dist/LensLink-unsigned.ipa
           body: |
             ## Installing
 
-            **Windows (OBS plugin):** download `lenslink-windows-x64.zip`
-            and extract it into `C:\Program Files\obs-studio\` (merge the
-            `obs-plugins` and `data` folders), then restart OBS. Built against
-            OBS Studio 32.x.
+            **Windows (OBS plugin):** download and run
+            `LensLink-installer-windows-x64.exe` — it finds your OBS Studio
+            folder automatically. Then restart OBS. (Prefer doing it by
+            hand? `lenslink-windows-x64.zip` extracts into
+            `C:\Program Files\obs-studio\`.) Built against OBS Studio 32.x.
 
             **Linux (OBS plugin):** download `lenslink-linux-x86_64.tar.gz`
             and extract it into `~/.config/obs-studio/plugins/`.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ phone.
 **1. The OBS plugin.** Download the build for your system from the
 [Releases](../../releases) page:
 
-- **Windows** — unzip `lenslink-windows-x64.zip` into
-  `C:\Program Files\obs-studio\` (merge the `obs-plugins` and `data`
-  folders), then restart OBS.
+- **Windows** — run `LensLink-installer-windows-x64.exe`. It finds your
+  OBS Studio folder automatically; restart OBS afterwards. (Prefer manual?
+  Unzip `lenslink-windows-x64.zip` into `C:\Program Files\obs-studio\`,
+  merging the `obs-plugins` and `data` folders.)
 - **Linux** — extract `lenslink-linux-x86_64.tar.gz` into
   `~/.config/obs-studio/plugins/`.
 - **macOS / building yourself** — see

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,7 @@ ios-app/               SwiftUI companion app (XcodeGen project)
   Sources/StreamClient.swift    Network.framework listener + framing
   Sources/AudioReference.swift  mic capture for lip-sync reference
   Sources/StreamingView.swift   full-screen streaming UI + camera controls
+installer/windows/     Inno Setup script for the Windows plugin installer
 docs/PROTOCOL.md       wire protocol specification
 docs/UI_DESIGN.md      app + web-panel design system
 ```

--- a/installer/windows/lenslink.iss
+++ b/installer/windows/lenslink.iss
@@ -1,0 +1,65 @@
+; LensLink OBS-plugin installer (Inno Setup 6).
+;
+; Compiled by the release workflow from the repository root:
+;   iscc /DAppVersion=1.2.0 installer\windows\lenslink.iss
+; with the plugin already packaged into stage\ (same layout the zip uses).
+;
+; Installs into the OBS Studio folder (auto-detected from the registry,
+; user-overridable) and registers a normal Windows uninstaller.
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{7C34D6B2-9A41-4F0E-8B7D-2E5A31C90F6E}
+AppName=LensLink for OBS Studio
+AppVersion={#AppVersion}
+AppPublisher=Exalted Pixels
+AppPublisherURL=https://github.com/MyNamesEMurray/LensLink
+AppSupportURL=https://github.com/MyNamesEMurray/LensLink/issues
+; Everything is laid out relative to the OBS install folder.
+DefaultDirName={code:GetObsDir}
+DirExistsWarning=no
+AppendDefaultDirName=no
+DisableProgramGroupPage=yes
+; OBS lives in Program Files, so writing there needs elevation.
+PrivilegesRequired=admin
+; "x64" (not the newer "x64compatible") so any Inno Setup 6.x compiles it.
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+; Keep the uninstaller out of OBS's root folder.
+UninstallFilesDir={app}\data\obs-plugins\lenslink
+OutputBaseFilename=LensLink-installer-windows-x64
+SourceDir=..\..
+OutputDir=.
+WizardStyle=modern
+SolidCompression=yes
+
+[Files]
+Source: "stage\obs-plugins\64bit\lenslink.dll"; DestDir: "{app}\obs-plugins\64bit"; Flags: ignoreversion
+Source: "stage\data\obs-plugins\lenslink\*"; DestDir: "{app}\data\obs-plugins\lenslink"; Flags: ignoreversion recursesubdirs
+
+[Messages]
+SelectDirDesc=Where is OBS Studio installed?
+SelectDirLabel3=Setup will install the LensLink plugin into your OBS Studio folder.
+
+[Code]
+function GetObsDir(Param: string): string;
+begin
+  { OBS Studio's installer records its location here. }
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\OBS Studio', '', Result) then
+    Result := ExpandConstant('{autopf}\obs-studio');
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  { A wrong folder installs "successfully" but OBS never sees the plugin;
+    warn (but allow — portable installs may look different). }
+  if (CurPageID = wpSelectDir) and
+     not FileExists(ExpandConstant('{app}\bin\64bit\obs64.exe')) then
+    Result := MsgBox('This folder does not look like an OBS Studio ' +
+                     'installation (bin\64bit\obs64.exe not found).' + #13#10 +
+                     'Install here anyway?', mbConfirmation, MB_YESNO) = IDYES;
+end;


### PR DESCRIPTION
Adds a one-click Windows installer so testers stop hand-merging folders into Program Files.

## What it does

- **`LensLink-installer-windows-x64.exe`** (Inno Setup): auto-detects the OBS Studio folder from the registry (`HKLM\SOFTWARE\OBS Studio`), lets the user override it, and warns if the chosen folder doesn't contain `obs64.exe` (portable installs can proceed anyway). Installs `lenslink.dll` + locale data and registers a normal Add/Remove Programs uninstaller.
- **Built in CI**: the release workflow compiles it (versioned from the tag) and attaches it to every release, listed first in the install notes. The zip remains for manual installs.
- **Validated on PRs**: the Windows PR job compiles the `.iss` too, so a broken script can't reach a release. Change detection and auto-release paths now include `installer/`.
- README and DEVELOPMENT.md updated.

Note: the exe is unsigned, so Windows SmartScreen will show its "unrecognized app" prompt (More info → Run anyway) — same as most free OBS plugins. Code-signing would need a paid certificate.

Tagged `Release-Bump: minor` → merging cuts v1.2.0 with the installer attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_