### PR TITLE
Link dxguid on Windows — fixes the v1.5.15 release build

### DIFF
--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -69,7 +69,9 @@ add_library(${PROJECT_NAME} MODULE
 target_link_libraries(${PROJECT_NAME} PRIVATE OBS::libobs ${FFMPEG_TARGET})
 
 if(WIN32)
-  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
+  # dxguid: gpu-frame.c references IID_ID3D11Texture2D/IID_IDXGIKeyedMutex,
+  # which are extern GUIDs resolved from this static lib in C builds.
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 dxguid)
 endif()
 
 if(APPLE)


### PR DESCRIPTION
The v1.5.15 auto-release died in the **OBS plugin (Windows)** job at link time:

```
gpu-frame.obj : error LNK2019: unresolved external symbol IID_IDXGIKeyedMutex referenced in function gpu_frame_map
gpu-frame.obj : error LNK2019: unresolved external symbol IID_ID3D11Texture2D referenced in function gpu_frame_map
```

**Cause:** the GPU pipeline's D3D11 interop references those COM interface GUIDs, which C builds resolve from `dxguid.lib`. PR CI never caught it because its Windows build enables the Qt frontend, and Qt6's link interface pulls `dxguid.lib` in transitively — the release build compiles without Qt, exposing the missing direct dependency.

**Fix:** one line — link `dxguid` explicitly in the `WIN32` block of `obs-plugin/CMakeLists.txt`. Linux and macOS release jobs were unaffected (their builds passed).

After this merges, auto-release will cut the next version with the GPU-pipeline release that v1.5.15 failed to publish. The orphan `v1.5.15` tag (pushed by the version job before the build failed) has no release attached and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f

---
_Generated by [Claude Code](https://claude.ai/code/session_017MpS3YQAjCWFXx4twdpX7f)_