### PR TITLE
App: fix post-stop UI hang, compact main screen, source-split verbiage

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -93,3 +93,14 @@ jobs:
       tag_name: ${{ needs.version.outputs.tag }}
     permissions:
       contents: write
+
+  # Called directly rather than relying on the `release: published`
+  # trigger: releases created with GITHUB_TOKEN never trigger other
+  # workflows (GitHub's recursion guard), so the TestFlight upload would
+  # silently not happen for auto-releases.
+  testflight:
+    name: TestFlight
+    needs: [version, release]
+    if: needs.version.outputs.tag != ''
+    uses: ./.github/workflows/testflight.yml
+    secrets: inherit

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,8 +16,13 @@ name: TestFlight
 
 on:
   workflow_dispatch:
+  # Only fires for releases published by a real user. Auto-releases are
+  # published with GITHUB_TOKEN, whose events GitHub suppresses from
+  # triggering workflows — auto-release.yml therefore *calls* this
+  # workflow directly instead (workflow_call below).
   release:
     types: [published]
+  workflow_call:
 
 concurrency:
   group: testflight

--- a/ios-app/BroadcastExtension/SampleHandler.swift
+++ b/ios-app/BroadcastExtension/SampleHandler.swift
@@ -128,9 +128,10 @@ class SampleHandler: RPBroadcastSampleHandler {
             try? await Task.sleep(nanoseconds: 30_000_000_000)
             guard let self, !Task.isCancelled, !self.everConnected else { return }
             self.fail("OBS did not connect within 30 seconds "
-                + "[\(self.client.debugStatus())]. Check the LensLink "
-                + "Camera source points at this phone (USB, or this "
-                + "phone's Wi-Fi IP) and the camera stream isn't running.")
+                + "[\(self.client.debugStatus())]. Check OBS has a LensLink "
+                + "Screen source pointing at this phone (USB, or this "
+                + "phone's Wi-Fi IP) — a LensLink Camera source won't accept "
+                + "a screen broadcast — and the camera stream isn't running.")
         }
     }
 

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -51,7 +51,10 @@ final class CameraManager: NSObject {
     /// The device currently feeding the session; camera controls act on it.
     private(set) var activeDevice: AVCaptureDevice?
 
-    private let sessionQueue = DispatchQueue(label: "obscam.session")
+    /* Internal (not private): the preview layer attaches/detaches its
+     * session on this queue too — doing that on the main thread contends
+     * with start/stopRunning and freezes the UI for seconds. */
+    let sessionQueue = DispatchQueue(label: "obscam.session")
     private let videoQueue = DispatchQueue(label: "obscam.video")
     private var videoOutput: AVCaptureVideoDataOutput?
 

--- a/ios-app/Sources/CameraPreviewView.swift
+++ b/ios-app/Sources/CameraPreviewView.swift
@@ -5,6 +5,13 @@ import AVFoundation
 /// tap-to-focus (reports the tap in device coordinates) and pinch-to-zoom.
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
+    /// The camera's session queue. Attaching/detaching the preview layer
+    /// takes the session's internal lock; doing it on the main thread while
+    /// `stopRunning()` (1–3 s) holds that lock on the session queue freezes
+    /// the whole UI — the classic "app hangs for a few seconds after
+    /// stopping the stream". Routing both through the session queue
+    /// serializes them after any start/stop instead of blocking main.
+    let sessionQueue: DispatchQueue
     var videoGravity: AVLayerVideoGravity = .resizeAspect
     var onTapAtDevicePoint: ((CGPoint) -> Void)?
     var onPinchZoom: ((_ phase: PinchPhase, _ scale: CGFloat) -> Void)?
@@ -55,8 +62,15 @@ struct CameraPreviewView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> PreviewView {
         let view = PreviewView()
-        view.previewLayer.session = session
-        view.previewLayer.videoGravity = videoGravity
+        let layer = view.previewLayer
+        layer.videoGravity = videoGravity
+        // Off-main attach (see `sessionQueue` note). The preview stays
+        // blank until the session is running anyway, so deferring the
+        // attach behind a pending startRunning() costs nothing visible.
+        let session = session
+        sessionQueue.async {
+            layer.session = session
+        }
 
         if onTapAtDevicePoint != nil {
             let tap = UITapGestureRecognizer(
@@ -76,5 +90,16 @@ struct CameraPreviewView: UIViewRepresentable {
     func updateUIView(_ uiView: PreviewView, context: Context) {
         context.coordinator.parent = self
         uiView.previewLayer.videoGravity = videoGravity
+    }
+
+    static func dismantleUIView(_ uiView: PreviewView, coordinator: Coordinator) {
+        // Off-main detach: when the streaming view closes right as
+        // stopRunning() executes, detaching here on the main thread would
+        // block until the stop completes (the 2–5 s hang). The queue hop
+        // retains the layer until the detach has actually run.
+        let layer = uiView.previewLayer
+        coordinator.parent.sessionQueue.async {
+            layer.session = nil
+        }
     }
 }

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -220,9 +220,13 @@ struct ContentView: View {
     }
 
     private var optionsSection: some View {
-        Section("Options") {
+        // Section has no (title-string + footer-closure) initializer; the
+        // header must be a closure too.
+        Section {
             Toggle("Dim screen while streaming", isOn: $streamer.dimWhileStreaming)
             Toggle("Auto lip-sync reference", isOn: $streamer.sendAudioReference)
+        } header: {
+            Text("Options")
         } footer: {
             Text("Dim: the screen dims after 10 seconds of streaming; tap to wake. Lip-sync: sends the phone mic to OBS purely as a timing reference so the plugin can auto-align your real microphone — it is never streamed or heard.")
         }

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -10,6 +10,12 @@ struct ContentView: View {
     @State private var availableResolutions: [CameraManager.Resolution] = []
     @State private var availableFrameRates: [Int] = []
 
+    // Collapsible help: the connection instructions are essential exactly
+    // once. Persisted so the form stays minimal after the user has
+    // collapsed them, keeping Start/Mirror near the top of the screen.
+    @AppStorage("showConnectionHelp") private var showConnectionHelp = true
+    @AppStorage("showMirrorTools") private var showMirrorTools = false
+
     var body: some View {
         if streamer.isStreaming {
             StreamingView()
@@ -21,13 +27,10 @@ struct ContentView: View {
     private var settingsForm: some View {
         NavigationView {
             Form {
-                statusSection
-                receiveSection
+                connectSection
+                streamSection
                 cameraSection
                 optionsSection
-                lipSyncSection
-                actionSection
-                screenMirrorSection
             }
             .navigationTitle("LensLink")
         }
@@ -60,75 +63,9 @@ struct ContentView: View {
         }
     }
 
-    private var optionsSection: some View {
-        Section {
-            Toggle("Dim screen while streaming", isOn: $streamer.dimWhileStreaming)
-        } footer: {
-            Text("Saves battery: the screen dims after 10 seconds of streaming; tap to wake it.")
-        }
-    }
-
-    private var lipSyncSection: some View {
-        Section {
-            Toggle("Auto lip-sync reference", isOn: $streamer.sendAudioReference)
-        } footer: {
-            Text("Sends the phone mic to OBS purely as a timing reference so the plugin can auto-align your real microphone to the video. Your phone audio is never streamed or heard.")
-        }
-    }
-
-    @State private var probeResult: String?
-    @State private var extensionStatus = ""
-
-    /// Screen mirroring is a separate path (a broadcast extension), not the
-    /// camera pipeline — so it lives in its own section with the system
-    /// broadcast picker.
-    private var screenMirrorSection: some View {
-        Section("Mirror your screen instead") {
-            HStack(spacing: Theme.Space.m) {
-                BroadcastButton()
-                    .frame(width: 52, height: 52)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Screen mirror to OBS")
-                        .font(.body.weight(.semibold))
-                    Text("Streams your whole screen + app audio. Point the same OBS source at this phone.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            // Whether the extension survived sideloading — the broadcast
-            // picker can show a stale entry even when it didn't.
-            Text(extensionStatus)
-                .font(.caption)
-                .foregroundColor(
-                    extensionStatus.hasPrefix("✓") ? .secondary : .red)
-                .onAppear {
-                    extensionStatus =
-                        BroadcastProbe.installedExtensionDescription()
-                }
-            // Diagnostic: verifies the broadcast extension's listener is
-            // reachable on-device, independent of OBS/USB. Run it while a
-            // broadcast is active.
-            Button {
-                probeResult = "Checking…"
-                BroadcastProbe.run { ok in
-                    probeResult = ok
-                        ? "✓ Broadcast link is up — OBS should be able to connect"
-                        : "✗ No listener — is a screen broadcast running? If yes, the extension isn't working"
-                }
-            } label: {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Check broadcast link")
-                    if let probeResult {
-                        Text(probeResult)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-            }
-        }
-    }
-
-    private var statusSection: some View {
+    /// Status + the phone's address on one compact line; the longer
+    /// instructions collapse away once read.
+    private var connectSection: some View {
         Section {
             HStack(spacing: Theme.Space.m) {
                 Circle()
@@ -136,39 +73,120 @@ struct ContentView: View {
                     .frame(width: 10, height: 10)
                 Text(streamer.status.displayName)
                     .font(.callout)
+                Spacer()
+                if let ip = wifiIP {
+                    Text(ip)
+                        .font(.callout.monospacedDigit().bold())
+                        .textSelection(.enabled)
+                }
+            }
+            DisclosureGroup("How to connect", isExpanded: $showConnectionHelp) {
+                if let ip = wifiIP {
+                    Label {
+                        Text("In OBS, add a \"LensLink Camera\" source and enter \(Text(ip).bold()) as the Phone IP. (Phone and computer must be on the same Wi-Fi.)")
+                            .font(.callout)
+                            .foregroundColor(.secondary)
+                    } icon: {
+                        Image(systemName: "wifi")
+                    }
+                } else {
+                    Label {
+                        Text("No Wi-Fi address found — connect to Wi-Fi, or use a USB cable.")
+                            .font(.callout)
+                            .foregroundColor(.secondary)
+                    } icon: {
+                        Image(systemName: "wifi.slash")
+                    }
+                }
+                Label {
+                    Text("Or plug in a USB cable and set the OBS source's Connection to \"USB cable\" (needs iTunes on Windows). No Wi-Fi required.")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                } icon: {
+                    Image(systemName: "cable.connector")
+                }
             }
         }
     }
 
-    private var receiveSection: some View {
-        Section("How to connect") {
-            if let ip = wifiIP {
-                HStack {
-                    Image(systemName: "wifi")
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("This phone's address")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Text(ip)
-                            .font(.title3.monospacedDigit().bold())
-                            .textSelection(.enabled)
+    @State private var probeResult: String?
+    @State private var extensionStatus = ""
+
+    /// Both ways to stream, side by side near the top: the camera (the
+    /// primary action) and the screen mirror (a broadcast extension, so it
+    /// uses the system picker). Mirror diagnostics hide in a disclosure.
+    private var streamSection: some View {
+        Section {
+            Button {
+                Task { await streamer.start() }
+            } label: {
+                Label("Start streaming to OBS", systemImage: "video.fill")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Theme.accent)
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color.clear)
+
+            if streamer.cameraPermissionDenied || streamer.micPermissionDenied {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
                     }
                 }
-                Text("In OBS, add a \"LensLink Camera\" source and enter this address as the Phone IP.")
-                    .font(.callout)
-                    .foregroundColor(.secondary)
-            } else {
-                Text("No Wi-Fi address found — connect to Wi-Fi, or use a USB cable.")
-                    .font(.callout)
-                    .foregroundColor(.secondary)
             }
-            Label {
-                Text("Or plug in a USB cable and set the OBS source's Connection to \"USB cable\" (needs iTunes on Windows). No Wi-Fi required.")
-                    .font(.callout)
-                    .foregroundColor(.secondary)
-            } icon: {
-                Image(systemName: "cable.connector")
+
+            HStack(spacing: Theme.Space.m) {
+                BroadcastButton()
+                    .frame(width: 44, height: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Mirror your screen instead")
+                        .font(.body.weight(.semibold))
+                    Text("Whole screen + app audio, to a \"LensLink Screen\" source.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
+
+            // Surface a broken extension unconditionally (sideloading can
+            // silently drop it); the healthy checkmark stays collapsed.
+            if !extensionStatus.isEmpty && !extensionStatus.hasPrefix("✓") {
+                Text(extensionStatus)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            DisclosureGroup("Screen mirror tools", isExpanded: $showMirrorTools) {
+                Text(extensionStatus)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                // Diagnostic: verifies the broadcast extension's listener
+                // is reachable on-device, independent of OBS/USB. Run it
+                // while a broadcast is active.
+                Button {
+                    probeResult = "Checking…"
+                    BroadcastProbe.run { ok in
+                        probeResult = ok
+                            ? "✓ Broadcast link is up — OBS should be able to connect"
+                            : "✗ No listener — is a screen broadcast running? If yes, the extension isn't working"
+                    }
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check broadcast link")
+                        if let probeResult {
+                            Text(probeResult)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // Whether the extension survived sideloading — the broadcast
+            // picker can show a stale entry even when it didn't.
+            extensionStatus = BroadcastProbe.installedExtensionDescription()
         }
     }
 
@@ -201,27 +219,12 @@ struct ContentView: View {
         }
     }
 
-    private var actionSection: some View {
-        Section {
-            Button {
-                Task { await streamer.start() }
-            } label: {
-                Label("Start streaming to OBS", systemImage: "video.fill")
-                    .font(.body.weight(.semibold))
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(Theme.accent)
-            .listRowInsets(EdgeInsets())
-            .listRowBackground(Color.clear)
-
-            if streamer.cameraPermissionDenied || streamer.micPermissionDenied {
-                Button("Open Settings") {
-                    if let url = URL(string: UIApplication.openSettingsURLString) {
-                        UIApplication.shared.open(url)
-                    }
-                }
-            }
+    private var optionsSection: some View {
+        Section("Options") {
+            Toggle("Dim screen while streaming", isOn: $streamer.dimWhileStreaming)
+            Toggle("Auto lip-sync reference", isOn: $streamer.sendAudioReference)
+        } footer: {
+            Text("Dim: the screen dims after 10 seconds of streaming; tap to wake. Lip-sync: sends the phone mic to OBS purely as a timing reference so the plugin can auto-align your real microphone — it is never streamed or heard.")
         }
     }
 }

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -20,6 +20,7 @@ struct StreamingView: View {
 
             CameraPreviewView(
                 session: streamer.camera.session,
+                sessionQueue: streamer.camera.sessionQueue,
                 videoGravity: .resizeAspect,
                 onTapAtDevicePoint: { point in
                     touched()


### PR DESCRIPTION
Three app-side improvements:

## 1. Fix the 2–5 s UI freeze after stopping the camera stream
`AVCaptureVideoPreviewLayer` attach/detach takes the capture session's internal lock. When the streaming view closed at the same moment `stopRunning()` (1–3 s) held that lock on the session queue, the **main thread blocked on the layer detach** until the stop finished — the freeze you saw back on the main screen. The preview layer now attaches/detaches on the camera's session queue, serialized after any start/stop, so the main thread never waits. Also removes the equivalent smaller stall when the preview first appears.

## 2. Minimal main screen
- Status + phone IP condensed to a single line
- "How to connect" instructions fold into a DisclosureGroup (state persisted across launches — read it once, it stays collapsed)
- **Start streaming and Mirror screen now sit together directly under the connect section** — no scrolling to reach screen mirroring
- Extension-status/probe diagnostics tucked into a "Screen mirror tools" disclosure (a broken extension still surfaces in red unconditionally)
- Dim + lip-sync merged into one Options section

## 3. Verbiage refresh for the source split
Connect help names the "LensLink Camera" source, the mirror row points at a "LensLink Screen" source, and the broadcast watchdog alert no longer tells you to check a Camera source (which now rejects screen streams).

Tagged `Release-Skip: true` (squash-merge with `Release-Bump:` when a release is wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qrp83VmgTR1fJmSeBRtHR)_