### PR TITLE
Sync main with the proven TestFlight config

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -11,7 +11,7 @@ name: TestFlight
 #   APP_STORE_CONNECT_ISSUER_ID    - the Issuer ID (Users and Access → Integrations)
 #   APP_STORE_CONNECT_KEY_P8       - the full contents of the .p8 file
 #   APPLE_TEAM_ID                  - your 10-character Developer Team ID
-# and create the app record (bundle id com.exaltedpixels.LensLink) in
+# and create the app record (bundle id com.exaltedpixels.LensLinkCamera) in
 # App Store Connect once.
 
 on:
@@ -38,6 +38,20 @@ jobs:
             echo "::error::App Store Connect secrets are not set — see docs/TESTFLIGHT.md."
             exit 1
           fi
+
+      # App Store Connect rejects uploads built with older SDKs ("must be
+      # built with the iOS 26 SDK or later"); the runner's default Xcode
+      # is older, so pick the newest Xcode 26.x on the image.
+      - name: Select Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "::error::No Xcode 26.x on this runner image. Installed:"
+            ls /Applications | grep -i xcode || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -29,7 +29,7 @@ repository secret**, four times:
 ## 3. Create the app record (once)
 
 1. App Store Connect → **Apps** → **+** → **New App**.
-2. Platform iOS, name **LensLink**, bundle ID **com.exaltedpixels.LensLink**
+2. Platform iOS, name **LensLink**, bundle ID **com.exaltedpixels.LensLinkCamera**
    (register it under Identifiers if it isn't offered; the CI's
    `-allowProvisioningUpdates` registers the broadcast extension's child id
    `…LensLink.broadcast` automatically on first run).

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -28,8 +28,12 @@ targets:
         # builds are testable immediately instead of "Missing Compliance".
         ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
+        # All four orientations: App Store validation requires the full set
+        # for iPad multitasking (or UIRequiresFullScreen, which we'd rather
+        # not force).
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         NSCameraUsageDescription: >-
@@ -42,6 +46,9 @@ targets:
           automatically sync your real microphone to the video.
     settings:
       base:
+        # Explicit (not derived from bundleIdPrefix): com.exaltedpixels.LensLink
+        # is registered to another Apple account, so it can't be used.
+        PRODUCT_BUNDLE_IDENTIFIER: com.exaltedpixels.LensLinkCamera
         TARGETED_DEVICE_FAMILY: "1,2"
         SWIFT_VERSION: "5.0"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
Brings everything the **first successful TestFlight upload** needed onto `main`, so release-triggered uploads work identically to the screen-mirror branch dispatch that just succeeded:

- **Bundle ID → `com.exaltedpixels.LensLinkCamera`** (the old `…LensLink` is registered to another Apple account; the ASC app record now points at the new ID)
- **All four interface orientations** (App Store iPad-multitasking validation)
- **Xcode 26 selection** on the TestFlight runner (Apple's iOS 26 SDK upload floor; the image default 16.4 is rejected)
- `docs/TESTFLIGHT.md` updated to match

Tagged `Release-Skip: true` — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_