### PR TITLE
Fix: walk the full hardware-decoder list (D3D11VA → DXVA2) before CPU fallback

### DIFF
--- a/obs-plugin/src/h264-decoder.c
+++ b/obs-plugin/src/h264-decoder.c
@@ -18,6 +18,7 @@ struct h264_decoder {
 	AVBufferRef *hw_device;
 	enum AVPixelFormat hw_pix_fmt;
 	bool is_hw;
+	int hw_index; /* slot in hw_priority, -1 = software */
 
 	/* Diagnostics. */
 	uint64_t frames_output;
@@ -59,9 +60,12 @@ static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
 	return formats[0];
 }
 
-static bool try_init_hw(struct h264_decoder *dec, const AVCodec *codec)
+static bool try_init_hw(struct h264_decoder *dec, const AVCodec *codec,
+			int hw_start)
 {
-	for (int i = 0; hw_priority[i] != AV_HWDEVICE_TYPE_NONE; i++) {
+	if (hw_start < 0)
+		hw_start = 0;
+	for (int i = hw_start; hw_priority[i] != AV_HWDEVICE_TYPE_NONE; i++) {
 		enum AVHWDeviceType type = hw_priority[i];
 
 		enum AVPixelFormat pix = AV_PIX_FMT_NONE;
@@ -87,6 +91,7 @@ static bool try_init_hw(struct h264_decoder *dec, const AVCodec *codec)
 		dec->hw_device = device;
 		dec->hw_pix_fmt = pix;
 		dec->is_hw = true;
+		dec->hw_index = i;
 		dec->ctx->hw_device_ctx = av_buffer_ref(device);
 		dec->ctx->opaque = dec;
 		dec->ctx->get_format = get_hw_format;
@@ -99,7 +104,8 @@ static bool try_init_hw(struct h264_decoder *dec, const AVCodec *codec)
 	return false;
 }
 
-struct h264_decoder *h264_decoder_create(enum AVCodecID codec_id, bool allow_hw)
+struct h264_decoder *h264_decoder_create(enum AVCodecID codec_id,
+					 bool allow_hw, int hw_start)
 {
 	const AVCodec *codec = avcodec_find_decoder(codec_id);
 	if (!codec) {
@@ -109,6 +115,7 @@ struct h264_decoder *h264_decoder_create(enum AVCodecID codec_id, bool allow_hw)
 	}
 
 	struct h264_decoder *dec = bzalloc(sizeof(*dec));
+	dec->hw_index = -1;
 
 	dec->ctx = avcodec_alloc_context3(codec);
 	dec->pkt = av_packet_alloc();
@@ -124,10 +131,11 @@ struct h264_decoder *h264_decoder_create(enum AVCodecID codec_id, bool allow_hw)
 	 * encoder sends single-slice frames, so decode single-threaded. */
 	dec->ctx->thread_count = 1;
 
-	if (allow_hw && !try_init_hw(dec, codec))
+	if (allow_hw && !try_init_hw(dec, codec, hw_start))
 		blog(LOG_INFO,
-		     "[lenslink] no hardware decoder available, "
-		     "using software");
+		     "[lenslink] no %shardware decoder available, "
+		     "using software",
+		     hw_start > 0 ? "further " : "");
 
 	if (avcodec_open2(dec->ctx, codec, NULL) < 0) {
 		blog(LOG_ERROR, "[lenslink] failed to open decoder");
@@ -144,6 +152,20 @@ fail:
 bool h264_decoder_is_hw(const struct h264_decoder *dec)
 {
 	return dec && dec->is_hw;
+}
+
+int h264_decoder_hw_index(const struct h264_decoder *dec)
+{
+	return (dec && dec->is_hw) ? dec->hw_index : -1;
+}
+
+const char *h264_decoder_hw_name(const struct h264_decoder *dec)
+{
+	if (!dec || !dec->is_hw)
+		return "software";
+	const char *name =
+		av_hwdevice_get_type_name(hw_priority[dec->hw_index]);
+	return name ? name : "hardware";
 }
 
 uint64_t h264_decoder_frames_output(const struct h264_decoder *dec)
@@ -243,7 +265,11 @@ bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
 	int ret = avcodec_send_packet(dec->ctx, dec->pkt);
 	bool resend = ret == AVERROR(EAGAIN); /* drain below, then retry */
 	if (ret < 0 && !resend) {
-		blog(LOG_WARNING, "[lenslink] avcodec_send_packet: %d", ret);
+		/* Name the API and the exact error: "which hardware decoder
+		 * rejects which stream and why" is the whole diagnosis when
+		 * a driver dislikes a stream (e.g. D3D11VA vs our H.264). */
+		blog(LOG_WARNING, "[lenslink] avcodec_send_packet (%s): %s",
+		     h264_decoder_hw_name(dec), av_err2str(ret));
 		return ret != AVERROR_INVALIDDATA ? false : true;
 	}
 
@@ -253,7 +279,8 @@ bool h264_decoder_decode(struct h264_decoder *dec, obs_source_t *source,
 			break;
 		if (ret < 0) {
 			blog(LOG_WARNING,
-			     "[lenslink] avcodec_receive_frame: %d", ret);
+			     "[lenslink] avcodec_receive_frame (%s): %s",
+			     h264_decoder_hw_name(dec), av_err2str(ret));
 			return false;
 		}
 

--- a/obs-plugin/src/h264-decoder.h
+++ b/obs-plugin/src/h264-decoder.h
@@ -10,14 +10,28 @@ struct h264_decoder;
 
 /*
  * codec_id: AV_CODEC_ID_H264 or AV_CODEC_ID_HEVC.
- * allow_hw: try GPU decoding (D3D11VA/VideoToolbox/VAAPI), silently
- * falling back to software when unavailable.
+ * allow_hw: try GPU decoding (D3D11VA/DXVA2/VideoToolbox/VAAPI/VDPAU),
+ * silently falling back to software when unavailable.
+ * hw_start: index into the platform's hardware-API priority list to start
+ * from (0 = best). A caller that watched hardware API N fail on the live
+ * stream recreates with hw_start = N + 1 to try the next one — a decoder
+ * that *initializes* is no proof it can decode this stream (a driver can
+ * accept the codec yet reject the stream, erroring or emitting nothing).
+ * Past the end of the list, the decoder is software.
  */
 struct h264_decoder *h264_decoder_create(enum AVCodecID codec_id,
-					 bool allow_hw);
+					 bool allow_hw, int hw_start);
 
 /* Whether this instance actually decodes on the GPU. */
 bool h264_decoder_is_hw(const struct h264_decoder *dec);
+
+/* Which hardware-API priority slot this instance uses (-1 = software);
+ * feed slot + 1 back into h264_decoder_create's hw_start to advance. */
+int h264_decoder_hw_index(const struct h264_decoder *dec);
+
+/* Human-readable name of the hardware API in use ("d3d11va", …), or
+ * "software". */
+const char *h264_decoder_hw_name(const struct h264_decoder *dec);
 void h264_decoder_destroy(struct h264_decoder *dec);
 
 /*

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -378,7 +378,15 @@ struct client_state {
 	struct recv_buf buf;
 	struct send_buf out;
 	struct h264_decoder *decoder;
-	bool hw_failed; /* GPU decode failed once: stay on software */
+	/* Next hardware-API priority slot to try. Each hardware decoder
+	 * that errors or silently emits nothing advances this by one, so
+	 * the connection walks the platform's whole list (e.g. D3D11VA →
+	 * DXVA2) before settling on software — a driver rejecting a stream
+	 * on one API frequently decodes it fine on the next. */
+	int hw_retry;
+	/* video_packets at the current decoder's creation: each decoder in
+	 * the fallback walk gets its own no-output grace window. */
+	uint64_t packets_at_decoder;
 	bool is_screen; /* screen mirror (plays system audio) vs camera */
 	bool standby;   /* app is idle, waiting for a start_stream command */
 	uint64_t next_decoder_attempt; /* cooldown after create failure */
@@ -1087,11 +1095,11 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 			 * it disarmed, so a hardware decoder that accepted
 			 * packets but emitted nothing froze the source
 			 * forever (works on a fresh connection, froze on a
-			 * mid-stream HEVC→H.264 switch). hw_failed resets
+			 * mid-stream HEVC→H.264 switch). hw_retry resets
 			 * too: it described the OLD codec's hardware path;
-			 * the new codec deserves its own hardware attempt,
-			 * with the watchdog and the error path both armed to
-			 * catch it. */
+			 * the new codec deserves its own walk of the
+			 * hardware list, with the watchdog and the error
+			 * path both armed to advance it. */
 			c->video_packets = 0;
 			c->video_bytes = 0;
 			c->keyframes_seen = 0;
@@ -1099,7 +1107,8 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 			c->decode_errors = 0;
 			c->first_frame_ns = 0;
 			c->no_output_warned = false;
-			c->hw_failed = false;
+			c->hw_retry = 0;
+			c->packets_at_decoder = c->video_packets;
 			c->next_decoder_attempt = 0;
 			/* Diagnostics measure per decode-stream from here. */
 			c->connected_ns = os_gettime_ns();
@@ -1129,7 +1138,7 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 				c->codec_id != AV_CODEC_ID_NONE
 					? c->codec_id
 					: AV_CODEC_ID_H264,
-				s->hw_decode && !c->hw_failed);
+				s->hw_decode, c->hw_retry);
 			if (!c->decoder) {
 				c->next_decoder_attempt =
 					now + 5000000000ULL;
@@ -1138,17 +1147,21 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 				break;
 			}
 			c->next_decoder_attempt = 0;
+			c->packets_at_decoder = c->video_packets;
 		}
 		if (!h264_decoder_decode(c->decoder, s->source, payload,
 					 hdr->payload_size, hdr->pts_ns)) {
 			c->decode_errors++;
 			if (h264_decoder_is_hw(c->decoder)) {
-				/* GPU path misbehaved: recreate in software
-				 * for the rest of this connection. */
+				/* This GPU path misbehaved on this stream:
+				 * advance to the next hardware API (then
+				 * software once the list is exhausted). */
+				c->hw_retry =
+					h264_decoder_hw_index(c->decoder) + 1;
 				blog(LOG_WARNING,
-				     "[lenslink] hardware decode error, "
-				     "switching to software");
-				c->hw_failed = true;
+				     "[lenslink] %s decode error — trying "
+				     "the next decoder",
+				     h264_decoder_hw_name(c->decoder));
 			} else {
 				blog(LOG_WARNING,
 				     "[lenslink] decoder error, resetting");
@@ -1191,21 +1204,25 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 		 * tall, non-16-aligned screen-mirror resolutions on D3D11VA
 		 * (e.g. 886x1918). avcodec_send_packet succeeds and
 		 * avcodec_receive_frame just returns EAGAIN forever, so decode
-		 * "succeeds" while OBS stays black. Auto-fall back to software
-		 * instead of leaving a black source; hardware stays the default
-		 * and is retried on the next connection. ~10 packets is ~1/6 s
-		 * at 60 fps — long enough not to trip on a decoder's normal
-		 * one-frame startup, short enough to recover quickly. */
+		 * "succeeds" while OBS stays black. Advance to the next
+		 * hardware API (software once the list is exhausted) instead
+		 * of leaving a black source; the walk restarts from the best
+		 * API on the next connection or codec switch. ~10 packets is
+		 * ~1/6 s at 60 fps — long enough not to trip on a decoder's
+		 * normal one-frame startup, short enough to recover quickly.
+		 * The counters aren't reset on fallback, so if the next API
+		 * also emits nothing this fires again and keeps walking. */
 		if (c->frames_output == 0 && c->keyframes_seen > 0 &&
-		    c->video_packets >= 10) {
-			if (c->decoder && h264_decoder_is_hw(c->decoder) &&
-			    !c->hw_failed) {
+		    c->video_packets - c->packets_at_decoder >= 10) {
+			if (c->decoder && h264_decoder_is_hw(c->decoder)) {
 				blog(LOG_WARNING,
-				     "[lenslink] hardware decoder produced no "
-				     "frames after %llu packets — falling back "
-				     "to software decoding",
+				     "[lenslink] %s decoder produced no "
+				     "frames after %llu packets — trying "
+				     "the next decoder",
+				     h264_decoder_hw_name(c->decoder),
 				     (unsigned long long)c->video_packets);
-				c->hw_failed = true;
+				c->hw_retry =
+					h264_decoder_hw_index(c->decoder) + 1;
 				h264_decoder_destroy(c->decoder);
 				c->decoder = NULL;
 				/* Recreated in software on the next keyframe;


### PR DESCRIPTION
Follow-up to the field report on #30: **H.264 always lands on CPU while HEVC decodes on the GPU**. The proximate cause is that machine's D3D11VA rejecting our H.264 stream — but the plugin made it worse than it needs to be: the hardware priority list (D3D11VA → DXVA2 on Windows; VAAPI → VDPAU on Linux) was only consulted at decoder *creation*. An API that initialized fine but then **errored on the live stream** — or silently emitted nothing — went straight to software, never trying the next API, which frequently decodes the same stream without complaint.

## Changes

- Both failure paths (hard decode error, and the silent no-output watchdog) now **advance to the next hardware API**, settling on software only once the platform's list is exhausted. The walk restarts from the best API on each new connection or codec switch.
- **Per-decoder grace window:** the no-output watchdog now measures packets since *this* decoder's creation, not since connection start — without that epoch, the second decoder in a walk would be condemned after a single packet.
- **Actionable logs:** decoder errors now name the hardware API and print the FFmpeg error string (`avcodec_send_packet (d3d11va): …`) instead of a bare errno — the next "why is my GPU decode failing" report should be one log line from an answer.

## For the reporter's machine specifically

After this, an H.264 stream should try **D3D11VA → (log line with the real error) → DXVA2 → software**, so there's a decent chance H.264 lands on the GPU via DXVA2. If it still ends on CPU, the new log line tells us exactly what the driver objects to — please paste it and the root-cause hunt continues from there (likely suspects: the Main-profile stream out of VideoToolbox, or driver-specific SPS handling).

Based on `main` (independent of the feature stack); once merged I'll sync it forward into the remaining stacked branches like the other main merges.

`-Werror` clean on Linux; no behavior change for streams whose first hardware API works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f

---
_Generated by [Claude Code](https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f)_