### PR TITLE
iOS: "Allow system video effects" experiment; Center Stage wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,15 @@ are the places to watch.
 - **Control Center's Video Effects (Portrait, Studio Light…) are missing
   or greyed out while streaming:** those system effects are toggled by
   you in Control Center while an app uses the camera — but iOS only
-  offers them on certain cameras and capture formats: mostly the front
-  camera, at moderate settings (think 1080p at 30 fps, not 4K/60), on
-  hardware that supports each effect. Center Stage is iPad-only.
-  LensLink picks an effect-capable format whenever your
-  resolution/frame-rate choice allows one; if the panel is still empty,
-  drop the frame rate or resolution, or switch to the front camera.
+  offers them on certain cameras and capture formats — typically the
+  front camera at moderate settings (think 1080p, not 4K), with newer
+  hardware extending more effects to more cameras (Center Stage needs
+  iPads or recent iPhones; iPhone 17-generation devices add rear-camera
+  support). The app's **Options → Camera diagnostics** table shows
+  exactly what your device offers per camera and format. LensLink picks
+  an effect-capable format whenever your resolution/frame-rate choice
+  allows one; if the panel is still empty, drop the frame rate or
+  resolution, or switch to the front camera.
   Apple's Camera-app filters and Photographic Styles aren't available
   to any third-party camera app — for creative looks, add filters to
   the source in OBS instead (right-click the source → **Filters**).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -170,8 +170,10 @@ Deliberate divergences (don't "fix" these without reading this):
   lets auto-exposure sag the frame rate in low light, like the Camera
   app's Auto FPS. A sagging cadence hurts the encoder's rate control,
   OBS timing, and the lip-sync/latency math; we hold cadence and let the
-  image get noisier instead. The thermal throttle above is the one
-  sanctioned exception.
+  image get noisier instead. Two sanctioned exceptions: the thermal
+  throttle above, and the opt-in **Allow system video effects** toggle
+  (Options), which leaves the max duration at the format default because
+  the Control Center effects appear to require that flexibility.
 - **Video stabilization stays off** (the AVCaptureVideoDataOutput
   default). Every stabilization mode adds frames of latency; this is a
   latency-first product. Revisit only as an opt-in.

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -318,16 +318,18 @@ final class CameraManager: NSObject {
     /// keep the throwing API).
     func configure(lens: Lens,
                    resolution: Resolution,
-                   fps: Int32) throws {
+                   fps: Int32,
+                   lockFrameRate: Bool = true) throws {
         try sessionQueue.sync {
             try configureOnQueue(lens: lens, resolution: resolution,
-                                 fps: fps)
+                                 fps: fps, lockFrameRate: lockFrameRate)
         }
     }
 
     private func configureOnQueue(lens: Lens,
                                   resolution: Resolution,
-                                  fps: Int32) throws {
+                                  fps: Int32,
+                                  lockFrameRate: Bool) throws {
         let position = lens.position
         session.beginConfiguration()
         defer { session.commitConfiguration() }
@@ -357,9 +359,16 @@ final class CameraManager: NSObject {
 
         try device.lockForConfiguration()
         device.activeFormat = format
+        // Min duration always caps the rate at the user's choice. The max
+        // (the cadence lock, see PERFORMANCE.md) is normally pinned too —
+        // but the "Allow system video effects" experiment leaves it at the
+        // format default, giving iOS the downward flexibility the Control
+        // Center effects appear to demand on some devices.
         let frameDuration = CMTime(value: 1, timescale: fps)
         device.activeVideoMinFrameDuration = frameDuration
-        device.activeVideoMaxFrameDuration = frameDuration
+        if lockFrameRate {
+            device.activeVideoMaxFrameDuration = frameDuration
+        }
         device.unlockForConfiguration()
         activeDevice = device
 

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -175,7 +175,8 @@ final class CameraManager: NSObject {
 
         // The device list carries near-duplicate formats whose practical
         // difference is whether the system video effects (Control Center:
-        // Portrait, Studio Light, Reactions; Center Stage on iPad) can
+        // Portrait, Studio Light, Reactions, Center Stage — all
+        // hardware-dependent, never assumed per camera) can
         // run — usually only the sensor-binned sibling supports them, and
         // picking the other one leaves the user's Video Effects panel
         // empty, which reads as a bug. Prefer the effect-capable sibling,

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -39,11 +39,13 @@ struct OptionsView: View {
                 }
 
                 Section {
+                    Toggle("Allow system video effects",
+                           isOn: $streamer.allowVideoEffects)
                     NavigationLink(destination: CameraDiagnosticsView()) {
                         Text("Camera diagnostics")
                     }
                 } footer: {
-                    Text("The camera's capture formats and which system video effects (Control Center) each supports — copy it into a bug report when an effect you expect is missing.")
+                    Text("Experimental: lets iOS lower the capture frame rate on its own, which the Control Center video effects (Portrait, Studio Light) may require. Off = the frame rate never varies. Takes effect when the camera next starts.\n\nCamera diagnostics lists the capture formats and which effects each supports — copy it into a bug report when an effect you expect is missing.")
                 }
             }
             .navigationTitle("Options")

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -76,7 +76,8 @@ final class Streamer: ObservableObject {
         do {
             try camera.configure(lens: selectedLens,
                                  resolution: resolution,
-                                 fps: Int32(fps))
+                                 fps: Int32(fps),
+                                 lockFrameRate: !allowVideoEffects)
         } catch {
             // Never swallow this: a failed reconfigure leaves the session
             // without input/output — a black stream labelled "Live".
@@ -136,6 +137,12 @@ final class Streamer: ObservableObject {
     }
     @Published var dimWhileStreaming: Bool {
         didSet { UserDefaults.standard.set(dimWhileStreaming, forKey: "dimWhileStreaming") }
+    }
+    /// Experiment: leave the max frame duration unlocked so iOS may vary
+    /// the rate downward — which the Control Center video effects appear
+    /// to require on some devices. Applies when the camera next starts.
+    @Published var allowVideoEffects: Bool {
+        didSet { UserDefaults.standard.set(allowVideoEffects, forKey: "allowVideoEffects") }
     }
     /// Send phone-mic audio as a lip-sync calibration reference (never
     /// played out — the plugin correlates it against your real mic).
@@ -484,6 +491,7 @@ final class Streamer: ObservableObject {
         codec = VideoCodec(rawValue: defaults.string(forKey: "videoCodec") ?? "")
             ?? (VideoEncoder.isSupported(.hevc) ? .hevc : .h264)
         dimWhileStreaming = defaults.object(forKey: "dimWhileStreaming") as? Bool ?? true
+        allowVideoEffects = defaults.bool(forKey: "allowVideoEffects")
         sendAudioReference = defaults.bool(forKey: "sendAudioReference")
         // didSet doesn't run during init; enforce the exclusivity here.
         sendMicAudio = defaults.bool(forKey: "sendMicAudio")
@@ -799,7 +807,8 @@ final class Streamer: ObservableObject {
         do {
             try camera.configure(lens: selectedLens,
                                  resolution: resolution,
-                                 fps: Int32(fps))
+                                 fps: Int32(fps),
+                                 lockFrameRate: !allowVideoEffects)
             try encoder.start()
         } catch {
             status = .error(error.localizedDescription)


### PR DESCRIPTION
## What & why

Continuing the empty-Video-Effects-panel investigation with field data from the reproducing iPhone 15 Pro (iOS 27): the diagnostics table shows the front camera's formats **do** advertise Portrait/Studio Light/Reactions — including the first-listed formats the picker already chose — and the rear cameras advertise nothing at all. So format selection was never the limiting factor, and the panel stays empty even on an effect-flagged format. The remaining variable separating LensLink from effect-working apps is the hard frame-duration lock (`min = max = 1/fps`).

- **New Options toggle, "Allow system video effects" (default off):** keeps the min duration (the chosen rate stays the ceiling) but leaves the max at the format default, giving iOS the downward rate flexibility the Control Center effects appear to require. Single-variable experiment: panel populates with it on → the lock was the gate and the toggle graduates to a documented feature; still empty → next bisect is a vanilla-session probe. The trade (low-light fps sag — deliberately what the cadence lock prevents) is why it defaults off; PERFORMANCE.md records it as the second sanctioned exception.
- **Center Stage wording:** the logic was already flag-driven per format on every camera, but the README and a comment said "iPad-only" — stale as of iPhone 17-generation hardware (front *and* rear Center Stage). Docs now defer to the in-app Camera diagnostics table as the per-device truth.

## How it was tested

Swift parse check locally; type check in this PR's macOS CI job. The experiment is the test: on the next TestFlight build — front camera, 1080p/30 — Control Center with the toggle off (baseline: empty) vs. on (hypothesis: populated). The reproducing device's diagnostics table is captured in the PR trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq)_