### PR TITLE
Feature: remote format switching (resolution / fps / codec) from the web panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ blanks the source.
 - **Live camera controls**, both on the phone (full-screen view with pinch
   zoom, tap-to-focus, exposure, focus lock, flashlight, camera flip) and
   **from your computer** via a browser panel at
-  `http://localhost:9980` (zoom / exposure / focus / flashlight / flip).
+  `http://localhost:9980` (zoom / exposure / focus / flashlight / flip,
+  plus switching lens, resolution, frame rate, and codec mid-stream).
 - **Remote start.** With the app open, OBS can start the camera for you —
   automatically when the source connects, or from a button in the source's
   properties or the browser panel. Siri works too: *"Start streaming with

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -99,7 +99,16 @@ Camera remote control. Payload: UTF-8 JSON, one command per packet:
 { "cmd": "flip" }
 { "cmd": "start_stream" }
 { "cmd": "stop_stream" }
+{ "cmd": "set_format", "resolution": "1080p", "fps": 60, "codec": "hevc" }
 ```
+
+`set_format` switches the capture format mid-stream; any subset of its
+fields may be present. The app validates the combination against the
+active lens (the STATE snapshot advertises the valid choices in
+`resolutions` / `frameRates` / `codecs`, plus the current `resolution` /
+`fps` / `codec`) and ignores unsupported requests. A format change flows
+through the normal live-reconfigure path: new VIDEO_CONFIG, fresh
+keyframe, decoder reset on a codec change.
 
 Unknown commands are ignored, so new ones can be added compatibly. The
 plugin's embedded web panel (http://localhost:9980) generates these.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,16 +103,7 @@ commands are already ignored by old apps, so it's compatible), and the
 web panel mirrors them like every other control. *Low-medium effort,
 natural extension of an existing surface.*
 
-### 5. Remote format switching from OBS
-Lens selection is already remote-controllable; resolution / frame rate /
-codec are not — walking to the phone to flip 1080p→4K contradicts the
-remote-start story. A `set_format` CONTROL command driving the same live
-reconfigure path the lens switch uses (`reconfigureLiveCapture`), with
-the capability list (which combos the camera supports) included in the
-STATE snapshot so OBS/web-panel pickers only offer what works. *Low
-effort on the app side; property-UI work on the plugin side.*
-
-### 6. Orientation metadata
+### 5. Orientation metadata
 A rotated phone streams sideways video today; streamers work around it
 with OBS transforms. Capturing device orientation and either rotating
 the buffer at the encoder or signaling it in VIDEO_CONFIG (plugin

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -86,8 +86,12 @@ final class Streamer: ObservableObject {
         }
         resetCameraControls()
 
-        if formatChanged, let oldEncoder = encoder {
-            let activeCodec = oldEncoder.codec
+        // Same HEVC fallback as start(): the codec setting may have been
+        // switched (remotely or locally) to one this device can't encode.
+        let activeCodec = (codec == .hevc && !VideoEncoder.isSupported(.hevc))
+            ? VideoCodec.h264 : codec
+        if let oldEncoder = encoder,
+           formatChanged || oldEncoder.codec != activeCodec {
             oldEncoder.stop()
             let size = resolution.size
             let newEncoder = VideoEncoder(
@@ -193,7 +197,8 @@ final class Streamer: ObservableObject {
     }
 
     private func controlStateSnapshot() -> [String: Any] {
-        [
+        let (resolutions, frameRates) = formatCapabilities()
+        return [
             "zoom": Double(zoom),
             "maxZoom": Double(camera.maxZoomFactor),
             "exposureBias": Double(exposureBias),
@@ -204,7 +209,39 @@ final class Streamer: ObservableObject {
             "camera": selectedLens.position == .front ? "front" : "back",
             "lens": selectedLens.label,
             "lenses": availableLenses.map { $0.label },
+            // Format state + what this lens supports, so remote UIs can
+            // offer set_format pickers with only valid choices.
+            "resolution": resolution.rawValue,
+            "fps": fps,
+            "codec": (encoder?.codec ?? codec).rawValue,
+            "resolutions": resolutions,
+            "frameRates": frameRates,
+            "codecs": VideoCodec.allCases
+                .filter { VideoEncoder.isSupported($0) }
+                .map { $0.rawValue },
         ]
+    }
+
+    /// Capability lists for the STATE snapshot. Cached per lens+resolution:
+    /// `CameraManager.supports` walks the device's format table, and the
+    /// snapshot is resent on every (debounced) control change — e.g. for
+    /// the whole length of a zoom drag.
+    private var capabilityCache: (key: String, resolutions: [String], frameRates: [Int])?
+
+    private func formatCapabilities() -> ([String], [Int]) {
+        let key = "\(selectedLens.id)|\(resolution.rawValue)"
+        if let cached = capabilityCache, cached.key == key {
+            return (cached.resolutions, cached.frameRates)
+        }
+        let resolutions = CameraManager.Resolution.allCases.filter {
+            CameraManager.supports(resolution: $0, fps: 30, lens: selectedLens)
+        }.map { $0.rawValue }
+        let frameRates = [30, 60].filter {
+            CameraManager.supports(resolution: resolution, fps: Int32($0),
+                                   lens: selectedLens)
+        }
+        capabilityCache = (key, resolutions, frameRates)
+        return (resolutions, frameRates)
     }
 
     private func applyFocus() {
@@ -440,6 +477,8 @@ final class Streamer: ObservableObject {
             }
         case "flip":
             flipCamera()
+        case "set_format":
+            applyRemoteFormat(command)
         case "selectLens":
             if let label = command["label"] as? String,
                let lens = availableLenses.first(where: { $0.label == label }),
@@ -450,6 +489,43 @@ final class Streamer: ObservableObject {
         default:
             break
         }
+    }
+
+    /// Remote format change (resolution / frame rate / codec) from the
+    /// plugin's web panel. Any subset of fields may be present; the combo
+    /// is validated against the current lens and ignored if unsupported —
+    /// the STATE snapshot advertises what's valid, so a remote UI only
+    /// offers combos that work.
+    private func applyRemoteFormat(_ command: [String: Any]) {
+        var newResolution = resolution
+        var newFps = fps
+        var newCodec = codec
+
+        if let raw = command["resolution"] as? String {
+            guard let parsed = CameraManager.Resolution(rawValue: raw) else { return }
+            newResolution = parsed
+        }
+        if let value = (command["fps"] as? NSNumber)?.intValue {
+            newFps = value
+        }
+        if let raw = command["codec"] as? String {
+            guard let parsed = VideoCodec(rawValue: raw),
+                  VideoEncoder.isSupported(parsed) else { return }
+            newCodec = parsed
+        }
+        guard CameraManager.supports(resolution: newResolution,
+                                     fps: Int32(newFps),
+                                     lens: selectedLens) else { return }
+
+        let formatChanged = newResolution != resolution || newFps != fps
+        let codecChanged = newCodec != codec
+        guard formatChanged || codecChanged else { return }
+        resolution = newResolution
+        fps = newFps
+        codec = newCodec
+        // reconfigure also rebuilds the encoder on a codec-only change
+        // (it compares the running encoder's codec itself).
+        reconfigureLiveCapture(formatChanged: formatChanged)
     }
 
     /// Switches front/back if a lens on the other side supports the

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -1080,6 +1080,29 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 			h264_decoder_destroy(c->decoder);
 			c->decoder = NULL;
 			c->codec_id = id;
+			/* A codec switch starts a NEW decode stream, so the
+			 * failover machinery must re-arm with it. The silent
+			 * no-output watchdog only fires while frames_output
+			 * is 0 — a stale count from the previous codec kept
+			 * it disarmed, so a hardware decoder that accepted
+			 * packets but emitted nothing froze the source
+			 * forever (works on a fresh connection, froze on a
+			 * mid-stream HEVC→H.264 switch). hw_failed resets
+			 * too: it described the OLD codec's hardware path;
+			 * the new codec deserves its own hardware attempt,
+			 * with the watchdog and the error path both armed to
+			 * catch it. */
+			c->video_packets = 0;
+			c->video_bytes = 0;
+			c->keyframes_seen = 0;
+			c->frames_output = 0;
+			c->decode_errors = 0;
+			c->first_frame_ns = 0;
+			c->no_output_warned = false;
+			c->hw_failed = false;
+			c->next_decoder_attempt = 0;
+			/* Diagnostics measure per decode-stream from here. */
+			c->connected_ns = os_gettime_ns();
 		}
 		break;
 	}

--- a/obs-plugin/src/web-control.c
+++ b/obs-plugin/src/web-control.c
@@ -109,6 +109,13 @@ static const char control_page[] =
 	"stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>"
 	"<path d='M15 4 h5 v5'/><path d='M20 9 A8 8 0 0 0 6 6'/>"
 	"<path d='M9 20 H4 v-5'/><path d='M4 15 A8 8 0 0 0 18 18'/></svg></button>"
+	"</div>"
+	/* Format row (resolution / fps / codec): shown once the app's STATE
+	 * advertises its capability lists; older apps just never show it. */
+	"<div class='row' id='fmtrow' style='display:none'>"
+	"<select id='fmtres' title='Resolution'></select>"
+	"<select id='fmtfps' title='Frame rate'></select>"
+	"<select id='fmtcodec' title='Codec'></select>"
 	"</div></div>"
 	"<script>"
 	/* NB: elements are looked up explicitly — a bare `status` would
@@ -118,7 +125,9 @@ static const char control_page[] =
 	"expEl=$('exposure'),evEl=$('ev'),afEl=$('af'),mfEl=$('mf'),lensEl=$('lens'),"
 	"fhintEl=$('fhint'),flashlightEl=$('flashlight'),flipEl=$('flip'),lensselEl=$('lenssel'),"
 	"panelEl=$('panel'),screennoteEl=$('screennote'),"
-	"startpanelEl=$('startpanel'),startbtnEl=$('startbtn');"
+	"startpanelEl=$('startpanel'),startbtnEl=$('startbtn'),"
+	"fmtrowEl=$('fmtrow'),fmtresEl=$('fmtres'),fmtfpsEl=$('fmtfps'),"
+	"fmtcodecEl=$('fmtcodec');"
 	"const COL={live:'#30D158',amber:'#FF9F0A',red:'#FF453A',grey:'#8E8E93'};"
 	"let lastTouch=0;const touch=()=>lastTouch=Date.now();"
 	"const send=o=>{touch();"
@@ -144,6 +153,17 @@ static const char control_page[] =
 	"flipEl.onclick=()=>send({cmd:'flip'});"
 	"lensselEl.onchange=()=>send({cmd:'selectLens',label:lensselEl.value});"
 	"startbtnEl.onclick=()=>send({cmd:'start_stream'});"
+	/* Rebuild a select only when its option list changes (same pattern as
+	 * the lens picker); values stay raw, labels get a formatter. */
+	"function fillSel(el,opts,val,fmt){const want=opts.join('|');"
+	"if(el.dataset.opts!==want){el.dataset.opts=want;"
+	"el.replaceChildren(...opts.map(o=>{const x=document.createElement('option');"
+	"x.value=o;x.textContent=fmt?fmt(o):o;return x}))}"
+	"if(val!=null)el.value=val}"
+	"const CODEC_NAMES={h264:'H.264',hevc:'HEVC'};"
+	"fmtresEl.onchange=()=>send({cmd:'set_format',resolution:fmtresEl.value});"
+	"fmtfpsEl.onchange=()=>send({cmd:'set_format',fps:+fmtfpsEl.value});"
+	"fmtcodecEl.onchange=()=>send({cmd:'set_format',codec:fmtcodecEl.value});"
 	"function statusColor(t){t=(t||'').toLowerCase();"
 	/* Standby/starting are amber (ready, not live) — test before the
 	 * generic 'connected' match, which their wording also contains. */
@@ -179,7 +199,15 @@ static const char control_page[] =
 	"lensselEl.replaceChildren(...st.lenses.map(l=>{"
 	"const o=document.createElement('option');o.textContent=l;return o}))}"
 	"if(st.lens)lensselEl.value=st.lens}"
-	"lensselEl.style.display=(st.lenses&&st.lenses.length>1)?'':'none'}"
+	"lensselEl.style.display=(st.lenses&&st.lenses.length>1)?'':'none';"
+	/* Format pickers, populated from the app's capability lists. */
+	"if(Array.isArray(st.resolutions)&&Array.isArray(st.frameRates)){"
+	"fmtrowEl.style.display='';"
+	"fillSel(fmtresEl,st.resolutions,st.resolution);"
+	"fillSel(fmtfpsEl,st.frameRates.map(String),String(st.fps),f=>f+' fps');"
+	"const codecs=Array.isArray(st.codecs)?st.codecs:[];"
+	"fmtcodecEl.style.display=codecs.length>1?'':'none';"
+	"fillSel(fmtcodecEl,codecs,st.codec,c=>CODEC_NAMES[c]||c)}}"
 	"}catch(e){statusEl.textContent='plugin unreachable';dotEl.style.background=COL.grey}}"
 	"setInterval(poll,1000);poll();"
 	"</script></body></html>";


### PR DESCRIPTION
**Feature stack 2/7** (stacked on #29).

Walking to the phone to flip 1080p→4K contradicts the remote-start story. New `set_format` CONTROL command (docs/PROTOCOL.md updated):

- STATE now carries the current `resolution`/`fps`/`codec` plus per-lens capability lists (`resolutions`/`frameRates`/`codecs`), **cached per lens+resolution** — the `supports()` format-table walk is too expensive to rerun on every debounced state send (e.g. throughout a zoom drag).
- The web panel gains a format row populated from those lists, so it only offers valid combos; the app validates anyway and ignores unsupported requests.
- Changes ride the existing live-reconfigure path (new VIDEO_CONFIG + keyframe); the reconfigure now also rebuilds the encoder when **only the codec** changed (previously unreachable mid-stream, so it kept the old codec).
- Older apps never advertise capabilities → older panels never show the row.

Plugin builds clean with `-Werror`; panel JS `node --check`'d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f

---
_Generated by [Claude Code](https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f)_