### PR TITLE
plugin: show the installed version in OBS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,8 +27,8 @@ body:
     id: versions
     attributes:
       label: Versions
-      description: LensLink version (bottom of the app's main screen), OBS version, computer OS, phone model + iOS version.
-      placeholder: "LensLink 1.0 (1031), OBS 32.1, Windows 11, iPhone 14 / iOS 18.2"
+      description: App version (bottom of the app's main screen), plugin version (bottom of the LensLink source's properties, or Tools → LensLink Settings), OBS version, computer OS, phone model + iOS version.
+      placeholder: "app 1.0 (1031), plugin 1.6.0, OBS 32.1, Windows 11, iPhone 14 / iOS 18.2"
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Build
         run: |
           set -o pipefail
-          cmake -B build -DCMAKE_BUILD_TYPE=Release | tee configure.log
+          version="${{ inputs.tag_name || github.ref_name }}"
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DLENSLINK_VERSION="${version#v}" | tee configure.log
           grep -q "frontend UI enabled" configure.log
           cmake --build build
         working-directory: obs-plugin
@@ -110,7 +112,9 @@ jobs:
       # shipped without it once) — a release build must fail instead.
       - name: Build plugin
         run: |
+          $version = "${{ inputs.tag_name || github.ref_name }}".TrimStart("v")
           cmake -S obs-plugin -B plugin-build -G "Visual Studio 17 2022" -A x64 `
+            -DLENSLINK_VERSION="$version" `
             -DCMAKE_PREFIX_PATH="${{ github.workspace }}\obs-deps" `
             -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs;${{ github.workspace }}\obs-build\config;${{ github.workspace }}\obs-studio\deps\w32-pthreads" `
             -DLIBOBS_LIBRARY="${{ github.workspace }}\obs-build\libobs\Release\obs.lib;${{ github.workspace }}\obs-build\deps\w32-pthreads\Release\w32-pthreads.lib" `
@@ -212,8 +216,10 @@ jobs:
       - name: Build plugin
         run: |
           set -o pipefail
+          version="${{ inputs.tag_name || github.ref_name }}"
           cmake -S obs-plugin -B plugin-build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DLENSLINK_VERSION="${version#v}" \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_PREFIX_PATH="$PWD/obs-deps" \

--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -2,7 +2,14 @@
 # is silently misparsed as a search path on older CMake.
 cmake_minimum_required(VERSION 3.18...3.30)
 
-project(lenslink VERSION 0.1.0 LANGUAGES C)
+project(lenslink LANGUAGES C)
+
+# Release version baked into the binary (log line, source-properties
+# footer, settings dialog). CI passes the release tag; anything built
+# without it — dev checkouts, PR CI — honestly says "dev".
+if(NOT DEFINED LENSLINK_VERSION OR LENSLINK_VERSION STREQUAL "")
+  set(LENSLINK_VERSION "dev")
+endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -67,6 +74,8 @@ add_library(${PROJECT_NAME} MODULE
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE OBS::libobs ${FFMPEG_TARGET})
+target_compile_definitions(${PROJECT_NAME}
+                           PRIVATE LENSLINK_VERSION="${LENSLINK_VERSION}")
 
 if(WIN32)
   # dxguid: gpu-frame.c references IID_ID3D11Texture2D/IID_IDXGIKeyedMutex,

--- a/obs-plugin/src/frontend-ui.cpp
+++ b/obs-plugin/src/frontend-ui.cpp
@@ -295,6 +295,14 @@ void show_settings_dialog(void *)
 	layout->addWidget(dump);
 	layout->addWidget(bench);
 
+	/* Version footer, mirroring the source-properties one. */
+	auto *version = new QLabel(
+		QStringLiteral("LensLink " LENSLINK_VERSION), &dialog);
+	version->setStyleSheet(
+		QStringLiteral("color: gray; font-size: 11px;"));
+	layout->addSpacing(8);
+	layout->addWidget(version);
+
 	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok |
 						     QDialogButtonBox::Cancel,
 					     &dialog);

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -2558,6 +2558,15 @@ static obs_properties_t *build_properties(struct ios_camera_source *s,
 				screen ? T_("HelpTextScreen") : T_("HelpText"),
 				OBS_TEXT_INFO);
 
+	/* Version footer — the one place a user can read the installed
+	 * plugin version from inside OBS, mirroring the app's own version
+	 * line; bug reports need it. */
+	char version_line[64];
+	snprintf(version_line, sizeof(version_line), "LensLink %s",
+		 LENSLINK_VERSION);
+	obs_properties_add_text(props, "version_info", version_line,
+				OBS_TEXT_INFO);
+
 	return props;
 }
 

--- a/obs-plugin/src/plugin-main.c
+++ b/obs-plugin/src/plugin-main.c
@@ -48,7 +48,7 @@ bool obs_module_load(void)
 #ifdef LENSLINK_FRONTEND
 	lenslink_frontend_init();
 #endif
-	blog(LOG_INFO, "[lenslink] plugin loaded");
+	blog(LOG_INFO, "[lenslink] LensLink %s loaded", LENSLINK_VERSION);
 	return true;
 }
 

--- a/obs-plugin/src/plugin-settings.h
+++ b/obs-plugin/src/plugin-settings.h
@@ -29,6 +29,11 @@ void lenslink_settings_shutdown(void);
  * restart (the dialog says so). */
 bool lenslink_settings_gpu_pipeline(void);
 
+/* Injected by CMake — the release tag on CI builds, "dev" otherwise. */
+#ifndef LENSLINK_VERSION
+#define LENSLINK_VERSION "dev"
+#endif
+
 bool lenslink_settings_web_enabled(void);
 int lenslink_settings_web_port(void);
 bool lenslink_settings_diagnostics(void);


### PR DESCRIPTION
## What & why

Users had no way to answer "which plugin version do you have?" — the binary carried no version at all; only the Windows installer's Add/Remove entry knew, and only for installer installs. This bakes the release tag into the binary at build time and surfaces it everywhere a user might look:

- A small `LensLink <version>` info footer at the bottom of **both** source-properties sheets (Camera and Screen share the builder).
- A grey small-print footer in **Tools → LensLink Settings**.
- The module-load log line — `[lenslink] LensLink 1.6.0 loaded` — so every uploaded OBS log names the exact build even when the reporter doesn't know where to look.

Mechanics: CI passes the tag as `-DLENSLINK_VERSION` in all three OS release builds; anything built without it (local checkouts, PR CI) honestly says `dev` instead of carrying a stale number. The never-read `VERSION 0.1.0` in `project()` is removed, and the bug-report form's versions hint now tells reporters where to find the plugin version.

Note: the footers become real for users with the next release — current installs stay unlabeled until they update.

## How it was tested

Built locally with CI's `-Wall -Wextra -Werror` flags, twice: default configure → binary carries the `dev` path; `-DLENSLINK_VERSION=9.9.9-test` → `strings` shows `9.9.9-test` (ASCII, the C surfaces) and `LensLink 9.9.9-test` (UTF-16, the Qt dialog's `QStringLiteral`) in the .so. Workflow and issue-form YAML validated. The three release.yml build blocks were edited in each OS's own shell dialect (bash `${version#v}` / PowerShell `TrimStart("v")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq)_