### PR TITLE
TestFlight fixes: distribution signing on CI + pre-answered export compliance

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -64,6 +64,11 @@ jobs:
           # Build number must strictly increase per upload; the run number
           # is monotonic. Offset keeps it clear of any earlier manual builds.
           BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 ))
+          # CODE_SIGN_IDENTITY="Apple Distribution": without it, automatic
+          # signing archives with a *development* profile — which needs a
+          # registered device, and CI has none ("No profiles for ... were
+          # found"). Distribution profiles have no device list, and the
+          # API key can create the cloud-managed cert on first run.
           xcodebuild archive \
             -project LensLink.xcodeproj \
             -scheme LensLink \
@@ -76,6 +81,7 @@ jobs:
             -allowProvisioningUpdates \
             DEVELOPMENT_TEAM="$TEAM_ID" \
             CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
         working-directory: ios-app
 

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -23,6 +23,10 @@ targets:
         CFBundleDisplayName: LensLink
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # Plain TCP on the local network, no custom crypto: pre-answers
+        # App Store Connect's export-compliance question so TestFlight
+        # builds are testable immediately instead of "Missing Compliance".
+        ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
Two follow-ups to the TestFlight pipeline (#18), from the first real dispatch:

- **Archive with `CODE_SIGN_IDENTITY="Apple Distribution"`.** Automatic signing archives with a *development* profile by default, which requires a registered device — CI runners have none, so the first run failed with `No profiles for 'com.exaltedpixels.LensLink' were found`. Distribution profiles carry no device list, and the API key mints the cloud-managed certificate on first use.
- **`ITSAppUsesNonExemptEncryption: false`** in the app's Info.plist — plain local-network TCP, no custom crypto — so uploads go straight to "Ready to Test" instead of parking at "Missing Compliance" pending a manual answer per build.

Same fixes are already on the screen-mirror branch for its next dispatch.

Tagged `Release-Skip: true` — infra only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_