### PR TITLE
ci: cancel stale PR builds, gate TestFlight on app changes, ship the dock UI in releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
+      ios: ${{ steps.bump.outputs.ios }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -58,8 +59,19 @@ jobs:
           # own commits), so a trailer in any PR commit counts.
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             messages=$(git log -1 --format=%B "$AFTER")
+            changed=$(git diff-tree --no-commit-id --name-only -r "$AFTER")
           else
             messages=$(git log --format=%B "$BEFORE..$AFTER")
+            changed=$(git diff --name-only "$BEFORE" "$AFTER")
+          fi
+
+          # Did this push touch the app? Gates the TestFlight job below —
+          # plugin/installer-only merges still release, but must not upload
+          # a byte-identical app build to TestFlight.
+          if grep -q '^ios-app/' <<< "$changed"; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ios=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Trailers only match on their own line (^…$), so prose that
@@ -98,9 +110,14 @@ jobs:
   # trigger: releases created with GITHUB_TOKEN never trigger other
   # workflows (GitHub's recursion guard), so the TestFlight upload would
   # silently not happen for auto-releases.
+  # Only when the push touched ios-app/: the version stream is repo-wide,
+  # but a plugin- or installer-only release would otherwise upload a
+  # byte-identical app (MARKETING_VERSION is static; only the injected
+  # build number changes) — burning a macOS runner, an App Store Connect
+  # build number, and a tester update notification for nothing.
   testflight:
     name: TestFlight
     needs: [version, release]
-    if: needs.version.outputs.tag != ''
+    if: needs.version.outputs.tag != '' && needs.version.outputs.ios == 'true'
     uses: ./.github/workflows/testflight.yml
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+# A new push to a PR supersedes the previous run: cancel the stale one
+# instead of letting its builds (two on 10x-billed macOS runners) finish
+# for a commit nobody can merge anymore. Auto-merge waits on the checks of
+# the new head commit, so cancelling the old run costs nothing. Manual
+# dispatches get a unique group (run_id) and are never cancelled.
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Detect changed areas

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -20,6 +20,13 @@ name: Dependabot Claude Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # Dependabot here only ever bumps GitHub Actions (.github/dependabot.yml
+    # watches nothing else), so its PRs always touch workflow files. The
+    # filter stops this workflow from creating a skipped run on every other
+    # PR event in the repo. If dependabot.yml ever grows more ecosystems,
+    # widen or drop this filter to match.
+    paths:
+      - ".github/workflows/**"
 
 permissions:
   contents: write # gh pr merge --auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,17 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake pkg-config libobs-dev \
+          sudo apt-get install -y cmake pkg-config libobs-dev qt6-base-dev \
             libavcodec-dev libavutil-dev
 
+      # The grep guard: the status-bar/dock UI degrades *silently* when Qt6
+      # or obs-frontend-api.h is missing (that's how releases shipped
+      # without it once) — a release build must fail instead.
       - name: Build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          set -o pipefail
+          cmake -B build -DCMAKE_BUILD_TYPE=Release | tee configure.log
+          grep -q "frontend UI enabled" configure.log
           cmake --build build
         working-directory: obs-plugin
 
@@ -73,10 +78,14 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg)
+      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
         run: |
           curl -L -o deps.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-${{ env.DEPS_TAG }}-x64.zip"
           7z x deps.zip -oobs-deps
+          # Qt6 (same bundle OBS itself builds with): needed only for the
+          # plugin's status-bar/dock UI — keep in sync with build.yml.
+          curl -L -o deps-qt6.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-qt6-${{ env.DEPS_TAG }}-x64.zip"
+          7z x -y deps-qt6.zip -oobs-deps
 
       - name: Cache libobs build
         id: cache-libobs
@@ -96,14 +105,23 @@ jobs:
             -DENABLE_AJA=OFF
           cmake --build obs-build --target libobs --config Release
 
+      # The Select-String guard: the status-bar/dock UI degrades *silently*
+      # when Qt6 or obs-frontend-api.h is missing (that's how releases
+      # shipped without it once) — a release build must fail instead.
       - name: Build plugin
         run: |
           cmake -S obs-plugin -B plugin-build -G "Visual Studio 17 2022" -A x64 `
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}\obs-deps" `
             -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs;${{ github.workspace }}\obs-build\config;${{ github.workspace }}\obs-studio\deps\w32-pthreads" `
             -DLIBOBS_LIBRARY="${{ github.workspace }}\obs-build\libobs\Release\obs.lib;${{ github.workspace }}\obs-build\deps\w32-pthreads\Release\w32-pthreads.lib" `
+            -DOBS_FRONTEND_API_HINT="${{ github.workspace }}\obs-studio\frontend\api;${{ github.workspace }}\obs-studio\UI\obs-frontend-api" `
             -DFFMPEG_INCLUDE_DIR="${{ github.workspace }}\obs-deps\include" `
             -DAVCODEC_LIBRARY="${{ github.workspace }}\obs-deps\lib\avcodec.lib" `
-            -DAVUTIL_LIBRARY="${{ github.workspace }}\obs-deps\lib\avutil.lib"
+            -DAVUTIL_LIBRARY="${{ github.workspace }}\obs-deps\lib\avutil.lib" `
+            | Tee-Object -FilePath configure.log
+          if (-not (Select-String -Quiet -SimpleMatch "frontend UI enabled" -Path configure.log)) {
+            throw "status-bar/dock UI missing from this release build (Qt6/obs-frontend-api not found)"
+          }
           cmake --build plugin-build --config Release
 
       - name: Package (extract into C:\Program Files\obs-studio)
@@ -151,11 +169,14 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg)
+      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
         run: |
           curl -L -o deps.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-${{ env.DEPS_TAG }}-universal.tar.xz"
           mkdir obs-deps
           tar -xJf deps.tar.xz -C obs-deps
+          # Qt6 for the status-bar/dock UI — keep in sync with build.yml.
+          curl -L -o deps-qt6.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-qt6-${{ env.DEPS_TAG }}-universal.tar.xz"
+          tar -xJf deps-qt6.tar.xz -C obs-deps
 
       # "macos" in the key: cache keys are not runner-scoped, and the
       # Windows job already uses libobs-<ref>-<tag> for its MSVC build.
@@ -185,17 +206,25 @@ jobs:
             -DENABLE_BROWSER=OFF -DENABLE_SCRIPTING=OFF
           cmake --build obs-build --target libobs --config Release
 
+      # The grep guard: the status-bar/dock UI degrades *silently* when Qt6
+      # or obs-frontend-api.h is missing (that's how releases shipped
+      # without it once) — a release build must fail instead.
       - name: Build plugin
         run: |
+          set -o pipefail
           cmake -S obs-plugin -B plugin-build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+            -DCMAKE_PREFIX_PATH="$PWD/obs-deps" \
+            -DOBS_FRONTEND_API_HINT="$PWD/obs-studio/frontend/api;$PWD/obs-studio/UI/obs-frontend-api" \
             -DLIBOBS_INCLUDE_DIR="$PWD/obs-studio/libobs;$PWD/obs-build/config" \
             -DLIBOBS_LIBRARY="$PWD/obs-build/libobs/Release/libobs.framework" \
             -DFFMPEG_INCLUDE_DIR="$PWD/obs-deps/include" \
             -DAVCODEC_LIBRARY="$PWD/obs-deps/lib/libavcodec.dylib" \
-            -DAVUTIL_LIBRARY="$PWD/obs-deps/lib/libavutil.dylib"
+            -DAVUTIL_LIBRARY="$PWD/obs-deps/lib/libavutil.dylib" \
+            | tee configure.log
+          grep -q "frontend UI enabled" configure.log
           cmake --build plugin-build
 
       # Ad-hoc signature only: without an Apple Developer ID the bundle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,12 @@ Details (signing, older Xcode): `ios-app/BUILDING.md`.
   branch pushes, and builds only the areas the PR touches (plugin on
   Ubuntu/Windows/macOS with `-Werror`; the app as an unsigned device build
   on macOS). PRs merge automatically once the required checks pass.
-- **Merging to `main` auto-releases** when `obs-plugin/` or `ios-app/`
-  changed: patch bump by default, or the bump named by a git trailer on its
-  own line in any commit of the PR — `Release-Bump: minor`,
+- **Merging to `main` auto-releases** when `obs-plugin/`, `ios-app/`, or
+  `installer/` changed: patch bump by default, or the bump named by a git
+  trailer on its own line in any commit of the PR — `Release-Bump: minor`,
   `Release-Bump: major`, or `Release-Skip: true` (no release). Mind this
-  when writing commit messages.
+  when writing commit messages. The TestFlight upload runs only when the
+  merge touched `ios-app/`.
 - **Never manually dispatch** `testflight.yml` or anything that creates
   releases/tags — a run uploads a real build to TestFlight / publishes a
   real release.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,10 +64,13 @@ protection on `main`).
 
 ## Releases
 
-Every merge to `main` that touches `obs-plugin/` or `ios-app/`
-automatically tags a version and publishes a GitHub Release with
-ready-to-install builds (Windows plugin zip, Linux plugin tarball, unsigned
-IPA), via [`.github/workflows/auto-release.yml`](../.github/workflows/auto-release.yml).
+Every merge to `main` that touches `obs-plugin/`, `ios-app/`, or
+`installer/` automatically tags a version and publishes a GitHub Release
+with ready-to-install builds (Windows plugin zip, Linux plugin tarball,
+unsigned IPA), via
+[`.github/workflows/auto-release.yml`](../.github/workflows/auto-release.yml).
+The TestFlight upload piggybacks on that release, but only when the merge
+touched `ios-app/`.
 
 The bump is a **git trailer** on its own line in any commit of the merged
 PR (case-insensitive):

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -38,7 +38,8 @@ repository secret**, four times:
 ## 4. Run it
 
 - Manually: **Actions → TestFlight → Run workflow**, or
-- Automatically: it runs on every **published release**.
+- Automatically: it runs for every release **whose merge touched
+  `ios-app/`** (plugin-only releases don't re-upload an unchanged app).
 
 The first upload takes a few extra minutes of App Store Connect processing;
 after that the build appears under the app's **TestFlight** tab. Add


### PR DESCRIPTION
## What & why

Fixes from a full audit of the PR/update/release pipeline — two CI-efficiency leaks, one noise nit, and one shipped-artifact bug the audit turned up:

- **`build.yml`: cancel superseded PR runs.** There was no concurrency group, so each new push to a PR let the previous run's builds — two of them on 10×-billed macOS runners — finish for a commit that could no longer merge. New pushes now cancel the stale run; manual dispatches get a unique group and are never cancelled.
- **`auto-release.yml`: TestFlight only when the app changed.** Every auto-release called the TestFlight upload, so a plugin- or installer-only merge burned a macOS runner, an App Store Connect build number, and a tester update notification on a byte-identical app (`MARKETING_VERSION` is static; only the injected build number changes). The version job now reports whether the push touched `ios-app/`, and the upload is gated on it.
- **`release.yml`: releases have been shipping without the status-bar/dock UI.** b513d7d added the Qt6 deps and `obs-frontend-api` hint to `build.yml` only; the plugin's CMake silently disables the frontend UI when those are missing, so every release since — through v1.5.17, on all three OSes — shipped plugin binaries without the health readout/dock that PR CI was validating and the README advertises. All three release jobs now match `build.yml`, and each fails loudly if `frontend UI enabled` is missing from the configure log so the divergence can't recur silently. The next release after this merges restores the feature to users.
- **`dependabot-claude-review.yml`: no more skipped run on every PR event.** A `paths: .github/workflows/**` filter limits it to PRs that can actually be Dependabot action bumps (its only ecosystem, per `dependabot.yml`).
- **Docs trued up:** `DEVELOPMENT.md`/`CLAUDE.md` now name `installer/` as a release trigger, and `TESTFLIGHT.md`/`DEVELOPMENT.md` describe the `ios-app/` gate on uploads.

## How it was tested

Workflow/docs-only change — no live A/V path touched. All four edited workflows were YAML-parsed; the new `ios-app/` change detection was dry-run against real `main` history (docs-only merge → `false`, plugin+workflow merge → `false`, app-redesign merge → `true`, plus the zero-SHA fallback path). The Linux release guard was validated against an actual PR CI log, which prints `lenslink: frontend UI enabled` with the identical package set the release job now installs. Merging this PR triggers no release (paths don't match `auto-release.yml`); because it edits `build.yml`, its own CI run rebuilds all areas, exercising the new concurrency group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV)_