### PR TITLE
Fix Dependabot review run: pass GITHUB_TOKEN, add issues permission

### DIFF
--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: write # gh pr merge --auto
   pull-requests: write # gh pr review --approve
+  issues: write # gh pr comment (PR comments ride the issues API)
 
 jobs:
   review:
@@ -52,6 +53,11 @@ jobs:
         if: steps.guard.outputs.run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without an explicit token the action mints one from the Claude
+          # GitHub App over OIDC — which needs `id-token: write` AND the
+          # app installed on the repo. The workflow's own token with the
+          # permissions declared above is all the gh commands need.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             You are reviewing Dependabot PR #${{ github.event.pull_request.number }} in ${{ github.repository }} — a dependency version bump.
 


### PR DESCRIPTION
## What & why

The first live run of the Dependabot Claude Review workflow (on #48) failed before the review started:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

With no explicit `github_token`, `claude-code-action` tries to mint a token from the Claude GitHub App via an OIDC exchange — which needs an `id-token: write` permission the workflow's explicit `permissions:` block didn't declare, and would additionally require the Claude GitHub App to be installed on the repo. Passing the workflow's own `GITHUB_TOKEN` skips the exchange entirely; the declared permissions cover everything the allowed `gh` commands need. Also adds `issues: write`, which `gh pr comment` rides on (PR comments use the issues API).

Everything upstream of the failure was verified working by the same run: the Dependabot actor gate, and the guard finding `CLAUDE_CODE_OAUTH_TOKEN` in the Dependabot secrets.

## How it was tested

Root cause read directly from the failed run's log (run 29553491757, `setupGitHubToken` → `getOidcToken` retry exhaustion). YAML validated. The live re-test is the point of the fix: after merging, a `·@·d·ependabot r·ebase` comment on #48 re-triggers the workflow with the token in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq)_