### PR TITLE
ci: bump stock actions to their Node 24 majors

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       plugin: ${{ steps.diff.outputs.plugin }}
       ios: ${{ steps.diff.outputs.ios }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Diff against base
         id: diff
@@ -58,7 +58,7 @@ jobs:
     if: needs.changes.outputs.plugin == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -75,7 +75,7 @@ jobs:
         working-directory: obs-plugin
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lenslink-linux-x86_64
           path: |
@@ -94,13 +94,13 @@ jobs:
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # No submodules here: cache-hit runs only need in-tree headers
       # (libobs/, deps/w32-pthreads/). The recursive fetch is minutes of
       # overhead, so it moves into the cache-miss build step below.
       - name: Checkout obs-studio (for libobs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Cache libobs build
         id: cache-libobs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: obs-build
           key: libobs-${{ env.OBS_REF }}-${{ env.DEPS_TAG }}
@@ -164,7 +164,7 @@ jobs:
           iscc /DAppVersion=0.0.0 installer\windows\lenslink.iss
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lenslink-windows-x64
           path: |
@@ -183,13 +183,13 @@ jobs:
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # No submodules here: cache-hit runs only need in-tree headers
       # (libobs/). The recursive fetch is minutes of overhead, so it moves
       # into the cache-miss build step below.
       - name: Checkout obs-studio (for libobs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
@@ -208,7 +208,7 @@ jobs:
       # Windows job already uses libobs-<ref>-<tag> for its MSVC build.
       - name: Cache libobs build
         id: cache-libobs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: obs-build
           key: libobs-macos-${{ env.OBS_REF }}-${{ env.DEPS_TAG }}
@@ -279,7 +279,7 @@ jobs:
             LensLink-installer-macos-universal.pkg
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lenslink-macos-universal
           path: |
@@ -294,7 +294,7 @@ jobs:
     # Xcode 15 (macos-14 runners) cannot open.
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -324,7 +324,7 @@ jobs:
         working-directory: ios-app
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: LensLink-unsigned-ipa
           path: ios-app/LensLink-unsigned.ipa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     name: OBS plugin (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
           cp -r obs-plugin/data/* stage/lenslink/data/
           tar czf lenslink-linux-x86_64.tar.gz -C stage lenslink
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: release-linux
           path: lenslink-linux-x86_64.tar.gz
@@ -61,13 +61,13 @@ jobs:
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # No submodules here: cache-hit runs only need in-tree headers
       # (libobs/, deps/w32-pthreads/); the recursive fetch runs only on a
       # cache miss, inside the build step.
       - name: Checkout obs-studio (for libobs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Cache libobs build
         id: cache-libobs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: obs-build
           key: libobs-${{ env.OBS_REF }}-${{ env.DEPS_TAG }}
@@ -125,7 +125,7 @@ jobs:
           $version = "${{ inputs.tag_name || github.ref_name }}".TrimStart("v")
           iscc /DAppVersion=$version installer\windows\lenslink.iss
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: release-windows
           path: |
@@ -139,13 +139,13 @@ jobs:
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # No submodules here: cache-hit runs only need in-tree headers
       # (libobs/); the recursive fetch runs only on a cache miss, inside
       # the build step.
       - name: Checkout obs-studio (for libobs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: obsproject/obs-studio
           ref: ${{ env.OBS_REF }}
@@ -161,7 +161,7 @@ jobs:
       # Windows job already uses libobs-<ref>-<tag> for its MSVC build.
       - name: Cache libobs build
         id: cache-libobs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: obs-build
           key: libobs-macos-${{ env.OBS_REF }}-${{ env.DEPS_TAG }}
@@ -235,7 +235,7 @@ jobs:
           productbuild --distribution distribution.xml --package-path . \
             LensLink-installer-macos-universal.pkg
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: release-macos
           path: |
@@ -246,7 +246,7 @@ jobs:
     name: iOS app (unsigned IPA)
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -270,7 +270,7 @@ jobs:
           zip -ry LensLink-unsigned.ipa Payload
         working-directory: ios-app
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: release-ipa
           path: ios-app/LensLink-unsigned.ipa
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build & upload to TestFlight
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Guard on secrets
         env:


### PR DESCRIPTION
The housekeeping item from the earlier warnings review: every CI job annotates "Node.js 20 is deprecated ... being forced to run on Node 24" because the v4 majors of `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, and `actions/cache` target Node 20. This bumps all of them to their v5 majors (Node 24 native) across all four workflows — build, release, auto-release, and testflight. No behavioral changes for our usage; the PR's own CI run is the proof.

(The other recurring annotation — Homebrew's "aws/tap is not trusted" on macOS runners — is noise from the runner image itself, not something in our workflows; deliberately left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f

---
_Generated by [Claude Code](https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f)_