### PR TITLE
app: force the Local Network permission dialog when the advertise is denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ phone.
    - **Wi-Fi** — open the **Phone** dropdown and pick your phone (it's
      found automatically by name while the app is open), or enter the IP
      the app shows. (Phone and computer must be on the same network.)
-     If the phone doesn't appear by name, check that **Settings → Privacy
-     & Security → Local Network → LensLink** is on — iOS needs it for the
-     name broadcast, and sideloaded builds sometimes need the toggle
-     flipped off and on once. Typing the IP works regardless.
+     If the phone doesn't appear by name, allow the **Local Network**
+     permission when the app asks (it needs it for the name broadcast) —
+     or check **Settings → Privacy & Security → Local Network →
+     LensLink**. Typing the IP works regardless.
    - **USB** — connect the cable, set **Connection → USB cable**. No
      network needed, and the phone charges while streaming.
 

--- a/ios-app/Sources/LocalNetworkPrompt.swift
+++ b/ios-app/Sources/LocalNetworkPrompt.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Network
+
+/// Forces iOS to present the Local Network permission dialog.
+///
+/// Advertising a Bonjour service (`NWListener.service`) can be *denied*
+/// without iOS ever showing the permission prompt — no TCC record is
+/// created, so no "Local Network" toggle appears in Settings either, and
+/// the user has no way to grant access. Browsing, unlike advertising,
+/// reliably registers the attempt: it presents the dialog when the state
+/// is undetermined, and even a denial creates the Settings toggle.
+///
+/// So when the listener lands in its advertise-denied fallback, we run
+/// one throwaway browse for our own service type (declared in
+/// `NSBonjourServices`) and report how it resolved. The browse finds
+/// nothing useful — it exists purely to make iOS ask the question.
+final class LocalNetworkPrompt {
+    private var browser: NWBrowser?
+    private var completion: ((Bool) -> Void)?
+
+    /// Starts the one-shot browse. Calls `completion(granted)` on the
+    /// main queue once the authorization resolves; safe to call again
+    /// only after that. `granted == true` means the caller can re-listen
+    /// with advertising and expect it to stick.
+    func trigger(completion: @escaping (Bool) -> Void) {
+        guard browser == nil else { return }
+        self.completion = completion
+
+        let browser = NWBrowser(
+            for: .bonjour(type: "_lenslink._tcp", domain: nil),
+            using: NWParameters())
+        self.browser = browser
+
+        browser.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                // Authorized (the user allowed the prompt, or access was
+                // already granted).
+                self?.finish(granted: true)
+            case .waiting(let error):
+                // Denied: the browse parks in .waiting on the NoAuth
+                // error and would sit there forever.
+                print("Local network browse waiting: \(error)")
+                self?.finish(granted: false)
+            case .failed(let error):
+                print("Local network browse failed: \(error)")
+                self?.finish(granted: false)
+            default:
+                break
+            }
+        }
+        browser.start(queue: .main)
+    }
+
+    private func finish(granted: Bool) {
+        browser?.cancel()
+        browser = nil
+        let completion = self.completion
+        self.completion = nil
+        completion?(granted)
+    }
+}

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -192,6 +192,26 @@ final class Streamer: ObservableObject {
     /// the Settings toggle so the OBS dropdown's silence is explained.
     @Published private(set) var discoverable: Bool?
 
+    private let localNetworkPrompt = LocalNetworkPrompt()
+    private var localNetworkPrompted = false
+
+    /// The advertise was denied. Advertising never presents the Local
+    /// Network dialog (or creates the Settings toggle) by itself — run
+    /// the one-shot browse that does, once per launch. If the user
+    /// grants, bounce the idle listener so it comes back advertising; a
+    /// live stream keeps its connection and advertises from next start.
+    private func promptForLocalNetwork() {
+        guard !localNetworkPrompted else { return }
+        localNetworkPrompted = true
+        localNetworkPrompt.trigger { [weak self] granted in
+            Task { @MainActor [weak self] in
+                guard let self, granted, !self.isStreaming else { return }
+                self.stopStandby()
+                self.updateStandby()
+            }
+        }
+    }
+
     // Live camera controls (also driven remotely via CONTROL packets)
     @Published var zoom: CGFloat = 1 {
         didSet {
@@ -478,7 +498,11 @@ final class Streamer: ObservableObject {
         }
         client.onDiscoveryChange = { [weak self] discoverable in
             Task { @MainActor [weak self] in
-                self?.discoverable = discoverable
+                guard let self else { return }
+                self.discoverable = discoverable
+                if discoverable == false {
+                    self.promptForLocalNetwork()
+                }
             }
         }
         client.onControl = { [weak self] json in

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -44,6 +44,12 @@ targets:
         NSLocalNetworkUsageDescription: >-
           LensLink connects to OBS Studio on your local network to send the
           camera feed.
+        # Required for the NWBrowser that triggers the Local Network
+        # permission dialog (browsing needs the service types declared;
+        # advertising alone can be denied without iOS ever showing the
+        # prompt or creating the Settings toggle).
+        NSBonjourServices:
+          - _lenslink._tcp
         NSMicrophoneUsageDescription: >-
           LensLink can send your microphone to OBS — as the camera's audio
           if you enable it, or purely as a timing reference to


### PR DESCRIPTION
Follow-up to #34, from live testing on the TestFlight build: iOS denied the Bonjour advertise with NoAuth **without ever presenting the Local Network prompt — and without creating the toggle in Settings**. The app's "tap to allow in Settings" pointer led to a settings page with no Local Network option at all, leaving no way to grant access.

The fix exploits an asymmetry in iOS's local-network privacy machinery: **browsing** reliably registers the authorization attempt where advertising doesn't. A browse presents the dialog when the state is undetermined, and even a denial creates the Settings toggle.

- New `LocalNetworkPrompt`: a one-shot throwaway `NWBrowser` for our own `_lenslink._tcp` type. It discovers nothing useful — it exists purely to make iOS ask the question.
- Runs once per launch, only when the listener lands in its advertise-denied fallback (users who already granted never see it).
- On grant, the idle standby listener bounces and comes back advertising immediately; a live stream keeps its connection untouched and advertises from the next start.
- `NSBonjourServices` (`_lenslink._tcp`) added to the app's Info.plist — required for browsing.
- README's Connect note updated: allow the prompt when asked.

**Retest on the release build:** open the app fresh — the Local Network dialog should now appear (because the fallback engages and triggers the browse). Tap Allow: the "Not visible by name" row should disappear within a second or two, LensLink should now be listed under Settings → Privacy & Security → Local Network, and the phone should appear in the OBS Phone dropdown when the properties sheet reopens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f

---
_Generated by [Claude Code](https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f)_