### PR TITLE
TestFlight: auto-assign builds to test groups; fix pip on macos-15

### DIFF
--- a/.github/scripts/testflight_feedback.py
+++ b/.github/scripts/testflight_feedback.py
@@ -42,7 +42,9 @@ def request(url, token, method="GET", body=None):
         req.data = json.dumps(body).encode()
     try:
         with urllib.request.urlopen(req) as resp:
-            return resp.status, json.load(resp)
+            raw = resp.read()
+            # Relationship writes answer 204 with an empty body.
+            return resp.status, (json.loads(raw) if raw else {})
     except urllib.error.HTTPError as e:
         return e.code, json.loads(e.read() or b"{}")
 

--- a/.github/scripts/testflight_whats_to_test.py
+++ b/.github/scripts/testflight_whats_to_test.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
-"""Populate the uploaded TestFlight build's "What to Test" section.
+"""Populate "What to Test" and distribute the uploaded TestFlight build.
 
 Runs right after the TestFlight upload: waits for App Store Connect to
-register the build (matched by CFBundleVersion), then writes the latest
-GitHub release's "What's Changed" section — converted to plain text —
-into the build's betaBuildLocalizations `whatsToTest` attribute, which
-is exactly what testers see under "What to Test" in the TestFlight app.
+finish processing the build (matched by CFBundleVersion), writes the
+latest GitHub release's "What's Changed" section — converted to plain
+text — into the build's betaBuildLocalizations `whatsToTest` attribute
+(exactly what testers see under "What to Test" in the TestFlight app),
+then assigns the build to the beta groups named in ASC_BETA_GROUPS.
+External groups are submitted for beta app review automatically — the
+first build of a version waits on Apple, later ones clear quickly.
 
 Environment:
   ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_P8   App Store Connect API key
   BUNDLE_ID                                 app bundle id
   BUILD_NUMBER                              CFBundleVersion just uploaded
+  ASC_BETA_GROUPS                           comma-separated TestFlight
+                                            group names (unset = skip)
   GITHUB_TOKEN / GITHUB_REPOSITORY          provided by Actions
 """
 
@@ -57,6 +62,63 @@ def plain_text(md):
     return re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip()
 
 
+def assign_groups(app_id, build_id, token):
+    """Distribute the build to the beta groups named in ASC_BETA_GROUPS."""
+    names = [n.strip()
+             for n in os.environ.get("ASC_BETA_GROUPS", "").split(",")
+             if n.strip()]
+    if not names:
+        print("ASC_BETA_GROUPS not set — skipping test-group assignment")
+        return True
+
+    ok = True
+    groups = []
+    for name in names:
+        found = asc_get("/v1/betaGroups", token,
+                        **{"filter[app]": app_id, "filter[name]": name,
+                           "fields[betaGroups]": "name,isInternalGroup"})
+        data = (found or {}).get("data", [])
+        if not data:
+            print(f"::warning::beta group \"{name}\" not found — "
+                  f"check the ASC_BETA_GROUPS repository variable")
+            ok = False
+            continue
+        groups.append(data[0])
+
+    # External groups only get builds that passed beta app review; submit
+    # before assigning (fastlane's order). Internal groups need neither.
+    if any(not g.get("attributes", {}).get("isInternalGroup")
+           for g in groups):
+        status, resp = request(
+            f"{ASC_BASE}/v1/betaAppReviewSubmissions", token, method="POST",
+            body={"data": {"type": "betaAppReviewSubmissions",
+                           "relationships": {"build": {"data": {
+                               "type": "builds", "id": build_id}}}}})
+        if status == 201:
+            print("submitted for beta app review")
+        elif status in (409, 422):
+            # Already submitted or already approved — both fine.
+            print(f"beta review submission not needed ({status})")
+        else:
+            print(f"::warning::beta review submission failed ({status}): "
+                  f"{str(resp)[:300]}")
+            ok = False
+
+    for group in groups:
+        name = group.get("attributes", {}).get("name", group["id"])
+        status, resp = request(
+            f"{ASC_BASE}/v1/betaGroups/{group['id']}/relationships/builds",
+            token, method="POST",
+            body={"data": [{"type": "builds", "id": build_id}]})
+        if status in (200, 201, 204):
+            print(f"build added to test group \"{name}\"")
+        else:
+            print(f"::warning::adding build to group \"{name}\" "
+                  f"failed ({status}): {str(resp)[:300]}")
+            ok = False
+    return ok
+
+
 def main():
     repo = os.environ["GITHUB_REPOSITORY"]
     bundle_id = os.environ["BUNDLE_ID"]
@@ -74,25 +136,34 @@ def main():
         return 1
     app_id = apps["data"][0]["id"]
 
-    # The upload finishes before ASC registers the build; poll for it.
-    # Tokens live ~10 min, so mint a fresh one per attempt.
+    # The upload finishes before ASC registers the build, and group
+    # assignment needs processing to have finished too — poll until the
+    # build is VALID. Tokens live ~10 min, so mint a fresh one per attempt.
     build_id = None
     for attempt in range(POLL_LIMIT):
         token = asc_token()
         builds = asc_get("/v1/builds", token,
                          **{"filter[app]": app_id,
-                            "filter[version]": build_number, "limit": 1})
-        if builds and builds.get("data"):
-            build_id = builds["data"][0]["id"]
+                            "filter[version]": build_number,
+                            "fields[builds]": "processingState", "limit": 1})
+        data = (builds or {}).get("data", [])
+        state = data[0]["attributes"]["processingState"] if data else "not registered"
+        if state == "VALID":
+            build_id = data[0]["id"]
             break
-        print(f"build {build_number} not registered yet "
+        if state in ("FAILED", "INVALID"):
+            print(f"::warning::build {build_number} processing "
+                  f"ended in {state} — nothing to distribute")
+            return 1
+        print(f"build {build_number}: {state} "
               f"({attempt + 1}/{POLL_LIMIT}) — retrying in {POLL_SECONDS}s")
         time.sleep(POLL_SECONDS)
     if not build_id:
-        print("::warning::build never appeared in App Store Connect — "
-              "set What to Test manually")
+        print("::warning::build never finished processing in App Store "
+              "Connect — set What to Test / groups manually")
         return 1
 
+    ok = True
     locs = asc_get(f"/v1/builds/{build_id}/betaBuildLocalizations", token)
     existing = (locs or {}).get("data", [])
     if existing:
@@ -113,10 +184,15 @@ def main():
     if status in (200, 201):
         print(f"What to Test set for build {build_number} "
               f"({len(text)} chars, from {tag or 'latest release'})")
-        return 0
-    print(f"::warning::setting What to Test failed ({status}): "
-          f"{str(resp)[:300]}")
-    return 1
+    else:
+        print(f"::warning::setting What to Test failed ({status}): "
+              f"{str(resp)[:300]}")
+        ok = False
+
+    # Even if the notes failed, still try to distribute the build.
+    if not assign_groups(app_id, build_id, token):
+        ok = False
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -130,20 +130,29 @@ jobs:
         working-directory: ios-app
 
       # Fills the TestFlight "What to Test" box from the latest GitHub
-      # release's "What's Changed" notes. Non-fatal: the build is already
-      # uploaded; worst case the box stays empty and can be set by hand.
-      - name: Set "What to Test" from the release notes
+      # release's "What's Changed" notes, then assigns the build to the
+      # beta groups named in the ASC_BETA_GROUPS repository variable
+      # (comma-separated group names; unset = no assignment). Non-fatal:
+      # the build is already uploaded; worst case the box stays empty
+      # and testers are pointed at the build by hand.
+      - name: Set "What to Test" and distribute to test groups
         continue-on-error: true
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           ASC_KEY_P8: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
           BUNDLE_ID: com.exaltedpixels.LensLinkCamera
+          ASC_BETA_GROUPS: ${{ vars.ASC_BETA_GROUPS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 -m pip install --quiet PyJWT cryptography
+          # The runner's default python3 is Homebrew's, which is
+          # PEP 668 "externally managed" and refuses pip installs —
+          # use a throwaway venv.
+          python3 -m venv "$RUNNER_TEMP/asc-venv"
+          "$RUNNER_TEMP/asc-venv/bin/pip" install --quiet PyJWT cryptography
           BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 )) \
-            python3 .github/scripts/testflight_whats_to_test.py
+            "$RUNNER_TEMP/asc-venv/bin/python" \
+            .github/scripts/testflight_whats_to_test.py
 
       - name: Clean up API key
         if: always()

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -49,13 +49,34 @@ review by Apple.
 
 ## "What to Test" fills itself in
 
-After each upload, the workflow waits for App Store Connect to register
-the build and writes the latest GitHub release's "What's Changed" notes
-(as plain text) into the build's **What to Test** field — so testers see
-the actual changelog in the TestFlight app without anyone typing it
-twice. The step is non-fatal: if it can't run (build stuck in
+After each upload, the workflow waits for App Store Connect to finish
+processing the build and writes the latest GitHub release's "What's
+Changed" notes (as plain text) into the build's **What to Test** field —
+so testers see the actual changelog in the TestFlight app without anyone
+typing it twice. The step is non-fatal: if it can't run (build stuck in
 processing, no release yet), the upload still succeeds and the field can
 be filled by hand in App Store Connect.
+
+## Builds auto-assign to your test groups (optional)
+
+The same step can hand each processed build to specific TestFlight
+groups. Set a repository **variable** (not secret) — GitHub repo →
+**Settings → Secrets and variables → Actions → Variables → New
+repository variable**:
+
+| Variable | Value |
+|---|---|
+| `ASC_BETA_GROUPS` | comma-separated TestFlight group names, exactly as they appear in App Store Connect (e.g. `Friends, Public Beta`) |
+
+- **Internal groups** (App Store Connect team members) get the build
+  immediately. (For internal groups you can also skip all of this and
+  enable the group's built-in "automatic distribution" toggle in App
+  Store Connect instead.)
+- **External groups** are submitted for **beta app review**
+  automatically before assignment. The first build of each version
+  number waits on Apple (usually under a day); later builds of the same
+  version clear almost instantly.
+- Unset the variable and the step just sets What to Test, as before.
 
 ## Tester feedback flows into GitHub issues
 


### PR DESCRIPTION
## What & why

Two changes to the TestFlight upload workflow's post-upload step:

- **Fix the `error: externally-managed-environment` failure** seen in the v1.7.2 run's "Set What to Test" step: macos-15 runners default to Homebrew's Python, which is PEP 668 externally managed and refuses `pip install`. PyJWT/cryptography now install into a throwaway venv.
- **Auto-distribute each build to TestFlight groups.** The same script (which already polls for the uploaded build) now waits for `processingState: VALID` and assigns the build to every group named in the new `ASC_BETA_GROUPS` repository **variable** (comma-separated names as shown in App Store Connect; unset = skip, exactly today's behavior). External groups are submitted for beta app review first, mirroring fastlane's order; internal groups need no review. Also hardened the shared `request()` helper to tolerate the empty 204 body that ASC relationship writes return (it previously crashed on it). Setup is documented in `docs/TESTFLIGHT.md`.

No release will fire from this merge (nothing under `obs-plugin/`, `ios-app/`, or `installer/` changed); the fix takes effect on the next release that touches `ios-app/`.

## How it was tested

Docs/CI-only change — no stream to observe. Per `.claude/skills/verify`, the unmodified script was driven against a local mock of the App Store Connect + GitHub APIs (ES256 JWT verified on every call — aud/kid checked against a throwaway EC key — and the real v1.7.2 release body as fixture). Six scenarios pass: happy path with registration lag + PROCESSING→VALID polling, internal-only group (no review submission), `ASC_BETA_GROUPS` unset, unknown group name (warning + exit 1), existing-localization PATCH path, and FAILED processing (bails before distributing). `testflight.yml` parse-checked with PyYAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01487A1FaQ835mqkw6U5sojP

---
_Generated by [Claude Code](https://claude.ai/code/session_01487A1FaQ835mqkw6U5sojP)_