### PR TITLE
TestFlight: drop CODE_SIGN_IDENTITY override (conflicts with automatic signing)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -64,11 +64,12 @@ jobs:
           # Build number must strictly increase per upload; the run number
           # is monotonic. Offset keeps it clear of any earlier manual builds.
           BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 ))
-          # CODE_SIGN_IDENTITY="Apple Distribution": without it, automatic
-          # signing archives with a *development* profile — which needs a
-          # registered device, and CI has none ("No profiles for ... were
-          # found"). Distribution profiles have no device list, and the
-          # API key can create the cloud-managed cert on first run.
+          # Automatic signing + -allowProvisioningUpdates is the whole
+          # story: an *archive* selects distribution signing and creates
+          # the App Store profile via the API key with no registered
+          # device. Do NOT override CODE_SIGN_IDENTITY — a manual identity
+          # conflicts with automatic style ("conflicting provisioning
+          # settings"). Export (next step) re-signs for the store.
           xcodebuild archive \
             -project LensLink.xcodeproj \
             -scheme LensLink \
@@ -81,7 +82,6 @@ jobs:
             -allowProvisioningUpdates \
             DEVELOPMENT_TEAM="$TEAM_ID" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
         working-directory: ios-app
 


### PR DESCRIPTION
Reverts the `CODE_SIGN_IDENTITY="Apple Distribution"` override added in #19 — it was the wrong fix.

The first TestFlight run failed with "No profiles for … were found", which I attributed to development-vs-distribution signing. It was actually the **wrong team ID** in the secret (since corrected). My override then caused a *new* failure — `conflicting provisioning settings` — because a manual identity can't be combined with automatic signing.

The correct recipe is plain automatic signing + `-allowProvisioningUpdates`: an *archive* selects distribution signing and creates the App Store profile via the API key with no registered device; the export step re-signs for the store. No identity override needed.

Same fix already on the screen-mirror branch.

Tagged `Release-Skip: true` — infra only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_