### PR TITLE
release notes: exclude dependabot[bot], not just dependabot

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,7 +9,10 @@
 changelog:
   exclude:
     authors:
+      # Both spellings: the generated notes attribute bot PRs to the
+      # "[bot]" login (v1.6.0 proved plain "dependabot" alone misses it).
       - dependabot
+      - dependabot[bot]
   categories:
     - title: New
       labels:


### PR DESCRIPTION
## What & why

The v1.6.0 changelog still listed the Dependabot bump (#48) — and credited it under "New Contributors" — because GitHub's generated release notes attribute bot PRs to the `dependabot[bot]` login, which the plain `dependabot` entry in `.github/release.yml`'s exclude list doesn't match. This lists both spellings so future releases' changelogs drop Dependabot noise as intended.

## How it was tested

Config-only change; YAML parses. The failure mode it fixes was observed directly on the v1.6.0 release notes (bot PR attributed to `dependabot[bot]`, not excluded). Takes effect on the next release's generated notes; no release is triggered by this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUCqzqvS5RLvBWuujSsrvV)_