### PR TITLE
release notes: compact install table + categorized changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+# Shapes the auto-generated "What's Changed" section of release notes.
+# (The install table above it is templated in release.yml's publish job;
+# the "What's Changed" heading itself must survive — the TestFlight
+# "What to Test" script splits the body on it.)
+#
+# Label a PR to sort it: `enhancement` → New, `bug` → Fixes. Unlabeled
+# PRs land under "Other changes". Dependabot bumps are excluded — they
+# only touch CI and never change what users download.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: New
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,12 +309,20 @@ jobs:
     needs: [plugin-linux, plugin-windows, plugin-macos, ios-app]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
+    env:
+      # Direct-download base for the install table's asset links.
+      DL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag_name || github.ref_name }}
     steps:
       - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
 
+      # The release-notes template. The install table must stay ABOVE the
+      # generated notes (the API prepends `body`), and the "What's Changed"
+      # heading GitHub generates is load-bearing: testflight_whats_to_test.py
+      # takes everything after it for the TestFlight "What to Test" box.
+      # The changelog itself is shaped by .github/release.yml.
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
@@ -327,36 +335,24 @@ jobs:
             dist/lenslink-linux-x86_64.tar.gz
             dist/LensLink-unsigned.ipa
           body: |
-            ## Installing
+            ## Install
 
-            **Windows (OBS plugin):** download and run
-            `LensLink-installer-windows-x64.exe` — it finds your OBS Studio
-            folder automatically. Then restart OBS. (Prefer doing it by
-            hand? `lenslink-windows-x64.zip` extracts into
-            `C:\Program Files\obs-studio\`.) Built against OBS Studio 32.x.
+            | Platform | Download | Then |
+            |----------|----------|------|
+            | **Windows** | [Installer](${{ env.DL }}/LensLink-installer-windows-x64.exe) | Run it (finds your OBS folder automatically), restart OBS. |
+            | **macOS** | [Installer](${{ env.DL }}/LensLink-installer-macos-universal.pkg) | Right-click → **Open** (not notarized), restart OBS. |
+            | **Linux** | [Plugin tarball](${{ env.DL }}/lenslink-linux-x86_64.tar.gz) | Extract into `~/.config/obs-studio/plugins/`. |
+            | **iPhone / iPad** | [TestFlight beta](https://testflight.apple.com/join/N7Rth6m3) | Installs via TestFlight, updates automatically. |
 
-            **macOS (OBS plugin):** download and open
-            `LensLink-installer-macos-universal.pkg` (right-click → Open the
-            first time — the package is not notarized). It installs into
-            your user OBS plugin folder
-            (`~/Library/Application Support/obs-studio/plugins/`).
-            Then restart OBS.
-            Prefer doing it by hand? Extract `lenslink-macos-universal.zip`
-            into `~/Library/Application Support/obs-studio/plugins/` and
-            clear the quarantine flag:
-            `xattr -dr com.apple.quarantine ~/Library/Application\ Support/obs-studio/plugins/lenslink.plugin`.
-            Universal binary (Apple Silicon + Intel), macOS 13+, built
-            against OBS Studio 32.x.
+            Plugin builds match OBS Studio 32.x; the macOS build is universal (macOS 13+).
 
-            **Linux (OBS plugin):** download `lenslink-linux-x86_64.tar.gz`
-            and extract it into `~/.config/obs-studio/plugins/`.
+            <details>
+            <summary><b>Manual installs, sideloading, USB</b></summary>
 
-            **iOS app:** easiest is the TestFlight beta —
-            https://testflight.apple.com/join/N7Rth6m3 — which updates
-            automatically.
-            Alternatively, download `LensLink-unsigned.ipa` and sideload it
-            with [Sideloadly](https://sideloadly.io) (Windows/macOS, free
-            Apple ID; re-sign every 7 days).
+            - **Windows zip:** extract [`lenslink-windows-x64.zip`](${{ env.DL }}/lenslink-windows-x64.zip) into `C:\Program Files\obs-studio\`, merging folders.
+            - **macOS zip:** extract [`lenslink-macos-universal.zip`](${{ env.DL }}/lenslink-macos-universal.zip) into `~/Library/Application Support/obs-studio/plugins/`, then clear quarantine: `xattr -dr com.apple.quarantine ~/Library/Application\ Support/obs-studio/plugins/lenslink.plugin`
+            - **iOS sideload:** install [`LensLink-unsigned.ipa`](${{ env.DL }}/LensLink-unsigned.ipa) with [Sideloadly](https://sideloadly.io) — free Apple IDs re-sign every 7 days.
+            - **USB on Windows** needs iTunes (it provides Apple's device driver).
 
-            USB mode requires iTunes on Windows (for the Apple Mobile Device
-            Service).
+            Full setup guide: the [README](https://github.com/${{ github.repository }}#install).
+            </details>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,3 +88,17 @@ can't trigger a bump. Manual releases also work — push any `v*` tag:
 ```bash
 git tag v0.4.0 && git push origin v0.4.0
 ```
+
+### Release notes
+
+Every release page follows a fixed template: a compact **Install** table
+(templated in `release.yml`'s publish job — direct asset links, with
+manual/sideload/USB detail collapsed underneath), then GitHub's generated
+**What's Changed** changelog, shaped by
+[`.github/release.yml`](../.github/release.yml). Label a PR `enhancement`
+or `bug` to sort it into the New/Fixes section; unlabeled PRs land under
+"Other changes", and Dependabot bumps are excluded. Two invariants:
+the install table stays *above* the changelog (the API prepends the
+body), and the "What's Changed" heading must survive verbatim —
+`testflight_whats_to_test.py` splits the body on it to fill TestFlight's
+"What to Test".


### PR DESCRIPTION
## What & why

Release pages were ~35 lines of identical install prose that buried the actual changes below the fold, followed by one flat PR list with Dependabot CI bumps mixed in. This tidies the template (which lives in `release.yml`'s publish job, so it stays consistent automatically):

- **`release.yml`**: the "Installing" prose becomes a four-row download table (direct asset links built from the release tag) plus a one-line compatibility note, with the rare-path detail — manual zips, the quarantine `xattr` command, sideloading, USB/iTunes — preserved in a collapsed `<details>` block and a README link for the full guide. Nothing is deleted, just folded away.
- **`.github/release.yml`** (new): shapes the generated "What's Changed" — PRs labeled `enhancement`/`bug` get **New**/**Fixes** sections, unlabeled PRs land under **Other changes**, and Dependabot bumps are excluded since they never affect what users download. Labeling stays optional.
- **`DEVELOPMENT.md`**: documents the template and its two invariants — the install table stays *above* the changelog (the API prepends the body), and the "What's Changed" heading must survive verbatim because `testflight_whats_to_test.py` splits the release body on it to fill TestFlight's "What to Test" box.

## How it was tested

Workflow/docs-only change. Both YAML files parse; the new body was rendered with a sample tag and checked by running the TestFlight script's exact parsing logic over a simulated new-format release body (install table + collapsed details + categorized generated notes): the "What's Changed" split still lands correctly, category headings flatten cleanly to plain text, and no install text leaks into the What to Test box. Merging this PR triggers no release; the next real release exercises the new template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV)_