### PR TITLE
TestFlight pipeline: cloud-signed CI upload

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,113 @@
+name: TestFlight
+
+# Builds, signs, and uploads the iOS app (with the screen-mirror extension)
+# to TestFlight. Signing is fully cloud-managed via an App Store Connect
+# API key + `-allowProvisioningUpdates`, so no certificates or provisioning
+# profiles are stored in the repo.
+#
+# One-time setup (see docs/TESTFLIGHT.md): create an App Store Connect API
+# key and add these repository secrets:
+#   APP_STORE_CONNECT_KEY_ID       - the key's Key ID
+#   APP_STORE_CONNECT_ISSUER_ID    - the Issuer ID (Users and Access → Integrations)
+#   APP_STORE_CONNECT_KEY_P8       - the full contents of the .p8 file
+#   APPLE_TEAM_ID                  - your 10-character Developer Team ID
+# and create the app record (bundle id com.exaltedpixels.LensLink) in
+# App Store Connect once.
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+concurrency:
+  group: testflight
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Build & upload to TestFlight
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard on secrets
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        run: |
+          if [ -z "$KEY_ID" ]; then
+            echo "::error::App Store Connect secrets are not set — see docs/TESTFLIGHT.md."
+            exit 1
+          fi
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+        working-directory: ios-app
+
+      - name: Write App Store Connect API key
+        env:
+          KEY_P8: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        run: |
+          mkdir -p ~/private_keys
+          echo "$KEY_P8" > ~/private_keys/AuthKey_${KEY_ID}.p8
+
+      - name: Archive (cloud-signed)
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -o pipefail
+          # Build number must strictly increase per upload; the run number
+          # is monotonic. Offset keeps it clear of any earlier manual builds.
+          BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 ))
+          xcodebuild archive \
+            -project LensLink.xcodeproj \
+            -scheme LensLink \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/LensLink.xcarchive" \
+            -authenticationKeyPath ~/private_keys/AuthKey_${KEY_ID}.p8 \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -allowProvisioningUpdates \
+            DEVELOPMENT_TEAM="$TEAM_ID" \
+            CODE_SIGN_STYLE=Automatic \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
+        working-directory: ios-app
+
+      - name: Export & upload to TestFlight
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -o pipefail
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>destination</key><string>upload</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>uploadSymbols</key><true/>
+          </dict></plist>
+          PLIST
+          # 'destination: upload' hands the build straight to App Store
+          # Connect / TestFlight — no separate altool step.
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/LensLink.xcarchive" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -authenticationKeyPath ~/private_keys/AuthKey_${KEY_ID}.p8 \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -allowProvisioningUpdates
+        working-directory: ios-app
+
+      - name: Clean up API key
+        if: always()
+        run: rm -f ~/private_keys/AuthKey_*.p8

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -1,0 +1,56 @@
+# TestFlight setup (one-time)
+
+The [`TestFlight` workflow](../.github/workflows/testflight.yml) builds,
+signs, and uploads the iOS app — including the screen-mirror broadcast
+extension — to TestFlight. Signing is cloud-managed: no certificates or
+provisioning profiles live in the repo, only an App Store Connect API key
+in repository secrets. Requires a paid Apple Developer account.
+
+## 1. Create an App Store Connect API key
+
+1. [App Store Connect](https://appstoreconnect.apple.com) → **Users and
+   Access** → **Integrations** → **App Store Connect API** → **Team Keys**.
+2. **Generate API Key**: name e.g. `lenslink-ci`, access **App Manager**.
+3. Note the **Key ID** and the **Issuer ID** (shown at the top of the page),
+   and **download the `.p8` file** (single chance — keep it safe).
+
+## 2. Add the repository secrets
+
+GitHub repo → **Settings → Secrets and variables → Actions → New
+repository secret**, four times:
+
+| Secret | Value |
+|---|---|
+| `APP_STORE_CONNECT_KEY_ID` | the Key ID from step 1 |
+| `APP_STORE_CONNECT_ISSUER_ID` | the Issuer ID from step 1 |
+| `APP_STORE_CONNECT_KEY_P8` | the *entire contents* of the `.p8` file (open it in a text editor, copy everything including the BEGIN/END lines) |
+| `APPLE_TEAM_ID` | your 10-character Team ID ([developer.apple.com/account](https://developer.apple.com/account) → Membership details) |
+
+## 3. Create the app record (once)
+
+1. App Store Connect → **Apps** → **+** → **New App**.
+2. Platform iOS, name **LensLink**, bundle ID **com.exaltedpixels.LensLink**
+   (register it under Identifiers if it isn't offered; the CI's
+   `-allowProvisioningUpdates` registers the broadcast extension's child id
+   `…LensLink.broadcast` automatically on first run).
+3. SKU: anything, e.g. `lenslink`.
+
+## 4. Run it
+
+- Manually: **Actions → TestFlight → Run workflow**, or
+- Automatically: it runs on every **published release**.
+
+The first upload takes a few extra minutes of App Store Connect processing;
+after that the build appears under the app's **TestFlight** tab. Add
+yourself (internal testing group) and it lands on your phone via the
+TestFlight app immediately — external tester groups need a one-time beta
+review by Apple.
+
+## Why this also matters for the screen-mirror extension
+
+Broadcast upload extensions are sensitive to how the app was signed:
+re-signing tools frequently produce an appex that iOS refuses to launch
+(installed, visible in the picker, but the broadcast never starts).
+TestFlight builds are provisioned through Apple's own pipeline, which
+removes that whole failure class — and removes the 7-day re-sign cycle for
+everyone.

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -21,6 +21,8 @@ targets:
       path: Sources/Info.plist
       properties:
         CFBundleDisplayName: LensLink
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
@@ -40,5 +42,7 @@ targets:
         SWIFT_VERSION: "5.0"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic
+        MARKETING_VERSION: "1.0"
+        CURRENT_PROJECT_VERSION: "1" # CI overrides with the run number
         # Set your Apple Developer team to run on a device:
         # DEVELOPMENT_TEAM: XXXXXXXXXX


### PR DESCRIPTION
Adds a `TestFlight` workflow that builds, signs, and uploads the iOS app to TestFlight — on **published releases** or **manual dispatch** (with a branch picker, so pre-merge feature branches like the screen mirror can be uploaded for on-device testing).

- **Cloud-managed signing**: an App Store Connect API key (repo secrets) + `xcodebuild -allowProvisioningUpdates`. No certificates or profiles in the repo; the key file is written to the runner and removed after.
- **Build numbers** come from the workflow run number (offset +1000), so every upload strictly increases as App Store Connect requires. `project.yml` gains `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` for CI to drive.
- **One-time setup** documented in `docs/TESTFLIGHT.md`: create an API key, add 4 secrets (`APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_P8`, `APPLE_TEAM_ID`), create the app record.
- Guarded: dispatching without the secrets fails fast with a pointer to the doc.

This replaces the Sideloadly install path for anyone on TestFlight — no 7-day expiry, proper Apple provisioning (which should also fix the broadcast extension refusing to launch under third-party re-signing).

Tagged `Release-Skip: true` — infra only, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_