### PR TITLE
Allow Dependabot through claude-code-action's bot gate

### DIFF
--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -53,6 +53,10 @@ jobs:
         if: steps.guard.outputs.run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The action refuses bot-initiated events by default. Allow
+          # exactly Dependabot — never '*': on a public repo that would
+          # let arbitrary Apps invoke this with prompts they control.
+          allowed_bots: "dependabot,dependabot[bot]"
           # Without an explicit token the action mints one from the Claude
           # GitHub App over OIDC — which needs `id-token: write` AND the
           # app installed on the repo. The workflow's own token with the


### PR DESCRIPTION
## What & why

Second live run on #48 got one gate further and hit the action's bot filter:

```
Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action` rejects bot-initiated events by default. This allows exactly the Dependabot identities (`allowed_bots: "dependabot,dependabot[bot]"`) — deliberately **not** `'*'`, which the action's own security docs warn against on public repos (arbitrary GitHub Apps could invoke the action with prompts they control). The job-level `if: github.actor == 'dependabot[bot]'` and this list stay aligned as a two-layer gate.

## How it was tested

Error taken from the live run; the `allowed_bots` input name, format (comma-separated usernames), and the `'*'` warning verified against the action's `action.yml` on main. YAML validated. Live re-test: merge, then `@dependabot rebase` on #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq)_