### PR TITLE
iOS: pick capture formats that permit the system video effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,18 @@ are the places to watch.
   through a Shortcuts automation (`lenslink://start` works everywhere).
   Also make sure the app has been launched once and "Use with Siri" is on
   in Settings → Siri & Search → LensLink.
+- **Control Center's Video Effects (Portrait, Studio Light…) are missing
+  or greyed out while streaming:** those system effects are toggled by
+  you in Control Center while an app uses the camera — but iOS only
+  offers them on certain cameras and capture formats: mostly the front
+  camera, at moderate settings (think 1080p at 30 fps, not 4K/60), on
+  hardware that supports each effect. Center Stage is iPad-only.
+  LensLink picks an effect-capable format whenever your
+  resolution/frame-rate choice allows one; if the panel is still empty,
+  drop the frame rate or resolution, or switch to the front camera.
+  Apple's Camera-app filters and Photographic Styles aren't available
+  to any third-party camera app — for creative looks, add filters to
+  the source in OBS instead (right-click the source → **Filters**).
 - **Screen broadcast won't connect (sideloaded only):** re-signing can
   silently break the broadcast extension. In the app, open **Screen mirror
   tools → Check broadcast link** while a broadcast is running — it verifies

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -151,3 +151,33 @@ memory that the GPU pipeline eliminates outright, roughly halving OBS
 process CPU. Capture→decode latency and decoded fps are measured before
 the pipelines diverge and showed no systematic difference — those are
 set by the network and the phone's encoder, not by the render path.
+
+## Apple capture guidance: what we follow, what we deliberately don't
+
+The iOS capture/encode path was audited against Apple's AVFoundation and
+VideoToolbox guidance for real-time capture. Followed: `RealTime` +
+`AllowFrameReordering=false` (no B-frames) + `PrioritizeEncodingSpeed
+OverQuality` + `MaxFrameDelayCount=1` on the encoder, average bitrate
+with a hard data-rate cap, 2-second keyframes, `alwaysDiscardsLate
+VideoFrames`, session interruption/runtime-error observers with restart,
+and — per the `systemPressureState` docs — thermal/power mitigation:
+at `.serious` the bitrate is halved, at `.critical` it's quartered and
+the frame rate halves (60→30, 30→15), restored when pressure abates.
+
+Deliberate divergences (don't "fix" these without reading this):
+
+- **Frame durations are locked** (min = max = 1/fps). Apple's default
+  lets auto-exposure sag the frame rate in low light, like the Camera
+  app's Auto FPS. A sagging cadence hurts the encoder's rate control,
+  OBS timing, and the lip-sync/latency math; we hold cadence and let the
+  image get noisier instead. The thermal throttle above is the one
+  sanctioned exception.
+- **Video stabilization stays off** (the AVCaptureVideoDataOutput
+  default). Every stabilization mode adds frames of latency; this is a
+  latency-first product. Revisit only as an opt-in.
+- **The wire is 8-bit 4:2:0 video-range** (`420v`); HDR formats are not
+  selected. The whole chain — encoder profile, wire protocol, plugin
+  decode, OBS frame — assumes 8-bit; HDR would need end-to-end work.
+- **Rotation is sensor-native** (`.landscapeRight`, an effective 0°).
+  The AVCaptureConnection docs warn per-frame rotation costs; we never
+  rotate the stream, only the on-phone preview.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,12 +19,15 @@ Continuity Camera, iVCam/Iriun, NDI HX Camera/Larix).
 | P1 | Graduate the GPU decode pipeline | Performance | Small |
 | P1 | Tally light on the phone | Control & workflow | Small |
 | P2 | Digital pan/tilt + crop | Control & workflow | Medium |
+| P2 | Virtual green screen (background removal) | Video & audio quality | Medium |
 | P2 | 10-bit HEVC + HDR (HLG/PQ) | Video & audio quality | Large |
 | P2 | Voice isolation for the phone mic | Video & audio quality | Small |
 | P2 | Document the control API | Control & workflow | Small |
 | P3 | Apple Log capture | Video & audio quality | Small¹ |
 | P3 | Manual bitrate cap | Video & audio quality | Small |
 | P3 | Zero-copy encoder output | Performance | Medium |
+| P3 | iPad: keep streaming in Split View | Control & workflow | Small |
+| P3 | Two lenses at once (multicam) | Video & audio quality | Large |
 
 ¹ once 10-bit HEVC ships.
 
@@ -36,15 +39,18 @@ Continuity Camera, iVCam/Iriun, NDI HX Camera/Larix).
 
 ## Reliability & security
 
-### Thermal & low-power adaptation on the phone — P1, medium
+### Thermal & low-power adaptation on the phone — P1, medium (partially shipped)
 For a mounted phone streaming for hours, the practical limit is heat
 soak: iOS throttles, capture stutters, and at worst the phone shuts
-down mid-stream. Watch `ProcessInfo.thermalState` and step down fps →
-bitrate → resolution at `.serious` (restore when it recovers), surface
-the adaptation in the app status and the OBS source status, and
-optionally respect Low Power Mode. No protocol changes — the app
-already reconfigures capture live for lens switches, and the plugin
-follows VIDEO_CONFIG. *The biggest real-world win for long streams.*
+down mid-stream. **Shipped (PR #63):** the capture device's
+`systemPressureState` is observed per Apple's guidance — `.serious`
+halves the bitrate, `.critical` quarters it and halves the frame rate,
+both restored on recovery, logged to the unified log. **Remaining:**
+surface the adaptation in the app status and the OBS source status
+(today it's silent), consider `ProcessInfo.thermalState` for
+earlier/coarser signals, resolution step-down as the last rung, and
+optionally respect Low Power Mode. *The biggest real-world win for
+long streams.*
 
 ### Optional pairing & encryption — close the trusted-LAN caveat — P1, medium
 The README honestly says the stream is unencrypted and intended for
@@ -96,6 +102,22 @@ default — Twitch is still SDR, so HDR mainly pays off for YouTube and
 local recording. *The headline video-quality differentiator; the only
 large item on the active list, and it unlocks Apple Log below.*
 
+### Virtual green screen — background removal without the screen — P2, medium
+Camo's flagship paid feature, on the free table. Vision's person
+segmentation (`VNGeneratePersonSegmentationRequest`, iOS 15 — exactly
+our floor) mattes a person from plain RGB on any camera, front or rear
+— no depth hardware required. The wire stays untouched: composite the
+removed background to solid chroma green on the phone and let OBS's
+chroma key provide the transparency. Staged: **v1** segmentation +
+green composite behind an Options toggle (per-frame GPU work — quote
+before/after numbers, lean on the thermal mitigation); **v2** the app
+advertises the mode in STATE and the plugin auto-adds a pre-configured
+chroma-key filter to the source, so the phone toggle alone yields a
+keyed subject in the scene; **v3** depth-assisted edge refinement
+(hair, glasses) where TrueDepth or LiDAR exists — this is where
+Apple's "enhancing live video with TrueDepth" techniques earn their
+keep, as an enhancer rather than a requirement.
+
 ### Voice isolation for the phone mic — P2, small
 The mic features send the raw microphone feed; iOS's built-in
 voice-processing pipeline (echo cancellation + noise suppression, the
@@ -109,6 +131,17 @@ On iPhone 15 Pro and later the camera can capture in Apple Log
 Once the 10-bit path exists this is mostly a capture-format toggle plus
 correct colour tagging, gated to devices that report support. Nothing
 else in this market offers it. *Trigger: 10-bit HEVC shipping.*
+
+### Two lenses at once (multicam) — P3, large
+`AVCaptureMultiCamSession` (iOS 13+) can run the front and a rear
+camera simultaneously — one phone feeding a face cam *and* a scene cam
+as two LensLink sources (a second connection with its own HELLO; the
+plugin's per-source device pinning already gives each stream a home).
+No competitor does this. It's P3 for a reason: multicam formats are
+heavily restricted (no 4K, limited fps), the thermal budget for two
+encodes is severe (prototype heat before UI), and the app's
+capture/encode/listener plumbing is currently single-stream. *Trigger:
+real user demand, and a thermal prototype that survives 30 minutes.*
 
 ### Manual bitrate cap — P3, small
 Adaptive bitrate already reacts to congestion, but there's no user
@@ -140,6 +173,17 @@ region, it reads sharper than cropping in OBS. New CONTROL command with
 a normalized crop rect, STATE carries it back, web panel and Live
 screen get a drag-to-frame control. *The biggest quality-of-life gap
 for the mounted-phone use case this app is built around.*
+
+### iPad: keep streaming in Split View — P3, small
+The app streams only while foregrounded (iOS suspends background
+camera capture), which on iPad is a real limitation — a streamer might
+want notes or chat beside the camera app. On supporting iPads,
+`AVCaptureSession.isMultitaskingCameraAccessEnabled` (iOS 16+) lets
+capture continue in Split View / Stage Manager. Gate on
+`isMultitaskingCameraAccessSupported`, keep the listener alive, and
+soften the "foregrounded only" wording where it applies. iPhone
+still suspends — this is iPad-only relief. *Trigger: iPad users
+asking; pairs naturally with the tally light for multi-window rigs.*
 
 ### Document the control API — Stream Deck without a plugin — P2, small
 The web panel's endpoints (`/api/state`, `POST /api/control`) are

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -273,6 +273,46 @@ final class CameraManager: NSObject {
         return format(for: device, resolution: resolution, fps: fps) != nil
     }
 
+    /// Fires on system-pressure (thermal/power) level changes, on the
+    /// main queue — Streamer scales the bitrate down in response.
+    var onSystemPressure: ((AVCaptureDevice.SystemPressureState.Level) -> Void)?
+    private var pressureObservation: NSKeyValueObservation?
+    private var configuredFps: Int32 = 30
+    private var fpsThrottled = false
+
+    private func systemPressureChanged(on device: AVCaptureDevice) {
+        let level = device.systemPressureState.level
+        let line = "System pressure: \(level.rawValue)"
+        Self.log.warning("\(line, privacy: .public)")
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            // Halve the frame rate at .critical (60→30, 30→15) — losing
+            // cadence beats losing the capture to a thermal shutdown —
+            // and restore the configured rate once pressure abates.
+            let throttle = level == .critical
+            if throttle != self.fpsThrottled {
+                self.fpsThrottled = throttle
+                self.applyFrameRate(divisor: throttle ? 2 : 1)
+            }
+        }
+        DispatchQueue.main.async { self.onSystemPressure?(level) }
+    }
+
+    /// sessionQueue only.
+    private func applyFrameRate(divisor: CMTimeValue) {
+        guard let device = activeDevice else { return }
+        let duration = CMTime(value: divisor,
+                              timescale: configuredFps)
+        do {
+            try device.lockForConfiguration()
+            device.activeVideoMinFrameDuration = duration
+            device.activeVideoMaxFrameDuration = duration
+            device.unlockForConfiguration()
+        } catch {
+            print("Frame-rate throttle failed: \(error.localizedDescription)")
+        }
+    }
+
     /// AVCaptureSession requires serialized access; start/stop run on
     /// `sessionQueue`, so configuration hops there too (synchronously, to
     /// keep the throwing API).
@@ -322,6 +362,19 @@ final class CameraManager: NSObject {
         device.activeVideoMaxFrameDuration = frameDuration
         device.unlockForConfiguration()
         activeDevice = device
+
+        // Thermal/power mitigation, per the systemPressureState docs:
+        // frame-rate throttling is Apple's recommended response, and at
+        // .shutdown iOS stops capture on its own (surfaced through the
+        // interruption observers above).
+        configuredFps = fps
+        fpsThrottled = false
+        pressureObservation?.invalidate()
+        pressureObservation = device.observe(\.systemPressureState,
+                                             options: [.new]) {
+            [weak self] observedDevice, _ in
+            self?.systemPressureChanged(on: observedDevice)
+        }
 
         let output = AVCaptureVideoDataOutput()
         output.videoSettings = [

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import UIKit
+import os
 
 /// Owns the AVCaptureSession and delivers raw camera frames.
 final class CameraManager: NSObject {
@@ -192,16 +193,60 @@ final class CameraManager: NSObject {
                 bestScore = score
             }
         }
-        // Device-log breadcrumb (Console.app): the candidate table with
-        // effect flags, so "Video Effects panel is empty on <device>" is
-        // diagnosable from a log instead of guessed at.
+        // Unified-log breadcrumb (Console.app when a Mac is handy; the
+        // full copyable table lives in Options → Camera diagnostics):
+        // the candidate list with effect flags, so "Video Effects panel
+        // is empty on <device>" is diagnosable instead of guessed at.
         for candidate in candidates {
-            print("Format \(target.width)x\(target.height)@\(fps) "
-                  + "binned=\(candidate.isVideoBinned) "
-                  + "effects=\(effectsScore(candidate))"
-                  + (candidate == best ? " <- chosen" : ""))
+            let line = "Format \(target.width)x\(target.height)@\(fps) "
+                + "binned=\(candidate.isVideoBinned) "
+                + "effects=\(effectsScore(candidate))"
+                + (candidate == best ? " <- chosen" : "")
+            log.info("\(line, privacy: .public)")
         }
         return best
+    }
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "LensLink",
+        category: "camera")
+
+    /// Human-readable dump of every lens's capture formats with the
+    /// system video-effect flags (CS = Center Stage, P = Portrait,
+    /// SL = Studio Light, R = Reactions) — the field diagnostic behind
+    /// Options → Camera diagnostics, copyable straight from the phone.
+    static func formatReport() -> String {
+        var out = ["\(UIDevice.current.model) — iOS "
+                   + UIDevice.current.systemVersion,
+                   "flags: binned / CS / P / SL / R", ""]
+        for lens in availableLenses() {
+            guard let device = device(for: lens) else { continue }
+            out.append("== \(lens.label) ==")
+            for format in device.formats {
+                let dims = CMVideoFormatDescriptionGetDimensions(
+                    format.formatDescription)
+                let maxFps = format.videoSupportedFrameRateRanges
+                    .map(\.maxFrameRate).max() ?? 0
+                var flags = [format.isVideoBinned ? "b" : "-",
+                             format.isCenterStageSupported ? "CS" : "--",
+                             format.isPortraitEffectSupported ? "P" : "-"]
+                if #available(iOS 16.0, *) {
+                    flags.append(format.isStudioLightSupported ? "SL" : "--")
+                } else {
+                    flags.append("?")
+                }
+                if #available(iOS 17.0, *) {
+                    flags.append(format.reactionEffectsSupported ? "R" : "-")
+                } else {
+                    flags.append("?")
+                }
+                out.append(String(format: "%5dx%-5d fps<=%-3.0f  %@",
+                                  dims.width, dims.height, maxFps,
+                                  flags.joined(separator: " ")))
+            }
+            out.append("")
+        }
+        return out.joined(separator: "\n")
     }
 
     /// How many of the system video effects this format can run. The

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -160,9 +160,9 @@ final class CameraManager: NSObject {
                                resolution: Resolution,
                                fps: Int32) -> AVCaptureDevice.Format? {
         let target = resolution.size
-        // Prefer earlier (unbinned, video-range) formats; require exact
-        // dimensions and a frame-rate range covering the requested rate.
-        return device.formats.first { format in
+        // Require exact dimensions and a frame-rate range covering the
+        // requested rate; earlier formats (unbinned, video-range) win ties.
+        let candidates = device.formats.filter { format in
             let dims = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
             guard dims.width == target.width, dims.height == target.height else {
                 return false
@@ -170,6 +170,45 @@ final class CameraManager: NSObject {
             return format.videoSupportedFrameRateRanges
                 .contains { $0.maxFrameRate >= Double(fps) }
         }
+        guard let first = candidates.first else { return nil }
+
+        // The device list carries near-duplicate formats whose practical
+        // difference is whether the system video effects (Control Center:
+        // Portrait, Studio Light, Reactions; Center Stage on iPad) can
+        // run — usually only the sensor-binned sibling supports them, and
+        // picking the other one leaves the user's Video Effects panel
+        // empty, which reads as a bug. Prefer the effect-capable sibling,
+        // but only with the same pixel format (colour range must never
+        // shift with this choice). The effects cost nothing unless the
+        // user actually switches one on.
+        let subtype = CMFormatDescriptionGetMediaSubType(first.formatDescription)
+        var best = first
+        var bestScore = effectsScore(first)
+        for candidate in candidates.dropFirst()
+        where CMFormatDescriptionGetMediaSubType(candidate.formatDescription) == subtype {
+            let score = effectsScore(candidate)
+            if score > bestScore {
+                best = candidate
+                bestScore = score
+            }
+        }
+        return best
+    }
+
+    /// How many of the system video effects this format can run. The
+    /// effects themselves are user-toggled in Control Center — apps can't
+    /// switch them on, only pick a format that permits them.
+    private static func effectsScore(_ format: AVCaptureDevice.Format) -> Int {
+        var score = 0
+        if format.isCenterStageSupported { score += 1 }
+        if format.isPortraitEffectSupported { score += 1 }
+        if #available(iOS 16.0, *), format.isStudioLightSupported {
+            score += 1
+        }
+        if #available(iOS 17.0, *), format.reactionEffectsSupported {
+            score += 1
+        }
+        return score
     }
 
     /// Whether this lens can capture the resolution at the frame rate.

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -192,6 +192,15 @@ final class CameraManager: NSObject {
                 bestScore = score
             }
         }
+        // Device-log breadcrumb (Console.app): the candidate table with
+        // effect flags, so "Video Effects panel is empty on <device>" is
+        // diagnosable from a log instead of guessed at.
+        for candidate in candidates {
+            print("Format \(target.width)x\(target.height)@\(fps) "
+                  + "binned=\(candidate.isVideoBinned) "
+                  + "effects=\(effectsScore(candidate))"
+                  + (candidate == best ? " <- chosen" : ""))
+        }
         return best
     }
 

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -37,6 +37,14 @@ struct OptionsView: View {
                     // exclusivity; this footer is where users learn it.
                     Text("**Send phone mic** streams this phone's microphone as the camera source's audio in OBS — a wireless mic.\n\n**Auto lip-sync** sends the mic purely as a timing reference so the plugin can auto-align your real microphone — it's never streamed or heard.\n\nOne mic, one role: turning one on turns the other off.")
                 }
+
+                Section {
+                    NavigationLink(destination: CameraDiagnosticsView()) {
+                        Text("Camera diagnostics")
+                    }
+                } footer: {
+                    Text("The camera's capture formats and which system video effects (Control Center) each supports — copy it into a bug report when an effect you expect is missing.")
+                }
             }
             .navigationTitle("Options")
             .navigationBarTitleDisplayMode(.inline)
@@ -48,5 +56,32 @@ struct OptionsView: View {
         }
         .navigationViewStyle(.stack)
         .tint(Theme.accent)
+    }
+}
+
+/// The camera's format table with the system video-effect flags, built
+/// on demand and copyable — so "the Video Effects panel is empty on my
+/// phone" can be diagnosed from a paste instead of a Mac-tethered log.
+private struct CameraDiagnosticsView: View {
+    private let report = CameraManager.formatReport()
+    @State private var copied = false
+
+    var body: some View {
+        ScrollView([.vertical, .horizontal]) {
+            Text(report)
+                .font(.system(.caption2, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .navigationTitle("Camera diagnostics")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(copied ? "Copied" : "Copy") {
+                    UIPasteboard.general.string = report
+                    copied = true
+                }
+            }
+        }
     }
 }

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -496,6 +496,22 @@ final class Streamer: ObservableObject {
                 self?.handleClientState(state)
             }
         }
+        camera.onSystemPressure = { [weak self] level in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // .serious halves the bitrate; .critical quarters it (on
+                // top of CameraManager halving the frame rate). The
+                // adaptive loop applies the cap within a second and ramps
+                // back up after recovery.
+                switch level {
+                case .serious: self.thermalBitrateScale = 0.5
+                case .critical: self.thermalBitrateScale = 0.25
+                default: self.thermalBitrateScale = 1.0
+                }
+                print("System pressure \(level.rawValue) -> "
+                      + "bitrate scale \(self.thermalBitrateScale)")
+            }
+        }
         client.onDiscoveryChange = { [weak self] discoverable in
             Task { @MainActor [weak self] in
                 guard let self else { return }
@@ -859,6 +875,10 @@ final class Streamer: ObservableObject {
     /// recover slowly (+10%/10s of clean streaming) up to the target.
     private var adaptiveTask: Task<Void, Never>?
 
+    /// 1.0 normally; lowered under system pressure (thermal/power) so
+    /// the encoder and radio shed load before iOS shuts capture down.
+    private var thermalBitrateScale = 1.0
+
     private func startAdaptiveBitrate(target: Int) {
         adaptiveTask?.cancel()
         adaptiveTask = Task { [weak self] in
@@ -880,6 +900,8 @@ final class Streamer: ObservableObject {
                 }
                 previousStats = stats
 
+                let effectiveTarget = max(
+                    1_000_000, Int(Double(target) * self.thermalBitrateScale))
                 let dropped = self.client.takeDroppedFrameCount()
                 let sendDelayMs = self.client.takeMaxSendDelayMs()
                 if dropped > 0 || sendDelayMs > 200 {
@@ -892,11 +914,15 @@ final class Streamer: ObservableObject {
                               + "\(dropped), send delay \(sendDelayMs) ms) "
                               + "-> \(current / 1000) kbps")
                     }
-                } else if current < target {
+                } else if current > effectiveTarget {
+                    current = effectiveTarget
+                    self.encoder?.setBitrate(current)
+                    print("Thermal cap -> \(current / 1000) kbps")
+                } else if current < effectiveTarget {
                     stableSeconds += 1
                     if stableSeconds >= 10 {
                         stableSeconds = 0
-                        current = min(target, current * 11 / 10)
+                        current = min(effectiveTarget, current * 11 / 10)
                         self.encoder?.setBitrate(current)
                     }
                 }


### PR DESCRIPTION
## What & why

Field report: on an iPhone 15 Pro where FaceTime shows Control Center's Video Effects (Portrait, Studio Light, Reactions), LensLink shows an empty Video Effects panel at **every** resolution/frame-rate combination. The device format list carries near-duplicates at the same dims+fps whose practical difference is whether the system effects can run — usually only the sensor-binned sibling advertises `isPortraitEffectSupported` & co. — and the picker chose purely by dimensions and fps, so it could land (apparently always, on this hardware) on the effect-less sibling.

- Among matching formats **with the same pixel format** (colour range must never shift from this choice), prefer the one supporting the most effects (`isCenterStageSupported` / `isPortraitEffectSupported` unguarded at the iOS 15 floor; Studio Light and Reactions behind `#available` 16/17). Nothing changes unless the user toggles an effect on in Control Center — apps can only *permit* effects, never enable them. 4K/60 formats generally support none, so behavior there is unchanged.
- **Options → Camera diagnostics**: a copyable per-lens format table (dimensions, max fps, binned, CS/P/SL/R flags, device + iOS header) — the field diagnostic works from the phone alone, no Mac required. The configure-time breadcrumb goes through `os.Logger` (not `print`, which TestFlight builds discard), so Console.app also shows the decision when a Mac is around.
- README troubleshooting now covers the whole topic: which effects exist where, Center Stage being iPad-only, and Apple's Camera-app filters / Photographic Styles being unavailable to every third-party capture app (OBS-side filters are the alternative for looks).

## How it was tested

Swift parse check locally; the type check runs in this PR's macOS CI job. The behavioral claim needs a device: after merge, the release's TestFlight build is the test vehicle — front camera at 1080p/30 on the iPhone 15 Pro that currently reproduces the empty panel. If the panel is still empty, Options → Camera diagnostics → Copy captures the hardware's actual format table for the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq