### PR TITLE
Statically link FFmpeg into the Linux release plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
   plugin-linux:
     name: OBS plugin (Linux)
     runs-on: ubuntu-latest
+    env:
+      FFMPEG_VERSION: "7.1"
     steps:
       - uses: actions/checkout@v7
 
@@ -34,20 +36,68 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake pkg-config libobs-dev qt6-base-dev \
-            libavcodec-dev libavutil-dev
+            nasm libva-dev libdrm-dev
+
+      # The release tarball has to run on every distro, but linking the
+      # runner's shared FFmpeg pins an FFmpeg-major soname
+      # (libavcodec.so.60) that rolling distros no longer ship — the
+      # plugin then fails to load at all (issue #65). So releases link a
+      # minimal static FFmpeg (H.264/HEVC decode + VAAPI, nothing else);
+      # the only FFmpeg-related runtime needs left are libva/libva-drm,
+      # whose soname has been stable since 2017 and which every
+      # VAAPI-capable system already ships.
+      - name: Cache static FFmpeg
+        id: cache-ffmpeg
+        uses: actions/cache@v6
+        with:
+          path: ffmpeg-static
+          key: ffmpeg-static-${{ env.FFMPEG_VERSION }}-decode-vaapi-v1
+
+      - name: Build static FFmpeg (H.264/HEVC decode + VAAPI only)
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+        run: |
+          curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+          tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+          cd "ffmpeg-${FFMPEG_VERSION}"
+          ./configure --prefix="$GITHUB_WORKSPACE/ffmpeg-static" \
+            --disable-everything --disable-programs --disable-doc \
+            --disable-avformat --disable-avfilter --disable-swscale \
+            --disable-swresample --disable-avdevice --disable-network \
+            --disable-debug --disable-autodetect \
+            --enable-decoder=h264,hevc --enable-parser=h264,hevc \
+            --enable-vaapi --enable-hwaccel=h264_vaapi,hevc_vaapi \
+            --enable-pic --disable-shared --enable-static
+          make -j"$(nproc)"
+          make install
 
       # The grep guard: the status-bar/dock UI degrades *silently* when Qt6
       # or obs-frontend-api.h is missing (that's how releases shipped
       # without it once) — a release build must fail instead.
+      #
+      # --exclude-libs,ALL hides the static FFmpeg's symbols in the module:
+      # the link fails without it (FFmpeg's asm uses PC-relative refs that
+      # need non-preemptible symbols), and the OBS process carries its own
+      # shared FFmpeg whose symbols must never interpose ours.
       - name: Build
         run: |
           set -o pipefail
           version="${{ inputs.tag_name || github.ref_name }}"
+          PKG_CONFIG_PATH="$GITHUB_WORKSPACE/ffmpeg-static/lib/pkgconfig" \
           cmake -B build -DCMAKE_BUILD_TYPE=Release \
-            -DLENSLINK_VERSION="${version#v}" | tee configure.log
+            -DLENSLINK_VERSION="${version#v}" \
+            -DCMAKE_MODULE_LINKER_FLAGS="-Wl,--exclude-libs,ALL" \
+            | tee configure.log
           grep -q "frontend UI enabled" configure.log
           cmake --build build
         working-directory: obs-plugin
+
+      # Fail the release if the binary regressed to soname-coupled shared
+      # FFmpeg (the exact breakage of issue #65), or lost its VAAPI link.
+      - name: Verify FFmpeg linked statically
+        run: |
+          readelf -d obs-plugin/build/lenslink.so | tee needed.log
+          ! grep -E "NEEDED.*(libavcodec|libavutil)" needed.log
+          grep -qE "NEEDED.*libva\.so" needed.log
 
       - name: Package (extract into ~/.config/obs-studio/plugins)
         run: |

--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ are the places to watch.
   Apple's Camera-app filters and Photographic Styles aren't available
   to any third-party camera app — for creative looks, add filters to
   the source in OBS instead (right-click the source → **Filters**).
+- **Plugin doesn't appear in OBS on Linux — log says
+  `libavcodec.so.60: cannot open shared object file`:** release tarballs
+  up to v1.7.x linked the build machine's FFmpeg, so they only loaded on
+  distros shipping that exact FFmpeg major (Ubuntu 24.04's FFmpeg 6). On
+  rolling distros like Arch, OBS skipped the plugin entirely. Fix: update
+  to the next release (its tarball bundles the decoder and runs on any
+  distro), or build from source with `obs-plugin/BUILDING.md` — a local
+  build links your system's own FFmpeg and always matches.
 - **Screen broadcast won't connect (sideloaded only):** re-signing can
   silently break the broadcast extension. In the app, open **Screen mirror
   tools → Check broadcast link** while a broadcast is running — it verifies

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,6 +89,15 @@ can't trigger a bump. Manual releases also work — push any `v*` tag:
 git tag v0.4.0 && git push origin v0.4.0
 ```
 
+The **Linux** release job builds its own minimal static FFmpeg
+(H.264/HEVC decode + VAAPI, cached between runs) and links it into
+`lenslink.so`, because a tarball linked against the runner's shared
+FFmpeg only loads on distros shipping that same FFmpeg major
+(issue #65 — `libavcodec.so.60` missing on Arch). The job verifies the
+binary has no `libavcodec`/`libavutil` `NEEDED` entries before
+packaging. Local/source builds are unaffected — they link the system
+FFmpeg via pkg-config, which always matches the machine they run on.
+
 ### Release notes
 
 Every release page follows a fixed template: a compact **Install** table


### PR DESCRIPTION
## What broke (#65)

The Linux release tarball was built against the Ubuntu runner's shared FFmpeg, so `lenslink.so` hard-required that machine's FFmpeg major: `libavcodec.so.60`. Arch ships FFmpeg 7.x (`libavcodec.so.61`), so `dlopen` failed and OBS silently skipped the plugin — no sources, no log lines beyond the loader error. It presented as "AMD not supported", but the reporter's AMD GPU was never involved: the plugin never loaded at all. (AMD + Mesa VAAPI is actually the best-supported Linux decode path.)

## The fix

The Linux release job now builds a **minimal static FFmpeg** and links it into the module:

- H.264/HEVC decoders + parsers and the two VAAPI hwaccels — everything else (`avformat`, filters, encoders, network, …) disabled. Adds ~2.5 MB to the module.
- The tarball's only FFmpeg-related runtime needs become `libva.so.2`/`libva-drm.so.2` — soname stable since 2017, present on any VAAPI-capable desktop.
- The FFmpeg build is cached (`actions/cache`), so steady-state release runs don't pay the compile.
- A new guard step fails the release if `libavcodec`/`libavutil` ever reappear in the binary's `NEEDED` list.
- `-Wl,--exclude-libs,ALL` on the link is load-bearing twice over: FFmpeg's x86 asm only links against non-preemptible symbols, and hiding the archive's symbols keeps the OBS process's own shared FFmpeg from interposing ours at runtime.

Local/source builds are unchanged — they still link the system FFmpeg via pkg-config, which by definition matches the machine they run on. No CMake changes were needed: the static prefix is injected purely via `PKG_CONFIG_PATH`.

Also: a README troubleshooting entry for the old tarballs' symptom, and a DEVELOPMENT.md note on why the Linux release job differs from CI.

## Verification (done locally on this branch's exact recipe)

- Plugin builds clean with `-Wall -Wextra -Werror` against static FFmpeg 7.1.
- `readelf -d`: no `libavcodec`/`libavutil` `NEEDED`, no `TEXTREL`; `libva`/`libva-drm` present.
- `nm -D`: zero `av_*`/`ff_*` symbols exported.
- `h264`, `hevc`, `h264_vaapi`, `hevc_vaapi` all baked in (verified via strings).
- dlopen smoke test: loads cleanly with `libobs.so.0` resident, the way OBS loads plugins.

## Note on shipping

This PR touches only `.github/` + docs, so merging it won't trigger an auto-release by itself. The fix reaches users with the next release — merging any `obs-plugin`/`ios-app` PR (e.g. #64) after this one, or pushing a manual `v*` tag, will produce a tarball with the static decoder.

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds2wz6ag94k59WUmtJfgxq)_