### PR TITLE
ci: Claude reviews Dependabot PRs and auto-merges routine bumps

### DIFF
--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -1,0 +1,67 @@
+name: Dependabot Claude Review
+
+# When Dependabot opens a PR, Claude reviews the bumps — diff, release
+# notes, how our workflows use the changed inputs — and, only when
+# everything is routine, approves and enables auto-merge. Branch
+# protection still gates the actual merge on the required Build checks:
+# Claude is the judgment gate, not the CI gate. If anything looks risky
+# it comments instead of approving, and a human decides.
+#
+# One-time setup (the workflow skips quietly until it's done):
+#   1. Settings → Secrets and variables → **Dependabot** → New secret →
+#      ANTHROPIC_API_KEY. Dependabot-triggered runs can only read
+#      Dependabot-scoped secrets — an Actions secret of the same name is
+#      invisible here. (Billing a Claude Pro/Max subscription instead:
+#      run `claude setup-token` locally and swap the `anthropic_api_key`
+#      input below for `claude_code_oauth_token`.)
+#   2. Settings → General → enable **Allow auto-merge**.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write # gh pr merge --auto
+  pull-requests: write # gh pr review --approve
+
+jobs:
+  review:
+    name: Claude review & auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard on secret
+        id: guard
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY is not set in the *Dependabot* secrets — skipping Claude review (see this workflow's header)."
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.guard.outputs.run == 'true'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: anthropics/claude-code-action@v1
+        if: steps.guard.outputs.run == 'true'
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are reviewing Dependabot PR #${{ github.event.pull_request.number }} in ${{ github.repository }} — a dependency version bump.
+
+            1. Read the diff (`gh pr diff ${{ github.event.pull_request.number }}`) and the release notes Dependabot quotes in the PR body (`gh pr view ${{ github.event.pull_request.number }}`).
+            2. This repo's Dependabot only bumps GitHub Actions. For each bump, judge whether it is routine: patch/minor releases, or major releases whose notes show no breaking changes for the inputs/behaviors our workflows in .github/workflows/ actually use (the checkout is this PR's tree — read the workflows to confirm usage).
+            3. If EVERY bump is routine:
+               gh pr review ${{ github.event.pull_request.number }} --approve --body "<one short paragraph: what was bumped and what you checked>"
+               gh pr merge ${{ github.event.pull_request.number }} --auto --merge
+            4. If ANY bump is unclear or risky — breaking changes in used inputs, changed defaults we rely on, anything unusual about the release — do NOT approve or merge. Instead leave one comment (`gh pr comment`) saying exactly what needs a human look and why.
+
+            Never modify files or push commits. Approval + auto-merge still waits for the required Build checks, so a green review never bypasses CI.
+          claude_args: |
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr merge:*),Bash(gh pr comment:*)"
+            --max-turns 12

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -9,11 +9,12 @@ name: Dependabot Claude Review
 #
 # One-time setup (the workflow skips quietly until it's done):
 #   1. Settings → Secrets and variables → **Dependabot** → New secret →
-#      ANTHROPIC_API_KEY. Dependabot-triggered runs can only read
-#      Dependabot-scoped secrets — an Actions secret of the same name is
-#      invisible here. (Billing a Claude Pro/Max subscription instead:
-#      run `claude setup-token` locally and swap the `anthropic_api_key`
-#      input below for `claude_code_oauth_token`.)
+#      CLAUDE_CODE_OAUTH_TOKEN, from `claude setup-token` (bills the
+#      maintainer's Claude subscription). Dependabot-triggered runs can
+#      only read Dependabot-scoped secrets — an Actions secret of the
+#      same name is invisible here. (To bill API credits instead, store
+#      ANTHROPIC_API_KEY and swap the `claude_code_oauth_token` input
+#      below for `anthropic_api_key`.)
 #   2. Settings → General → enable **Allow auto-merge**.
 
 on:
@@ -33,13 +34,13 @@ jobs:
       - name: Guard on secret
         id: guard
         env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           if [ -n "$KEY" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY is not set in the *Dependabot* secrets — skipping Claude review (see this workflow's header)."
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set in the *Dependabot* secrets — skipping Claude review (see this workflow's header)."
           fi
 
       - uses: actions/checkout@v5
@@ -50,7 +51,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         if: steps.guard.outputs.run == 'true'
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are reviewing Dependabot PR #${{ github.event.pull_request.number }} in ${{ github.repository }} — a dependency version bump.
 


### PR DESCRIPTION
## What & why

Dependabot PRs currently wait for a human even when the change is a routine version pin. This adds a workflow (`dependabot-claude-review.yml`) that runs whenever the PR author is `dependabot[bot]`: Anthropic's `claude-code-action@v1` reads the diff, the release notes quoted in the PR body, and this repo's own workflows (to check whether a bump's breaking changes touch inputs we actually use). Routine bumps get an approval + `gh pr merge --auto`; anything unclear gets a comment explaining what needs a human look, and no approval.

Safety properties:

- Auto-merge still waits on the required Build checks — the review is a judgment gate, never a CI bypass.
- The action's allowed tools are only `gh pr view/diff/review/merge/comment`; it cannot modify files or push.
- Inert until configured: a guard step skips quietly while `CLAUDE_CODE_OAUTH_TOKEN` is absent from the **Dependabot** secrets (Dependabot-triggered runs can't read Actions secrets), so nothing shows red in the meantime. Setup steps are documented in the workflow header.

Auth bills the maintainer's Claude subscription via `claude_code_oauth_token` (from `claude setup-token`); the header documents the `anthropic_api_key` alternative for API-credit billing.

## How it was tested

Workflow YAML validated; the action inputs (`claude_code_oauth_token`, `prompt`, `claude_args`/`--allowedTools`), the Dependabot-secrets scoping gotcha, and the auto-merge token permissions were verified against the official claude-code-action docs and GitHub's Dependabot-automation docs. The live path can only run on a real Dependabot PR once the secret and repo toggle are in place — first exercised by the next weekly Dependabot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq