### PR TITLE
Lip-sync lock + tally light, plus beta releases and some hot-path cleanups

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,6 @@
 <!-- Releases: merging auto-releases a patch bump when obs-plugin/ or
      ios-app/ changed. For a bigger bump put `Release-Bump: minor` or
      `Release-Bump: major` on its own line in a commit message;
-     `Release-Skip: true` suppresses the release. See docs/DEVELOPMENT.md. -->
+     `Release-Skip: true` suppresses the release, and `Release-Beta: true`
+     publishes it as a pre-release (still goes to TestFlight, but isn't
+     marked Latest on GitHub). See docs/DEVELOPMENT.md. -->

--- a/.github/scripts/testflight_whats_to_test.py
+++ b/.github/scripts/testflight_whats_to_test.py
@@ -33,9 +33,22 @@ POLL_LIMIT = 30       # ~30 min; processing usually takes 5-15
 
 
 def release_notes(repo):
-    """Latest release's tag + the changelog part of its body."""
-    status, rel = gh(f"/repos/{repo}/releases/latest")
+    """The release's tag + the changelog part of its body.
+
+    RELEASE_TAG names the release this build came from. It matters for
+    pre-releases: /releases/latest is defined as the newest release that
+    is *not* a pre-release, so a beta would otherwise hand testers the
+    previous stable release's notes without any error to notice. It also
+    closes the race where another release publishes mid-upload.
+    """
+    tag = os.environ.get("RELEASE_TAG", "").strip()
+    path = f"/repos/{repo}/releases/tags/{tag}" if tag \
+        else f"/repos/{repo}/releases/latest"
+    status, rel = gh(path)
     if status != 200:
+        if tag:
+            print(f"::warning::no release found for tag {tag} "
+                  f"(HTTP {status}) — leaving 'What to Test' empty")
         return "", ""
     body = rel.get("body") or ""
     # The release body is install boilerplate followed by the

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,8 +9,17 @@ name: Auto Release
 #   Release-Bump: major   -> major (v0.3.0 -> v1.0.0)
 #   (none)                -> patch (v0.3.0 -> v0.3.1)
 #   Release-Skip: true    -> no release
+#   Release-Beta: true    -> pre-release (v0.3.0 -> v0.3.1-beta.1)
 # A trailer must be its own line, so merely *writing about* the keywords in
 # prose can never trigger a bump (that mistake shipped v1.0.0 once).
+#
+# Release-Beta publishes the same builds, from the same code, and still
+# uploads to TestFlight — TestFlight is the beta channel either way. What
+# changes is the GitHub release: it's flagged "Pre-release", so it never
+# becomes Latest and the README's version badge keeps pointing at the last
+# stable build. The tag gains a -beta.N suffix, counting up within the
+# version it is a beta *of*, so v0.3.1-beta.1, -beta.2, … all lead up to
+# the eventual stable v0.3.1 (merge without the trailer to cut it).
 on:
   push:
     branches: ["main"]
@@ -36,6 +45,7 @@ jobs:
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
       ios: ${{ steps.bump.outputs.ios }}
+      prerelease: ${{ steps.bump.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -50,7 +60,13 @@ jobs:
           # Refresh tags at the last moment: a queued run's checkout can
           # predate the previous run's tag push.
           git fetch origin --tags --quiet
-          latest=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          # Only *stable* tags seed the next number. Git's version sort puts
+          # a pre-release above the version it precedes (v1.9.0-beta.2 sorts
+          # top), and the patch field would then read "0-beta.2", which
+          # $(( )) rejects outright — so an unfiltered list doesn't just pick
+          # the wrong base, it fails the next stable release entirely.
+          latest=$(git tag --list 'v*' --sort=-v:refname \
+                   | grep -xE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           latest=${latest:-v0.1.0}
           version=${latest#v}
           IFS=. read -r major minor patch <<< "$version"
@@ -91,7 +107,23 @@ jobs:
           fi
 
           tag="v$major.$minor.$patch"
-          echo "Releasing $tag (previous: $latest)"
+
+          # Beta: same version, suffixed, counting up within it. Probing for
+          # the first free suffix (rather than counting existing ones) keeps
+          # numbering right even if a beta tag was deleted by hand.
+          if grep -qiE '^Release-Beta:[[:space:]]*true[[:space:]]*$' <<< "$messages"; then
+            n=1
+            while git rev-parse -q --verify "refs/tags/$tag-beta.$n" >/dev/null; do
+              n=$((n + 1))
+            done
+            tag="$tag-beta.$n"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Releasing $tag as a pre-release (previous stable: $latest)"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Releasing $tag (previous: $latest)"
+          fi
+
           git tag "$tag"
           git push origin "$tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
@@ -103,6 +135,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag_name: ${{ needs.version.outputs.tag }}
+      prerelease: ${{ needs.version.outputs.prerelease == 'true' }}
     permissions:
       contents: write
 
@@ -115,9 +148,16 @@ jobs:
   # byte-identical app (MARKETING_VERSION is static; only the injected
   # build number changes) — burning a macOS runner, an App Store Connect
   # build number, and a tester update notification for nothing.
+  # Betas upload here too — TestFlight *is* the beta channel, so a
+  # pre-release that skipped it would defeat the point. The tag is passed
+  # explicitly because the "What to Test" lookup otherwise falls back to
+  # /releases/latest, which by definition never returns a pre-release and
+  # would quietly hand testers the previous stable release's notes.
   testflight:
     name: TestFlight
     needs: [version, release]
     if: needs.version.outputs.tag != '' && needs.version.outputs.ios == 'true'
     uses: ./.github/workflows/testflight.yml
+    with:
+      tag: ${{ needs.version.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,15 @@ on:
         description: "Existing tag to publish the release under"
         required: true
         type: string
+      prerelease:
+        description: >-
+          Publish as a pre-release: flagged "Pre-release" on the releases
+          page and never shown as Latest, so the README badge and anyone
+          following the latest release stay on the last stable build.
+          Assets, install table and TestFlight upload are unchanged.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -383,6 +392,8 @@ jobs:
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           generate_release_notes: true
+          # A tag pushed by hand publishes a normal release, as before.
+          prerelease: ${{ inputs.prerelease || false }}
           files: |
             dist/LensLink-installer-windows-x64.exe
             dist/lenslink-windows-x64.zip

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -23,6 +23,14 @@ on:
   release:
     types: [published]
   workflow_call:
+    inputs:
+      tag:
+        description: >-
+          Release tag this build comes from, for the "What to Test" notes.
+          Required for pre-releases: the fallback lookup is
+          /releases/latest, which by definition skips them.
+        required: false
+        type: string
 
 concurrency:
   group: testflight
@@ -144,6 +152,9 @@ jobs:
           BUNDLE_ID: com.exaltedpixels.LensLinkCamera
           ASC_BETA_GROUPS: ${{ vars.ASC_BETA_GROUPS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Empty for a release-triggered or manual run, where the script
+          # falls back to /releases/latest as before.
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           # The runner's default python3 is Homebrew's, which is
           # PEP 668 "externally managed" and refuses pip installs —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,19 @@ Read the matching doc before touching an area:
   backpressure). Performance PRs must quote benchmark numbers
   (`tools/bench-report.py`).
 - `docs/DEVELOPMENT.md` — architecture, repo layout, CI, release automation.
+- `docs/ROADMAP.md` (planned work — check before designing a feature),
+  `docs/TESTFLIGHT.md` (App Store Connect / TestFlight automation),
+  `docs/DEBUGGING-SCREEN-MIRROR.md` (the broadcast extension's failure
+  modes, which are hard to observe from the app).
+
+### Things that must change together
+
+| Change | Also update |
+|--------|-------------|
+| Wire protocol | `docs/PROTOCOL.md` + `obs-plugin/src/protocol.h` + `ios-app/Sources/Protocol.swift` (the constants/enums are hand-mirrored, not generated) |
+| Design tokens, status vocabulary | `docs/UI_DESIGN.md` + `ios-app/Sources/DesignSystem.swift` + the inline page in `obs-plugin/src/web-control.c` |
+| Any plugin-visible string | `obs-plugin/data/locale/en-US.ini` |
+| A control the user can set from more than one place | app UI, web panel, and source properties all read the same cached STATE — add the field to STATE, not to one surface |
 
 ## Commands
 
@@ -67,6 +80,10 @@ CI builds with `-Wall -Wextra -Werror`, so use those flags locally to match.
 `qt6-base-dev` is optional — the status-bar/dock UI (`frontend-ui.cpp`)
 compiles only when Qt6 is found; the rest must build and work without it.
 
+New `.c` files must be added to the `add_library()` list in
+`obs-plugin/CMakeLists.txt` — there is no globbing. `LENSLINK_VERSION`
+defaults to `"dev"`; CI passes the release tag.
+
 ### iOS app: full build (macOS only)
 
 ```bash
@@ -74,7 +91,20 @@ brew install xcodegen
 cd ios-app && xcodegen generate && open LensLink.xcodeproj
 ```
 
-Details (signing, older Xcode): `ios-app/BUILDING.md`.
+New files under `Sources/` are picked up automatically, but anything the
+**broadcast extension** also needs must be listed explicitly under
+`LensLinkBroadcast.sources` in `ios-app/project.yml` (today: `Protocol.swift`,
+`StreamClient.swift`, `VideoEncoder.swift`). Details (signing, older Xcode):
+`ios-app/BUILDING.md`.
+
+### Performance measurements
+
+Enable "Log pipeline benchmark numbers" (Tools → LensLink Settings) and the
+plugin writes `bench-<pipeline>-<epoch>.csv` (one row per second of live
+video) into the OBS plugin config dir — `pipeline-bench.c`. Compare a
+before/after pair with `python3 tools/bench-report.py BEFORE.csv AFTER.csv`
+(standard library only). That pairing is what a performance PR is expected
+to quote.
 
 ## CI and releases
 
@@ -133,6 +163,13 @@ and idle, waiting for remote start". Points that shape the code:
   plus `/api/state` and `/api/control`.
 - `plugin-settings.c` holds plugin-wide settings (Tools → LensLink
   Settings); global settings are never duplicated in per-source properties.
+- `frontend-ui.cpp` (Qt, optional — guarded by `LENSLINK_FRONTEND`) draws
+  the status-bar readout and the LensLink dock. It resolves the five
+  obs-frontend-api symbols at runtime rather than linking a frontend
+  library, and reads state only through the `health.h` snapshot API — keep
+  that boundary; nothing else may reach across it.
+- `net-compat.h` is the Winsock/BSD-socket shim; use it instead of
+  platform `#ifdef`s in new code.
 - Locale strings: `obs-plugin/data/locale/en-US.ini`.
 
 ### iOS app (ios-app/Sources/)
@@ -149,6 +186,11 @@ and idle, waiting for remote start". Points that shape the code:
 - The app only streams while foregrounded (iOS suspends background camera
   capture); the remote-start machinery (standby HELLO + `start_stream`)
   exists because of this.
+- Deployment target is iOS 15, but `RemoteStartIntents.swift` uses
+  AppIntents (iOS 16+): it is weak-linked via `OTHER_LDFLAGS` in
+  `project.yml` and must stay `@available`-gated, or the app won't launch
+  on iOS 15. The `lenslink://start` / `lenslink://stop` URL scheme is the
+  iOS 15 fallback path for the same feature.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,10 @@ to quote.
   `Release-Bump: major`, or `Release-Skip: true` (no release). Mind this
   when writing commit messages. The TestFlight upload runs only when the
   merge touched `ios-app/`.
+- `Release-Beta: true` publishes the same builds as a **pre-release**
+  (`v1.8.2-beta.1`) — still uploaded to TestFlight, but never "Latest" on
+  GitHub. Betas count up within a version; merging without the trailer
+  cuts the stable release. Details: `docs/DEVELOPMENT.md`.
 - **Never manually dispatch** `testflight.yml` or anything that creates
   releases/tags — a run uploads a real build to TestFlight / publishes a
   real release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,9 @@ surfaces follow).
 Merging to `main` releases automatically when `obs-plugin/` or `ios-app/`
 changed: a patch bump by default, or the bump named by a
 `Release-Bump: minor` / `Release-Bump: major` trailer line in a commit of
-the PR (`Release-Skip: true` suppresses it). Details in
+the PR (`Release-Skip: true` suppresses it). `Release-Beta: true` publishes
+it as a pre-release instead — same builds, still uploaded to TestFlight,
+but not marked "Latest" on GitHub. Details in
 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#releases).
 
 ## Bugs and ideas

--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ exact offset and correct it. If your mic is *slower* than the video (some
 USB audio interfaces are), enable **Auto video delay** and it delays the
 video to match instead.
 
+It settles after about fifteen seconds of talking and then locks on. From
+there your microphone's own delay is a known quantity, so the correction
+keeps following the camera's latency by itself — through silence, and
+straight after a reconnect — instead of waiting for you to speak again. It
+re-checks periodically and recalibrates on its own if you change audio gear
+mid-stream.
+
 Prefer a fixed correction? Leave **Auto-calibrate** off and the delay
 checkbox alone shifts your mic by the measured camera latency; if your
 audio device adds its own delay, enter it under **Audio device's own

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,12 +75,44 @@ touched `ios-app/`.
 The bump is a **git trailer** on its own line in any commit of the merged
 PR (case-insensitive):
 
-| Trailer line          | Bump   | Example           |
-|-----------------------|--------|-------------------|
-| *(none)*              | patch  | v0.3.0 → v0.3.1   |
-| `Release-Bump: minor` | minor  | v0.3.0 → v0.4.0   |
-| `Release-Bump: major` | major  | v0.3.0 → v1.0.0   |
-| `Release-Skip: true`  | none   | no release        |
+| Trailer line          | Bump   | Example                 |
+|-----------------------|--------|-------------------------|
+| *(none)*              | patch  | v0.3.0 → v0.3.1         |
+| `Release-Bump: minor` | minor  | v0.3.0 → v0.4.0         |
+| `Release-Bump: major` | major  | v0.3.0 → v1.0.0         |
+| `Release-Skip: true`  | none   | no release              |
+| `Release-Beta: true`  | *(as above)*, pre-release | v0.3.0 → v0.3.1-beta.1 |
+
+### Beta releases
+
+`Release-Beta: true` ships everything a normal release does — same builds,
+same assets, **same TestFlight upload** (TestFlight is the beta channel
+either way) — but publishes the GitHub release flagged **Pre-release**. A
+pre-release never becomes "Latest", so the README's version badge and
+anyone downloading the latest release stay on the last stable build until
+you cut one.
+
+The tag gains a `-beta.N` suffix inside the version it is a beta *of*, and
+`N` counts up as you iterate:
+
+```
+v1.8.1                    <- last stable
+v1.8.2-beta.1             merge with Release-Beta: true
+v1.8.2-beta.2             merge again with Release-Beta: true
+v1.8.2                    merge without it — the beta becomes the release
+```
+
+Combine it with a bump trailer to beta a bigger version:
+`Release-Bump: minor` + `Release-Beta: true` → `v1.9.0-beta.1`.
+
+Two details worth knowing. The next version is computed from **stable tags
+only** — git's version sort puts `v1.9.0-beta.2` *above* `v1.9.0`, and the
+patch field would read `0-beta.2`, which the shell can't add 1 to, so an
+unfiltered list would fail the next stable release outright. And the
+TestFlight "What to Test" notes are looked up **by tag**, because the
+`/releases/latest` endpoint is defined as the newest non-pre-release and
+would otherwise hand testers the previous stable release's changelog with
+nothing to indicate it had.
 
 Because it must be a standalone line, mentioning the keywords in prose
 can't trigger a bump. Manual releases also work — push any `v*` tag:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -70,6 +70,15 @@ should add as close to zero as possible.
   independent accumulators, because one `double` accumulator serializes
   the loop on FP-add latency regardless of how little else it does.
   Together: 1.51 ms → 0.90 ms per estimate, bit-identical results.
+- It also runs **far less often**. What it measures — the mic's latency —
+  is a property of the audio gear, while the number that actually moves
+  is the video latency timesync already tracks for free. So the mic
+  figure is latched once confident and the offset is re-derived from
+  latency alone; the correlation returns only every 90 s to confirm the
+  latched figure still holds (`lipsync-cal.h`). Over a quiet ten-minute
+  stretch that is 6 correlations instead of 120 — and, more importantly,
+  120 offset updates instead of none, since tracking no longer waits on
+  someone talking.
 - Effect parameter handles are resolved **once**, with the effect, not per
   render (`yuv_effect()`). `video_render` runs per source per rendered
   frame on the graphics thread — the thread the whole compositor waits

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -43,6 +43,11 @@ should add as close to zero as possible.
 - Idle standby listener costs nothing measurable: no timers, no camera —
   just an accepting socket and 1 Hz timesync replies while OBS is
   connected.
+- The health overlay's `@Published` sample is only written while the
+  overlay is on screen (off by default). A 1 Hz publish on the main actor
+  invalidates the whole Live view once a second, which is exactly the
+  wakeup "dimmed = GPU idle" is trying to avoid; the counters advance
+  regardless, so switching it on still reads correctly a second later.
 
 **OBS plugin**
 - The receive buffer is parsed **in place**; video packets go to
@@ -57,6 +62,18 @@ should add as close to zero as possible.
   timesync (1 Hz), control forwarding, and diagnostics all piggyback on
   that loop — no extra threads or timers.
 - The web panel is a 1 Hz poll of two tiny JSON endpoints on loopback.
+- Lip-sync cross-correlation runs **on the dial-loop thread**, so its cost
+  is a hole in the video receive path, not spare CPU. Two things keep it
+  small (`lipsync.c`): the mic window's energy comes from a prefix sum
+  (successive lags overlap almost completely — recomputing it per lag was
+  a second pass over the whole window), and the dot product uses four
+  independent accumulators, because one `double` accumulator serializes
+  the loop on FP-add latency regardless of how little else it does.
+  Together: 1.51 ms → 0.90 ms per estimate, bit-identical results.
+- Effect parameter handles are resolved **once**, with the effect, not per
+  render (`yuv_effect()`). `video_render` runs per source per rendered
+  frame on the graphics thread — the thread the whole compositor waits
+  on — and `gs_effect_get_param_by_name` is a by-name lookup.
 
 ## How to measure (before optimizing further)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -105,6 +105,7 @@ Camera remote control. Payload: UTF-8 JSON, one command per packet:
 { "cmd": "stop_stream" }
 { "cmd": "set_format", "resolution": "1080p", "fps": 60, "codec": "hevc" }
 { "cmd": "mic", "id": "builtin:2" }
+{ "cmd": "tally", "program": true, "preview": false, "sync": "locked" }
 ```
 
 `set_format` switches the capture format mid-stream; any subset of its
@@ -121,6 +122,21 @@ mid-stream. Ids come from the STATE snapshot's `mics` list: `"auto"`
 Bottom/Front/Back), or `"port:<uid>"` (an external input). The app
 validates the id against the live list and ignores stale ones (e.g. a
 Bluetooth mic that just disconnected).
+
+`tally` drives the app's on-air light and its lip-sync readout. `program`
+is true while the source is part of what OBS is actually sending out;
+`preview` is true when it's visible somewhere else (preview, a projector)
+but not on air — the two are mutually exclusive, and both false means
+neither. `sync` reports auto lip-sync calibration as one of `"off"`,
+`"measuring"`, `"locked"` or `"relocking"` (see docs/UI_DESIGN.md for the
+words and colours each maps to).
+
+Unlike the camera commands, `tally` is sent **on change** rather than on
+request, and re-announced on every new connection — a device is never
+assumed to remember what it was last told. The app clears the light
+whenever the connection drops, so a stale "live" can't outlive the OBS
+that set it. Screen-mirror connections receive it too and ignore it: the
+broadcast extension has no UI.
 
 Unknown commands are ignored, so new ones can be added compatibly. The
 plugin's embedded web panel (http://localhost:9980) generates these.

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -71,6 +71,48 @@ The status **word and colour are defined once** (`Streamer.Status.displayName`
 / `.tint` in the app) and reused by every view; the web panel maps the
 plugin's status string to the same palette.
 
+### Tally (on air)
+
+| State   | Token          | Hex       | Treatment |
+|---------|----------------|-----------|-----------|
+| Live    | `tallyLive`    | `#FF3B30` | 6 pt border around the whole Live screen |
+| Preview | `tallyPreview` | `#FF9F0A` | 4 pt border (same as `connectAmber`) |
+| Neither | —              | —         | No border drawn |
+
+The tally answers one question — *am I on air?* — and must never be
+ambiguous, so it is **its own indicator**, not a mode of the status dot,
+and it carries no other meaning. It's a border rather than a dot because
+it has to read at arm's length from a phone mounted behind a monitor, and
+it draws **above the dim overlay**: the screen dims after ten seconds
+exactly when the operator is furthest away. An unlit tally is as
+meaningful as a lit one, so "not on air" draws nothing at all rather than
+a grey border that could be mistaken for a dark red one.
+
+`tallyLive` is deliberately separate from `errorRed` despite both being
+red today: on air is not an error, and the two must stay independently
+adjustable. Preview reuses `connectAmber` — it means the same thing the
+amber statuses do, "linked, not yet live".
+
+### Lip-sync calibration (dot + label)
+
+| State      | Token          | Hex       | Label            |
+|------------|----------------|-----------|------------------|
+| Off        | —              | —         | *(nothing shown)* |
+| Measuring  | `accent`       | `#3D7BFF` | "Measuring sync" |
+| Locked     | `liveGreen`    | `#30D158` | "Sync locked"    |
+| Relocking  | `connectAmber` | `#FF9F0A` | "Recalibrating"  |
+
+Shown on the Live screen beside the status pill, and in the web panel's
+header as a second pill. Blue reads as *working on it*, green as *done*,
+amber as *attention, transitional* — the same reading those colours carry
+elsewhere in the product. Nothing is drawn when auto-calibrate isn't
+running, so setups that don't use it never see a readout they'd have to
+learn to ignore.
+
+The plugin owns these states (`lipsync-cal.h`) and pushes them to the app
+in the `tally` command's `sync` field; the web panel reads the same value
+from `/api/status`.
+
 ### Surfaces (dark / over-video)
 | Token          | Value                                   | Use |
 |----------------|-----------------------------------------|-----|

--- a/ios-app/Sources/DesignSystem.swift
+++ b/ios-app/Sources/DesignSystem.swift
@@ -13,6 +13,13 @@ enum Theme {
     static let liveGreen = Color(hex: 0x30D158)
     static let errorRed = Color(hex: 0xFF453A)
 
+    /// Tally. Deliberately its own token rather than `errorRed`: on air is
+    /// not an error, and the two must stay independently adjustable even
+    /// though both are red today. Preview borrows `connectAmber` — same
+    /// "linked, not yet live" meaning it already carries.
+    static let tallyLive = Color(hex: 0xFF3B30)
+    static let tallyPreview = connectAmber
+
     // Over-video surfaces
     static let glassPanel = Color.black.opacity(0.55)
     static let glassChip = Color.white.opacity(0.12)

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -3,6 +3,16 @@ import AVFoundation
 import Combine
 import SwiftUI
 
+/// Defaults keys shared between the streamer and the views. Kept out of
+/// `Streamer` (which is `@MainActor`) so a `@AppStorage` property
+/// initializer can reference them without an isolation hop.
+enum StreamerDefaults {
+    /// Whether the Live screen shows the health pill. StreamingView owns it
+    /// via `@AppStorage`; the streamer reads it to decide whether sampling
+    /// health is worth waking SwiftUI for.
+    static let showHealth = "showStreamHealth"
+}
+
 /// Glues camera → encoder → network together and exposes state for SwiftUI.
 @MainActor
 final class Streamer: ObservableObject {
@@ -435,6 +445,10 @@ final class Streamer: ObservableObject {
         var droppedFrames = 0
     }
 
+    /// Only published while the overlay is actually on screen. It's a 1 Hz
+    /// `@Published` write on the main actor, so publishing it unwatched
+    /// invalidates the whole Live view once a second for a value nothing
+    /// reads — including while dimmed, which is meant to be idle.
     @Published private(set) var health: StreamHealth?
     /// Counters are cumulative across connections; baseline them at each
     /// stream start so the overlay shows this stream's drops, not the
@@ -885,19 +899,30 @@ final class Streamer: ObservableObject {
             var current = target
             var stableSeconds = 0
             var previousStats: StreamClient.Stats?
+            var healthWasVisible = false
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 guard let self, self.isStreaming else { break }
 
                 // Health overlay sample: per-second deltas of the send
-                // counters (the sleep above sets the 1 s window).
+                // counters (the sleep above sets the 1 s window). Skipped
+                // while the overlay is off — the counters keep advancing
+                // either way, so turning it on still reads correctly one
+                // second later.
                 let stats = self.client.statsSnapshot()
-                if let previous = previousStats {
+                let healthVisible = UserDefaults.standard.bool(
+                    forKey: StreamerDefaults.showHealth)
+                if healthVisible, let previous = previousStats {
                     self.health = StreamHealth(
                         fps: max(0, stats.framesSent - previous.framesSent),
                         megabitsPerSecond: Double(max(0, stats.bytesSent - previous.bytesSent)) * 8 / 1_000_000,
                         droppedFrames: max(0, stats.framesDropped - self.healthDroppedBaseline))
+                } else if healthWasVisible {
+                    // Cleared once on hide, so re-enabling can't flash the
+                    // reading from whenever it was last switched off.
+                    self.health = nil
                 }
+                healthWasVisible = healthVisible
                 previousStats = stats
 
                 let effectiveTarget = max(

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -436,6 +436,31 @@ final class Streamer: ObservableObject {
     @Published private(set) var isStreaming = false
     @Published var cameraPermissionDenied = false
 
+    /// Tally: what OBS is doing with this camera right now. `live` means it
+    /// is part of the program — what the audience sees. `preview` means it
+    /// is visible somewhere (preview, a projector) but not on air.
+    enum Tally: String {
+        case off
+        case preview
+        case live
+    }
+
+    /// Lip-sync auto-calibration progress, as reported by the plugin. The
+    /// plugin measures the microphone's latency, locks it in, and then
+    /// tracks the camera latency on its own — these are the stages of that
+    /// (see docs/UI_DESIGN.md for the vocabulary and colours).
+    enum SyncState: String {
+        case off
+        case measuring
+        case locked
+        case relocking
+    }
+
+    /// Pushed by the plugin on change only, so these cost nothing while
+    /// they're steady.
+    @Published private(set) var tally: Tally = .off
+    @Published private(set) var syncState: SyncState = .off
+
     /// Per-second stream health for the Live screen's optional overlay.
     /// Sampled by the adaptive-bitrate loop (already 1 Hz), so the overlay
     /// costs nothing beyond what's measured anyway.
@@ -662,6 +687,16 @@ final class Streamer: ObservableObject {
             if remoteStartEnabled, isStreaming {
                 stop()
             }
+            return
+        case "tally":
+            // Handled before the isStreaming guard: the plugin announces
+            // tally on connect, which for a remote-start setup is while
+            // the app is still idle in standby.
+            let program = command["program"] as? Bool ?? false
+            let preview = command["preview"] as? Bool ?? false
+            tally = program ? .live : (preview ? .preview : .off)
+            syncState = (command["sync"] as? String)
+                .flatMap(SyncState.init(rawValue:)) ?? .off
             return
         default:
             break
@@ -964,6 +999,8 @@ final class Streamer: ObservableObject {
         adaptiveTask?.cancel()
         adaptiveTask = nil
         health = nil
+        tally = .off
+        syncState = .off
         if flashlightOn {
             flashlightOn = false
         }
@@ -988,6 +1025,14 @@ final class Streamer: ObservableObject {
 
     private func handleClientState(_ state: StreamClient.State) {
         lastClientState = state
+        // Tally is only ever as true as the connection carrying it. A
+        // "live" light left burning after OBS went away is worse than no
+        // light at all, so any state but `connected` clears it; the plugin
+        // re-announces on the next connection.
+        if case .connected = state {} else {
+            tally = .off
+            syncState = .off
+        }
         guard isStreaming else {
             handleStandbyClientState(state)
             return

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -12,8 +12,9 @@ struct StreamingView: View {
     @State private var pinchBaseZoom: CGFloat = 1
     @State private var previousBrightness: CGFloat = UIScreen.main.brightness
     /// Stream health pill (fps · Mb/s · dropped). Persisted: someone who
-    /// turns it on is debugging and wants it next stream too.
-    @AppStorage("showStreamHealth") private var showHealth = false
+    /// turns it on is debugging and wants it next stream too. The streamer
+    /// reads the same key to decide whether to sample health at all.
+    @AppStorage(StreamerDefaults.showHealth) private var showHealth = false
 
     private static let dimAfterSeconds: TimeInterval = 10
 

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -64,6 +64,11 @@ struct StreamingView: View {
             if dimmed {
                 dimOverlay
             }
+
+            // Above the dim overlay on purpose: a phone mounted out of
+            // reach dims itself after ten seconds, and that is exactly
+            // when knowing you're on air matters most.
+            tallyBorder
         }
         .statusBar(hidden: true)
         .task {
@@ -115,6 +120,32 @@ struct StreamingView: View {
         .onTapGesture { undim() }
     }
 
+    /// Tally: a border round the whole screen, readable at arm's length
+    /// from behind a monitor where a small dot wouldn't be. Red is on air,
+    /// amber is in preview, and nothing is drawn otherwise — an unlit
+    /// tally has to be as unambiguous as a lit one.
+    @ViewBuilder private var tallyBorder: some View {
+        switch streamer.tally {
+        case .live:
+            tallyEdge(Theme.tallyLive, width: 6)
+        case .preview:
+            tallyEdge(Theme.tallyPreview, width: 4)
+        case .off:
+            EmptyView()
+        }
+    }
+
+    private func tallyEdge(_ colour: Color, width: CGFloat) -> some View {
+        // allowsHitTesting(false): the border sits over the preview, and
+        // tap-to-focus near the screen edge must still reach it.
+        Rectangle()
+            .strokeBorder(colour, lineWidth: width)
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+            .transition(.opacity)
+            .animation(.easeInOut(duration: 0.15), value: streamer.tally)
+    }
+
     private var statusBar: some View {
         HStack(spacing: Theme.Space.m) {
             HStack(spacing: Theme.Space.s) {
@@ -126,6 +157,19 @@ struct StreamingView: View {
                     .lineLimit(1)
             }
             .glassPill()
+
+            if let sync = syncLabel {
+                HStack(spacing: Theme.Space.s) {
+                    Circle()
+                        .fill(sync.colour)
+                        .frame(width: 8, height: 8)
+                    Text(sync.text)
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+                .glassPill()
+                .foregroundColor(Theme.textSecondary)
+            }
 
             Spacer()
 
@@ -149,6 +193,22 @@ struct StreamingView: View {
             }
         }
         .foregroundColor(Theme.textPrimary)
+    }
+
+    /// Lip-sync calibration, shown only while it has something to say —
+    /// nothing appears unless auto-calibrate is running in OBS. Wording and
+    /// colours come from docs/UI_DESIGN.md and match the web panel's pill.
+    private var syncLabel: (text: String, colour: Color)? {
+        switch streamer.syncState {
+        case .off:
+            return nil
+        case .measuring:
+            return ("Measuring sync", Theme.accent)
+        case .locked:
+            return ("Sync locked", Theme.liveGreen)
+        case .relocking:
+            return ("Recalibrating", Theme.connectAmber)
+        }
     }
 
     /// One-line health readout under the status bar: encoder output rate,

--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(${PROJECT_NAME} MODULE
   src/protocol.h
   src/web-control.h
   src/lipsync.h
+  src/lipsync-cal.h
   src/net-compat.h
   src/h264-decoder.h
   src/usbmux.h

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -24,6 +24,7 @@
 #include "usbmux.h"
 #include "web-control.h"
 #include "lipsync.h"
+#include "lipsync-cal.h"
 #include "plugin-settings.h"
 #include "gpu-frame.h"
 #include "pipeline-bench.h"
@@ -145,6 +146,25 @@ struct ios_camera_source {
 	 * median smoothing before applying an offset. */
 	int64_t cal_hist[5];
 	int cal_count;
+
+	/*
+	 * Latched mic latency. The correlation recovers a property of the
+	 * streamer's audio gear (interface buffering, driver, OBS's audio
+	 * path) — not of the link — because it compares timestamps already
+	 * translated into a common clock. It therefore doesn't change while
+	 * the audio path doesn't. Video latency *does* change, and timesync
+	 * measures it every second for free, so once the mic figure is known
+	 * the offset can be re-derived from latency alone: offset = video
+	 * latency - mic latency, applied whether or not anyone is talking.
+	 * That both removes a repeated correlation of a constant and fixes a
+	 * real gap — before, a latency change during silence went uncorrected
+	 * because no confident reading arrived to trigger an update.
+	 * cal_verified_ns is network-thread only; the rest is status_mutex.
+	 */
+	bool cal_locked;
+	int64_t cal_locked_mic_ns;
+	uint64_t cal_verified_ns; /* last correlation run while locked */
+	enum lipsync_cal_state cal_state;
 
 	/* Remote-control commands queued for the device (JSON strings),
 	 * pushed by the web control thread, drained by the stream thread.
@@ -689,8 +709,8 @@ static void hook_audio(struct ios_camera_source *s, const char *name)
 	obs_source_release(src);
 }
 
-#define CAL_MIN_CONFIDENCE 0.5
-#define CAL_NS_MS 1000000LL
+/* Calibration policy (states, thresholds, the lock/verify decisions) lives
+ * in lipsync-cal.h, free of libobs so it can be exercised standalone. */
 
 /*
  * Adds/updates/removes a private "Video Delay (Async)" filter on our own
@@ -758,90 +778,31 @@ static int cmp_i64(const void *a, const void *b)
 	return (x > y) - (x < y);
 }
 
-/*
- * Cross-correlation result drives the offset. A single measurement is
- * noisy, so we gate on confidence and smooth over recent measurements
- * (median of the last few, only when they agree) before applying. Then
- * offset = videoLatency - micLatency; if the mic is actually slower than
- * the video path, audio delay can't help and we say so.
- */
-static void apply_auto_calibrated(struct ios_camera_source *s,
-				  int64_t video_latency_ns)
+/* Records the calibration stage for the user-facing readouts. */
+static void set_cal_state(struct ios_camera_source *s,
+			  enum lipsync_cal_state state)
 {
-	char name[256];
-
 	pthread_mutex_lock(&s->status_mutex);
-	bool enabled = s->audio_sync && s->auto_calibrate;
-	bool video_delay = s->auto_video_delay;
-	snprintf(name, sizeof(name), "%s", s->audio_source);
-	int64_t applied = s->applied_audio_offset;
+	s->cal_state = state;
 	pthread_mutex_unlock(&s->status_mutex);
+}
 
-	if (!enabled || !name[0])
-		return;
-
-	/* Hold the mutex only for a snapshot: the correlation is ~1.8M
-	 * multiply-adds, and the OBS audio callback blocks on this lock. */
-	int64_t mic_delay = 0;
-	double conf = 0;
-	pthread_mutex_lock(&s->lipsync_mutex);
-	struct lipsync *snap = s->lipsync ? lipsync_clone(s->lipsync) : NULL;
-	pthread_mutex_unlock(&s->lipsync_mutex);
-
-	bool ok = snap && lipsync_estimate(snap, &mic_delay, &conf);
-	lipsync_destroy(snap);
-
-	if (!ok) {
-		blog(LOG_INFO,
-		     "[lenslink] auto lip-sync: no reading (need the app's "
-		     "'Auto lip-sync reference' on, plus speech/sound)");
-		return;
-	}
-	if (conf < CAL_MIN_CONFIDENCE) {
-		blog(LOG_INFO,
-		     "[lenslink] auto lip-sync: mic ~%d ms but low "
-		     "confidence %.2f — ignoring (keep talking / raise mic "
-		     "level)",
-		     (int)(mic_delay / CAL_NS_MS), conf);
-		return;
-	}
-
-	/* Accumulate confident readings; require agreement before acting. */
-	int n = s->cal_count < 5 ? s->cal_count : 5;
-	if (n == 5)
-		memmove(&s->cal_hist[0], &s->cal_hist[1], sizeof(int64_t) * 4);
-	s->cal_hist[n < 5 ? n : 4] = mic_delay;
-	if (s->cal_count < 5)
-		s->cal_count++;
-
-	if (s->cal_count < 3) {
-		blog(LOG_INFO,
-		     "[lenslink] auto lip-sync: mic ~%d ms (conf %.2f), "
-		     "collecting %d/3…",
-		     (int)(mic_delay / CAL_NS_MS), conf, s->cal_count);
-		return;
-	}
-
-	int64_t sorted[5];
-	memcpy(sorted, s->cal_hist, sizeof(int64_t) * (size_t)s->cal_count);
-	qsort(sorted, (size_t)s->cal_count, sizeof(int64_t), cmp_i64);
-	int64_t median = sorted[s->cal_count / 2];
-	int64_t spread = sorted[s->cal_count - 1] - sorted[0];
-
-	if (spread > 40 * CAL_NS_MS) {
-		blog(LOG_INFO,
-		     "[lenslink] auto lip-sync: readings unstable "
-		     "(spread %d ms) — holding",
-		     (int)(spread / CAL_NS_MS));
-		return;
-	}
-
-	int64_t offset = video_latency_ns - median;
+/*
+ * offset = videoLatency - micLatency, applied to the chosen OBS audio
+ * source. If the mic is actually slower than the video path, audio delay
+ * can't help and we say so (or delay the video instead, when enabled).
+ */
+static void apply_calibrated_offset(struct ios_camera_source *s,
+				    int64_t video_latency_ns,
+				    int64_t mic_delay_ns, const char *name,
+				    bool video_delay, int64_t applied,
+				    bool from_lock, double conf)
+{
+	int64_t offset = video_latency_ns - mic_delay_ns;
 	bool mic_slower = offset < 0;
-	int video_delay_ms = mic_slower
-				     ? (int)((median - video_latency_ns) /
-					     CAL_NS_MS)
-				     : 0;
+	int video_delay_ms =
+		mic_slower ? (int)((mic_delay_ns - video_latency_ns) / CAL_NS_MS)
+			   : 0;
 	if (mic_slower)
 		offset = 0;
 
@@ -864,29 +825,191 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	if (video_delay)
 		set_video_delay(s, video_delay_ms);
 
+	/* Tracking a latency change against an already-known mic figure is
+	 * routine and happens every window — only log when something is
+	 * actually applied, or the log would fill with unchanged values. */
+	if (from_lock && diff < 5 * CAL_NS_MS)
+		return;
+
 	if (mic_slower && video_delay) {
 		blog(LOG_INFO,
 		     "[lenslink] auto lip-sync: mic %d ms > video %d ms -> "
 		     "delaying video by %d ms (conf %.2f)",
-		     (int)(median / CAL_NS_MS),
-		     (int)(video_latency_ns / CAL_NS_MS), video_delay_ms,
-		     conf);
+		     (int)(mic_delay_ns / CAL_NS_MS),
+		     (int)(video_latency_ns / CAL_NS_MS), video_delay_ms, conf);
 	} else if (mic_slower) {
 		blog(LOG_WARNING,
 		     "[lenslink] auto lip-sync: mic latency %d ms exceeds "
 		     "video %d ms — audio can't be delayed to match. Enable "
 		     "'Auto video delay' to delay the video ~%d ms, or use a "
 		     "lower-latency mic.",
-		     (int)(median / CAL_NS_MS),
+		     (int)(mic_delay_ns / CAL_NS_MS),
 		     (int)(video_latency_ns / CAL_NS_MS), video_delay_ms);
+	} else if (from_lock) {
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: video latency now %d ms, mic "
+		     "%d ms (locked) -> '%s' offset %d ms",
+		     (int)(video_latency_ns / CAL_NS_MS),
+		     (int)(mic_delay_ns / CAL_NS_MS), name,
+		     (int)(offset / CAL_NS_MS));
 	} else {
 		blog(LOG_INFO,
 		     "[lenslink] auto lip-sync: mic %d ms, video %d ms -> "
 		     "'%s' offset %d ms (conf %.2f)",
-		     (int)(median / CAL_NS_MS),
+		     (int)(mic_delay_ns / CAL_NS_MS),
 		     (int)(video_latency_ns / CAL_NS_MS), name,
 		     (int)(offset / CAL_NS_MS), conf);
 	}
+}
+
+/*
+ * Runs on each stable latency window. Two phases:
+ *
+ *  - Measuring. A single correlation is noisy, so gate on confidence and
+ *    smooth over recent readings (median of the last few, only when they
+ *    agree) before latching the mic's latency.
+ *  - Locked. The latched figure is a property of the audio gear, so the
+ *    offset just tracks the video latency from here on — no correlation,
+ *    and no dependence on the streamer making noise. The correlation
+ *    re-runs only every CAL_VERIFY_INTERVAL_NS, purely to notice if the
+ *    audio path changed underneath us (a re-plugged interface, a headset
+ *    taking over) and re-measure if so.
+ */
+static void apply_auto_calibrated(struct ios_camera_source *s,
+				  int64_t video_latency_ns)
+{
+	char name[256];
+
+	pthread_mutex_lock(&s->status_mutex);
+	bool enabled = s->audio_sync && s->auto_calibrate;
+	bool video_delay = s->auto_video_delay;
+	snprintf(name, sizeof(name), "%s", s->audio_source);
+	int64_t applied = s->applied_audio_offset;
+	bool locked = s->cal_locked;
+	int64_t locked_mic = s->cal_locked_mic_ns;
+	pthread_mutex_unlock(&s->status_mutex);
+
+	if (!enabled || !name[0]) {
+		set_cal_state(s, LS_CAL_OFF);
+		return;
+	}
+
+	uint64_t now = os_gettime_ns();
+
+	if (locked) {
+		apply_calibrated_offset(s, video_latency_ns, locked_mic, name,
+					video_delay, applied, true, 0);
+		if (!lipsync_cal_due_for_verify(now, s->cal_verified_ns))
+			return;
+	}
+
+	/* Hold the mutex only for a snapshot: the correlation is ~1.8M
+	 * multiply-adds, and the OBS audio callback blocks on this lock. */
+	int64_t mic_delay = 0;
+	double conf = 0;
+	pthread_mutex_lock(&s->lipsync_mutex);
+	struct lipsync *snap = s->lipsync ? lipsync_clone(s->lipsync) : NULL;
+	pthread_mutex_unlock(&s->lipsync_mutex);
+
+	bool ok = snap && lipsync_estimate(snap, &mic_delay, &conf);
+	lipsync_destroy(snap);
+
+	/* While locked, a missing or unconvincing reading means nothing — it
+	 * usually just means nobody is talking. The lock stands; try again at
+	 * the next verification interval. */
+	if (!ok) {
+		if (locked) {
+			s->cal_verified_ns = now;
+			return;
+		}
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: no reading (need the app's "
+		     "'Auto lip-sync reference' on, plus speech/sound)");
+		return;
+	}
+	if (conf < CAL_MIN_CONFIDENCE) {
+		if (locked) {
+			s->cal_verified_ns = now;
+			return;
+		}
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: mic ~%d ms but low "
+		     "confidence %.2f — ignoring (keep talking / raise mic "
+		     "level)",
+		     (int)(mic_delay / CAL_NS_MS), conf);
+		return;
+	}
+
+	if (locked) {
+		s->cal_verified_ns = now;
+		if (!lipsync_cal_reading_invalidates(mic_delay, locked_mic))
+			return; /* still the same audio path */
+
+		blog(LOG_WARNING,
+		     "[lenslink] auto lip-sync: mic latency moved %d ms -> "
+		     "%d ms (conf %.2f) — the audio path changed, "
+		     "recalibrating",
+		     (int)(locked_mic / CAL_NS_MS), (int)(mic_delay / CAL_NS_MS),
+		     conf);
+		pthread_mutex_lock(&s->status_mutex);
+		s->cal_locked = false;
+		pthread_mutex_unlock(&s->status_mutex);
+		s->cal_count = 0;
+		set_cal_state(s, LS_CAL_RELOCK);
+		return;
+	}
+
+	/* Accumulate confident readings; require agreement before acting. */
+	int n = s->cal_count < 5 ? s->cal_count : 5;
+	if (n == 5)
+		memmove(&s->cal_hist[0], &s->cal_hist[1], sizeof(int64_t) * 4);
+	s->cal_hist[n < 5 ? n : 4] = mic_delay;
+	if (s->cal_count < 5)
+		s->cal_count++;
+
+	if (s->cal_count < 3) {
+		set_cal_state(s, s->cal_locked_mic_ns ? LS_CAL_RELOCK
+						      : LS_CAL_MEASURING);
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: mic ~%d ms (conf %.2f), "
+		     "collecting %d/3…",
+		     (int)(mic_delay / CAL_NS_MS), conf, s->cal_count);
+		return;
+	}
+
+	int64_t sorted[5];
+	memcpy(sorted, s->cal_hist, sizeof(int64_t) * (size_t)s->cal_count);
+	qsort(sorted, (size_t)s->cal_count, sizeof(int64_t), cmp_i64);
+	int64_t median = sorted[s->cal_count / 2];
+	int64_t spread = sorted[s->cal_count - 1] - sorted[0];
+
+	if (spread > 40 * CAL_NS_MS) {
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: readings unstable "
+		     "(spread %d ms) — holding",
+		     (int)(spread / CAL_NS_MS));
+		return;
+	}
+
+	/* Agreed readings: latch the mic figure. From here the offset tracks
+	 * the video latency without needing the correlation — including
+	 * across reconnects, where the latency changes but the audio gear
+	 * doesn't, so the right offset applies immediately instead of after
+	 * another 15 s of talking. */
+	pthread_mutex_lock(&s->status_mutex);
+	s->cal_locked = true;
+	s->cal_locked_mic_ns = median;
+	pthread_mutex_unlock(&s->status_mutex);
+	s->cal_verified_ns = now;
+	set_cal_state(s, LS_CAL_LOCKED);
+
+	blog(LOG_INFO,
+	     "[lenslink] auto lip-sync: locked mic latency at %d ms "
+	     "(conf %.2f) — tracking video latency from here",
+	     (int)(median / CAL_NS_MS), conf);
+
+	apply_calibrated_offset(s, video_latency_ns, median, name, video_delay,
+				applied, false, conf);
 }
 
 /*
@@ -912,6 +1035,18 @@ static void lipsync_reference_absent(struct ios_camera_source *s)
 
 	bool cleared = s->sync_offset_owned;
 	set_video_delay(s, 0);
+
+	/* Drop the lock with it: no reference means no way to confirm the
+	 * latched figure, and the offset it produced is being cleared here
+	 * anyway. (If a future protocol command lets the plugin stop the
+	 * reference on purpose after locking, this path has to learn the
+	 * difference between "off" and "no longer needed".) */
+	pthread_mutex_lock(&s->status_mutex);
+	s->cal_locked = false;
+	s->cal_locked_mic_ns = 0;
+	s->cal_state = LS_CAL_OFF;
+	pthread_mutex_unlock(&s->status_mutex);
+	s->cal_count = 0;
 
 	if (applied != 0 && name[0]) {
 		obs_source_t *audio = obs_get_source_by_name(name);
@@ -2231,6 +2366,13 @@ static void ios_camera_update(void *data, obs_data_t *settings)
 			lipsync_reset(s->lipsync);
 		pthread_mutex_unlock(&s->lipsync_mutex);
 		s->cal_count = 0;
+		/* A different audio source is different gear: the latched mic
+		 * latency describes the old one and must not carry over. */
+		pthread_mutex_lock(&s->status_mutex);
+		s->cal_locked = false;
+		s->cal_locked_mic_ns = 0;
+		s->cal_state = LS_CAL_MEASURING;
+		pthread_mutex_unlock(&s->status_mutex);
 	} else if (!want_hook && was_hooked) {
 		unhook_audio(s);
 	}

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -99,6 +99,12 @@ struct ios_camera_source {
 	 * encoding (battery) and becomes usable by another LensLink source.
 	 * `showing` is maintained by the show/hide callbacks. */
 	volatile bool deactivate_hidden;
+
+	/* Tally: `active` is program (what the audience sees), `showing` is
+	 * any view at all — preview, a projector, a hidden-but-rendered
+	 * scene. Preview is therefore "showing but not active". OBS drives
+	 * both through callbacks; the dial loop reads them. */
+	volatile bool active;
 	volatile bool showing;
 
 	/* Remote start: when the app connects in standby (open but idle,
@@ -551,6 +557,12 @@ struct client_state {
 	uint64_t packets_at_decoder;
 	bool is_screen; /* screen mirror (plays system audio) vs camera */
 	bool standby;   /* app is idle, waiting for a start_stream command */
+	/* Last tally state pushed to the device. Per connection, so a
+	 * reconnect re-announces rather than assuming the phone still knows. */
+	bool tally_valid;
+	bool tally_program;
+	bool tally_preview;
+	int tally_sync;
 	uint64_t next_decoder_attempt; /* cooldown after create failure */
 	enum AVCodecID codec_id;
 	char name[128];
@@ -1122,6 +1134,68 @@ static void send_control_cmd(struct client_state *c, const char *json)
 	obsc_build_header(hdr, OBSC_PKT_CONTROL, 0, 0, (uint32_t)len);
 	client_send(c, hdr, OBSC_HEADER_SIZE);
 	client_send(c, json, len);
+}
+
+/* Wire names for the calibration states (docs/PROTOCOL.md, UI_DESIGN.md). */
+static const char *cal_state_name(enum lipsync_cal_state state)
+{
+	switch (state) {
+	case LS_CAL_MEASURING:
+		return "measuring";
+	case LS_CAL_LOCKED:
+		return "locked";
+	case LS_CAL_RELOCK:
+		return "relocking";
+	case LS_CAL_OFF:
+	default:
+		return "off";
+	}
+}
+
+/* Same vocabulary, for the web panel's readout. */
+const char *ios_camera_sync_state(struct ios_camera_source *s)
+{
+	pthread_mutex_lock(&s->status_mutex);
+	enum lipsync_cal_state state = s->cal_state;
+	pthread_mutex_unlock(&s->status_mutex);
+	return cal_state_name(state);
+}
+
+/*
+ * Tally: tells the phone whether it's on program ("live"), merely visible
+ * somewhere ("preview"), or neither — plus how lip-sync calibration is
+ * getting on, which the app shows in the same corner.
+ *
+ * Sent only on change, so a phone sitting in one scene costs nothing, and
+ * re-announced on every new connection because the device can't be assumed
+ * to remember. Camera-only in practice: the screen-mirror extension has no
+ * UI and ignores it, like any command it doesn't recognise.
+ */
+static void tally_tick(struct ios_camera_source *s, struct client_state *c)
+{
+	bool program = s->active;
+	bool preview = s->showing && !program;
+
+	pthread_mutex_lock(&s->status_mutex);
+	int sync = (int)s->cal_state;
+	pthread_mutex_unlock(&s->status_mutex);
+
+	if (c->tally_valid && c->tally_program == program &&
+	    c->tally_preview == preview && c->tally_sync == sync)
+		return;
+
+	c->tally_valid = true;
+	c->tally_program = program;
+	c->tally_preview = preview;
+	c->tally_sync = sync;
+
+	char json[160];
+	snprintf(json, sizeof(json),
+		 "{\"cmd\":\"tally\",\"program\":%s,\"preview\":%s,"
+		 "\"sync\":\"%s\"}",
+		 program ? "true" : "false", preview ? "true" : "false",
+		 cal_state_name((enum lipsync_cal_state)sync));
+	send_control_cmd(c, json);
 }
 
 /* Asks the device to emit a fresh keyframe immediately. The screen
@@ -2187,6 +2261,7 @@ static void dial_loop(struct ios_camera_source *s)
 				client_flush(&client);
 			latency_tick(s, &client);
 			control_tick(s, &client);
+			tally_tick(s, &client);
 			diag_tick(s, &client);
 			stats_tick(s, &client);
 			if (client.out.failed)
@@ -2258,6 +2333,20 @@ static void ios_camera_hide(void *data)
 {
 	struct ios_camera_source *s = data;
 	s->showing = false;
+}
+
+/* Program tally: OBS calls these when the source starts/stops being part
+ * of what's actually going out. Same contract as show/hide — record only. */
+static void ios_camera_activate(void *data)
+{
+	struct ios_camera_source *s = data;
+	s->active = true;
+}
+
+static void ios_camera_deactivate(void *data)
+{
+	struct ios_camera_source *s = data;
+	s->active = false;
 }
 
 static const char *ios_camera_get_name(void *unused)
@@ -3048,6 +3137,8 @@ struct obs_source_info ios_camera_source_info = {
 	.get_properties = ios_camera_get_properties,
 	.show = ios_camera_show,
 	.hide = ios_camera_hide,
+	.activate = ios_camera_activate,
+	.deactivate = ios_camera_deactivate,
 	.icon_type = OBS_ICON_TYPE_CAMERA,
 };
 
@@ -3064,5 +3155,7 @@ struct obs_source_info lenslink_screen_source_info = {
 	.get_properties = lenslink_screen_get_properties,
 	.show = ios_camera_show,
 	.hide = ios_camera_hide,
+	.activate = ios_camera_activate,
+	.deactivate = ios_camera_deactivate,
 	.icon_type = OBS_ICON_TYPE_DESKTOP_CAPTURE,
 };

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -2634,9 +2634,16 @@ static uint32_t ios_camera_get_height(void *data)
 	return s->frame_height;
 }
 
-/* The NV12/I420 draw effect, shared by every source (graphics thread). */
+/* The NV12/I420 draw effect, shared by every source (graphics thread).
+ * The parameter handles are resolved once with it: gs_effect_get_param_by_name
+ * is a by-name lookup, and video_render runs per source per rendered frame on
+ * the graphics thread — the one thread the whole compositor waits on. Handles
+ * stay valid as long as the effect, which lives until module unload. */
 static gs_effect_t *g_yuv_effect = NULL;
 static bool g_yuv_effect_tried = false;
+static gs_eparam_t *g_yuv_y = NULL;
+static gs_eparam_t *g_yuv_uv = NULL;
+static gs_eparam_t *g_yuv_v = NULL;
 
 static gs_effect_t *yuv_effect(void)
 {
@@ -2651,6 +2658,14 @@ static gs_effect_t *yuv_effect(void)
 			blog(LOG_ERROR,
 			     "[lenslink] gpu pipeline: nv12.effect missing — "
 			     "YUV frames cannot be drawn");
+		else {
+			g_yuv_y = gs_effect_get_param_by_name(g_yuv_effect,
+							      "y_tex");
+			g_yuv_uv = gs_effect_get_param_by_name(g_yuv_effect,
+							       "uv_tex");
+			g_yuv_v = gs_effect_get_param_by_name(g_yuv_effect,
+							      "v_tex");
+		}
 	}
 	return g_yuv_effect;
 }
@@ -2807,8 +2822,17 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 
 	if (s->gpu_map.rgba) {
 		gs_effect_t *eff = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-		gs_eparam_t *image = gs_effect_get_param_by_name(eff, "image");
-		gs_effect_set_texture(image, s->gpu_map.tex[0]);
+		/* OBS owns the base effect; cache its "image" handle against
+		 * the effect we resolved it from, so a different (or reloaded)
+		 * base effect re-resolves instead of reusing a stale handle. */
+		static gs_effect_t *cached_base = NULL;
+		static gs_eparam_t *cached_image = NULL;
+		if (eff != cached_base) {
+			cached_base = eff;
+			cached_image =
+				gs_effect_get_param_by_name(eff, "image");
+		}
+		gs_effect_set_texture(cached_image, s->gpu_map.tex[0]);
 		while (gs_effect_loop(eff, "Draw"))
 			gs_draw_sprite(s->gpu_map.tex[0], 0, s->gpu_map.width,
 				       s->gpu_map.height);
@@ -2817,17 +2841,10 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 		if (eff) {
 			bool i420 = !s->gpu_mapped &&
 				    s->cpu_tex_fmt != AV_PIX_FMT_NV12;
-			gs_effect_set_texture(
-				gs_effect_get_param_by_name(eff, "y_tex"),
-				s->gpu_map.tex[0]);
-			gs_effect_set_texture(
-				gs_effect_get_param_by_name(eff, "uv_tex"),
-				s->gpu_map.tex[1]);
+			gs_effect_set_texture(g_yuv_y, s->gpu_map.tex[0]);
+			gs_effect_set_texture(g_yuv_uv, s->gpu_map.tex[1]);
 			if (i420)
-				gs_effect_set_texture(
-					gs_effect_get_param_by_name(eff,
-								    "v_tex"),
-					s->cpu_tex[2]);
+				gs_effect_set_texture(g_yuv_v, s->cpu_tex[2]);
 			while (gs_effect_loop(eff, i420 ? "DrawI420" : "Draw"))
 				gs_draw_sprite(s->gpu_map.tex[0], 0,
 					       s->gpu_map.width,

--- a/obs-plugin/src/lipsync-cal.h
+++ b/obs-plugin/src/lipsync-cal.h
@@ -1,0 +1,77 @@
+/*
+ * Auto lip-sync calibration policy.
+ *
+ * The offset LensLink applies is `video latency - mic latency`. Those two
+ * numbers come from very different places:
+ *
+ *   - Video latency is a property of the *link*. It moves with network
+ *     conditions, resolution and USB-vs-Wi-Fi, and timesync measures it
+ *     every second for free.
+ *   - Mic latency is a property of the streamer's *audio gear* — interface
+ *     buffering, driver, OBS's audio path. Recovering it needs the audio
+ *     cross-correlation, which needs the phone's reference audio and
+ *     someone making noise. It doesn't change while the audio path
+ *     doesn't.
+ *
+ * So the correlation runs until the mic figure is known, then the figure
+ * is latched and the offset simply tracks the video latency. The
+ * correlation re-runs only occasionally, to notice if the audio path
+ * changed underneath us (a re-plugged interface, a headset taking over).
+ *
+ * The decisions that drive that live here, free of libobs, so they can be
+ * exercised without OBS or a phone.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Calibration progress. Reported to the user, so the wording of each state
+ * matters as much as the value (see docs/UI_DESIGN.md). */
+enum lipsync_cal_state {
+	LS_CAL_OFF,       /* auto-calibrate disabled, or no audio source */
+	LS_CAL_MEASURING, /* listening for agreeing readings; nothing applied */
+	LS_CAL_LOCKED,    /* mic latency latched; tracking video latency */
+	LS_CAL_RELOCK,    /* the latched figure stopped matching — re-measuring */
+};
+
+#define CAL_NS_MS 1000000LL
+
+/* A correlation peak below this is noise, not a reading. */
+#define CAL_MIN_CONFIDENCE 0.5
+
+/* Once locked, the correlation only runs to confirm the latched figure is
+ * still right — rarely, since what it measures doesn't drift on its own. */
+#define CAL_VERIFY_INTERVAL_NS (90 * 1000000000ULL)
+
+/* How far a confirming reading may sit from the latched figure before the
+ * audio path is assumed to have changed under us. Comfortably wider than
+ * the reading-to-reading noise the 40 ms agreement gate already tolerates,
+ * so ordinary jitter can't knock a good lock loose. */
+#define CAL_RELOCK_DIFF_NS (50 * CAL_NS_MS)
+
+/* Whether a locked source should spend a correlation confirming itself.
+ * `verified_ns` is when it last did (0 = never, which is due immediately). */
+static inline bool lipsync_cal_due_for_verify(uint64_t now,
+					      uint64_t verified_ns)
+{
+	/* Locking always stamps this, so 0 means a lock arrived some other
+	 * way; confirm it at the first opportunity rather than trusting it
+	 * for an interval. Explicit because `now - 0` is a plain duration
+	 * since the clock's epoch, which says nothing about staleness. */
+	if (verified_ns == 0)
+		return true;
+	return now - verified_ns >= CAL_VERIFY_INTERVAL_NS;
+}
+
+/* Whether a confirming reading is far enough from the latched figure to
+ * mean the audio path changed, rather than ordinary measurement noise. */
+static inline bool lipsync_cal_reading_invalidates(int64_t reading_ns,
+						   int64_t locked_ns)
+{
+	int64_t drift = reading_ns - locked_ns;
+	if (drift < 0)
+		drift = -drift;
+	return drift >= CAL_RELOCK_DIFF_NS;
+}

--- a/obs-plugin/src/lipsync.c
+++ b/obs-plugin/src/lipsync.c
@@ -113,13 +113,19 @@ void lipsync_add_mic(struct lipsync *ls, const float *mono, size_t count,
 	}
 }
 
+/* Newest-first walk of the ring. RING isn't a power of two, so stepping the
+ * index by hand keeps an integer division out of these per-element loops. */
+#define RING_WALK(s, idx)                                                     \
+	for (int idx = ((s)->head ? (s)->head : RING) - 1, walk_n = (s)->count; \
+	     walk_n > 0; walk_n--, idx = idx ? idx - 1 : RING - 1)
+
 static bool stream_bounds(const struct env_stream *s, int64_t *lo, int64_t *hi)
 {
 	if (s->count == 0)
 		return false;
 	int64_t mn = INT64_MAX, mx = INT64_MIN;
-	for (int i = 0; i < s->count; i++) {
-		int idx = (s->head - 1 - i + 2 * RING) % RING;
+	RING_WALK(s, idx)
+	{
 		int64_t f = s->frame[idx];
 		if (f < mn)
 			mn = f;
@@ -136,8 +142,8 @@ static void build_dense(const struct env_stream *s, int64_t lo, int64_t hi,
 			float *out)
 {
 	memset(out, 0, sizeof(float) * (size_t)(hi - lo));
-	for (int i = 0; i < s->count; i++) {
-		int idx = (s->head - 1 - i + 2 * RING) % RING;
+	RING_WALK(s, idx)
+	{
 		int64_t f = s->frame[idx];
 		if (f >= lo && f < hi)
 			out[f - lo] = s->energy[idx];
@@ -175,9 +181,13 @@ bool lipsync_estimate(struct lipsync *ls, int64_t *mic_delay_ns,
 	int ML = L + 2 * MAX_LAG_FRAMES;
 	float *p = malloc(sizeof(float) * (size_t)L);
 	float *m = malloc(sizeof(float) * (size_t)ML);
-	if (!p || !m) {
+	/* Prefix sums of m[]^2, so each lag's window energy is one
+	 * subtraction instead of a second pass over the window. */
+	double *msq = malloc(sizeof(double) * (size_t)(ML + 1));
+	if (!p || !m || !msq) {
 		free(p);
 		free(m);
+		free(msq);
 		return false;
 	}
 
@@ -194,23 +204,45 @@ bool lipsync_estimate(struct lipsync *ls, int64_t *mic_delay_ns,
 	if (norm_p < MIN_ENERGY) {
 		free(p);
 		free(m);
+		free(msq);
 		return false; /* reference essentially silent */
 	}
+
+	msq[0] = 0;
+	for (int i = 0; i < ML; i++)
+		msq[i + 1] = msq[i] + (double)m[i] * m[i];
 
 	double best = -1e30;
 	int best_lag = 0;
 	bool found = false;
-	/* score(lag) = sum p[i] * m[i+lag]; peaks at lag == mic delay. */
+	/* score(lag) = sum p[i] * m[i+lag]; peaks at lag == mic delay.
+	 *
+	 * Two things keep this ~1.8M-iteration loop honest. The window's own
+	 * energy comes from the prefix sums above: successive lags overlap
+	 * almost entirely, so recomputing it per lag was pure waste.
+	 * (Cancellation can make a near-silent window read slightly negative;
+	 * the MIN_ENERGY guard rejects that before the sqrt.) And the dot
+	 * product accumulates into four independent partials, because a single
+	 * double accumulator serializes the loop on FP-add latency — the adds
+	 * can't overlap, and the loop runs at one add per ~4 cycles no matter
+	 * how little else it does. Four chains let them pipeline. */
 	for (int lag = -MAX_LAG_FRAMES; lag <= MAX_LAG_FRAMES; lag++) {
-		double dot = 0, norm_m = 0;
 		int base = lag + MAX_LAG_FRAMES; /* index into padded m */
-		for (int i = 0; i < L; i++) {
-			float mv = m[i + base];
-			dot += (double)p[i] * mv;
-			norm_m += (double)mv * mv;
-		}
+		double norm_m = msq[base + L] - msq[base];
 		if (norm_m < MIN_ENERGY)
 			continue;
+		const float *mw = m + base;
+		double d0 = 0, d1 = 0, d2 = 0, d3 = 0;
+		int i = 0;
+		for (; i + 4 <= L; i += 4) {
+			d0 += (double)p[i] * mw[i];
+			d1 += (double)p[i + 1] * mw[i + 1];
+			d2 += (double)p[i + 2] * mw[i + 2];
+			d3 += (double)p[i + 3] * mw[i + 3];
+		}
+		double dot = (d0 + d1) + (d2 + d3);
+		for (; i < L; i++)
+			dot += (double)p[i] * mw[i];
 		double ncc = dot / sqrt(norm_p * norm_m);
 		if (!found || ncc > best) {
 			best = ncc;
@@ -221,6 +253,7 @@ bool lipsync_estimate(struct lipsync *ls, int64_t *mic_delay_ns,
 
 	free(p);
 	free(m);
+	free(msq);
 
 	/* No lag had usable mic energy (mic silent): no estimate. */
 	if (!found)

--- a/obs-plugin/src/web-control.c
+++ b/obs-plugin/src/web-control.c
@@ -36,8 +36,11 @@ static const char control_page[] =
 	"*{box-sizing:border-box}"
 	"body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);"
 	"color:var(--txt);max-width:440px;margin:0 auto;padding:20px 16px}"
+	/* Wraps so the sync pill drops below the status pill on a narrow
+	 * phone screen instead of squeezing either one. */
 	"header{display:flex;align-items:center;justify-content:space-between;"
-	"margin-bottom:16px}h1{font-size:20px;font-weight:600;margin:0}"
+	"gap:8px;flex-wrap:wrap;margin-bottom:16px}"
+	"h1{font-size:20px;font-weight:600;margin:0}"
 	".pill{display:inline-flex;align-items:center;gap:8px;background:var(--glass);"
 	"border:1px solid var(--hair);border-radius:999px;padding:6px 12px;"
 	"font-size:13px;font-weight:600}"
@@ -78,7 +81,12 @@ static const char control_page[] =
 	"</style></head><body>"
 	"<header><h1>LensLink</h1>"
 	"<div class='pill'><span class='dot' id='dot'></span>"
-	"<span id='status'>connecting&hellip;</span></div></header>"
+	"<span id='status'>connecting&hellip;</span></div>"
+	/* Lip-sync calibration stage — hidden unless auto-calibrate is on,
+	 * so it never nags setups that don't use it. */
+	"<div class='pill' id='syncpill' style='display:none'>"
+	"<span class='dot' id='syncdot'></span>"
+	"<span id='sync'></span></div></header>"
 	/* Source tabs: hidden until more than one camera source is live.
 	 * Every API call carries the selected source's ?src= id. */
 	"<div class='seg' id='srctabs' "
@@ -184,7 +192,8 @@ static const char control_page[] =
 	/* NB: elements are looked up explicitly — a bare `status` would
 	 * resolve to window.status, not the element. */
 	"const $=id=>document.getElementById(id);"
-	"const dotEl=$('dot'),statusEl=$('status'),zoomEl=$('zoom'),zvEl=$('zv'),"
+	"const syncEl=$('sync'),syncdotEl=$('syncdot'),syncpillEl=$('syncpill'),"
+	"dotEl=$('dot'),statusEl=$('status'),zoomEl=$('zoom'),zvEl=$('zv'),"
 	"expEl=$('exposure'),evEl=$('ev'),afEl=$('af'),mfEl=$('mf'),lensEl=$('lens'),"
 	"fhintEl=$('fhint'),flashlightEl=$('flashlight'),flipEl=$('flip'),lensselEl=$('lenssel'),"
 	"panelEl=$('panel'),screennoteEl=$('screennote'),"
@@ -198,7 +207,8 @@ static const char control_page[] =
 	"wbrowEl=$('wbrow'),awbEl=$('awb'),wblEl=$('wbl'),wbtempEl=$('wbtemp'),"
 	"wbvEl=$('wbv'),wbhintEl=$('wbhint'),"
 	"microwEl=$('microw'),micselEl=$('micsel'),srctabsEl=$('srctabs');"
-	"const COL={live:'#30D158',amber:'#FF9F0A',red:'#FF453A',grey:'#8E8E93'};"
+	"const COL={live:'#30D158',amber:'#FF9F0A',red:'#FF453A',grey:'#8E8E93',"
+	"accent:'#3D7BFF'};"
 	/* Selected source id (from /api/sources); every request carries it. */
 	"let src=null;const q=()=>src==null?'':('?src='+src);"
 	"let lastTouch=0;const touch=()=>lastTouch=Date.now();"
@@ -302,6 +312,12 @@ static const char control_page[] =
 	"b.onclick=()=>{src=x.id;lastTouch=0;poll()};return b}))}"
 	"const s=await(await fetch('/api/status'+q())).json();"
 	"statusEl.textContent=s.status||'idle';dotEl.style.background=statusColor(s.status);"
+	/* Lip-sync stage: same words and colours as the phone's own light. */
+	"const SYNC={measuring:['Measuring lip-sync',COL.accent],"
+	"locked:['Lip-sync locked',COL.live],"
+	"relocking:['Recalibrating lip-sync',COL.amber]};"
+	"const sy=SYNC[s.sync];syncpillEl.style.display=sy?'':'none';"
+	"if(sy){syncEl.textContent=sy[0];syncdotEl.style.background=sy[1]}"
 	/* Live controls only when a camera stream is actually connected;
 	 * standby gets the Start panel; screen mirror gets the note; not
 	 * connected shows just the status pill. */
@@ -634,6 +650,7 @@ static void handle_client(socket_t client)
 		char json[768];
 		bool screen = false, standby = false, connected = false;
 		bool auto_start = false;
+		const char *sync = "off";
 
 		pthread_mutex_lock(&g_reg.mutex);
 		struct ios_camera_source *s = locked_pick_source(request);
@@ -643,6 +660,7 @@ static void handle_client(socket_t client)
 			standby = ios_camera_is_standby(s);
 			connected = ios_camera_is_connected(s);
 			auto_start = ios_camera_auto_start(s);
+			sync = ios_camera_sync_state(s);
 		}
 		pthread_mutex_unlock(&g_reg.mutex);
 		if (!s) {
@@ -653,11 +671,11 @@ static void handle_client(socket_t client)
 		json_escape(status, escaped, sizeof(escaped));
 		snprintf(json, sizeof(json),
 			 "{\"status\":\"%s\",\"screen\":%s,\"standby\":%s,"
-			 "\"connected\":%s,\"autoStart\":%s}",
+			 "\"connected\":%s,\"autoStart\":%s,\"sync\":\"%s\"}",
 			 escaped, screen ? "true" : "false",
 			 standby ? "true" : "false",
 			 connected ? "true" : "false",
-			 auto_start ? "true" : "false");
+			 auto_start ? "true" : "false", sync);
 		respond(client, "200 OK", "application/json", json);
 		return;
 	}

--- a/obs-plugin/src/web-control.h
+++ b/obs-plugin/src/web-control.h
@@ -25,6 +25,9 @@ bool ios_camera_is_screen(struct ios_camera_source *s);
 bool ios_camera_is_standby(struct ios_camera_source *s);
 bool ios_camera_is_connected(struct ios_camera_source *s);
 bool ios_camera_auto_start(struct ios_camera_source *s);
+/* Lip-sync calibration stage: "off", "measuring", "locked" or "relocking"
+ * (docs/UI_DESIGN.md). Returns a static string — no ownership. */
+const char *ios_camera_sync_state(struct ios_camera_source *s);
 void ios_camera_set_auto_start(struct ios_camera_source *s, bool on);
 
 /* One server, many sources. Camera sources register at create and


### PR DESCRIPTION
## What & why

Four related changes, in the order they were built.

**Lock the lip-sync mic figure, then track latency alone.** The applied offset is video latency minus mic latency, and those behave very differently: video latency belongs to the link and moves constantly (timesync already measures it every second, for free), while mic latency belongs to the streamer's audio gear and doesn't change while the gear doesn't. The code re-derived that constant every five seconds forever, and gated the whole update path on getting a confident reading — so a latency change during silence went uncorrected until the streamer talked again. Now the mic figure latches once three readings agree, the offset tracks live latency every window whether or not anyone is making noise, and the correlation returns only every 90 s to confirm the latched figure still holds. A reading more than 50 ms away means the audio path changed, so it drops the lock and re-measures. The lock also survives reconnects, where latency changes but the gear doesn't.

**A tally light in the app.** The plugin now tells the phone what OBS is doing with it, via a new `tally` control command carrying `program`, `preview` and the lip-sync stage. Tally and lip-sync are kept as *two* indicators rather than one light with three meanings: a tally answers exactly one question — am I on air? — and someone glancing at a phone behind a monitor shouldn't have to work out whether red means "live" or "something about audio". So the tally is a border around the Live screen (red live, amber preview, nothing otherwise), drawn above the dim overlay because the screen dims after ten seconds precisely when the operator is furthest away. Lip-sync gets a dot and a word beside the status pill. Both clear when the connection drops — a "live" light outliving the OBS that set it is worse than no light.

**`Release-Beta: true`.** A fourth release trailer: same builds, same assets, same TestFlight upload, but the GitHub release is flagged Pre-release so it never becomes Latest and the README badge stays on the last stable build. Tags gain a `-beta.N` suffix inside the version they're a beta of; merging without the trailer cuts the stable release. Two latent problems had to be fixed for this to work rather than quietly misbehave — see "How it was tested".

**Hot-path cleanups.** The lip-sync correlation was recomputing the mic window's energy at every one of 600 lag positions (successive positions overlap almost entirely) and accumulating into a single `double`, which serializes the loop on FP-add latency. Prefix sums plus four independent accumulators: 1.51 ms → 0.90 ms per estimate. Effect parameter handles are now resolved once with the effect instead of by name on every `video_render` call. And the app's health sample is only published while the overlay is on screen — it defaults to off, and publishing it unwatched invalidated the whole Live view once a second, including while dimmed.

## How it was tested

Everything here was verified from a Linux container, so **none of the runtime behaviour has been seen on a device** — that's the gap worth knowing about before merging.

- **Plugin:** builds clean with `-Wall -Wextra -Werror` (Linux, libobs 30).
- **Swift:** `ios-app/syntax-check.sh` parses clean. Type checking still only happens in macOS CI.
- **Lip-sync correlation:** a differential harness drove the real API over 12 scenarios — wrapped ring, silent mic, negative lag, out-of-range delay, mixed sample rates — and confirmed byte-identical lag and confidence against the previous implementation, so the faster version is arithmetically the same.
- **Calibration policy:** the lock/verify decisions live in `lipsync-cal.h`, free of libobs, and are exercised by a harness covering convergence, ten minutes of silence, a device swap mid-stream, an hour of jittery confirmations, and a low-confidence outlier. Writing it caught a real defect: the header documented `0` as "never verified, check immediately" while the arithmetic read it as a timestamp.
- **Web panel:** the embedded JS was extracted and run through `node --check` (a syntax error there fails silently in the browser), and the sync-state mapping was exercised for all four states plus the older-plugin case.
- **Release logic:** the version computation was extracted and run against throwaway repos — existing bump/skip/prose behaviour unchanged, beta numbering, gaps from hand-deleted tags, and the stable release that follows a beta. This caught the two problems mentioned above: git's version sort puts `v1.9.0-beta.2` *above* `v1.9.0` and the patch field then reads `0-beta.2`, which `$(( ))` rejects outright — so the next stable release after any beta would have failed, not merely mis-numbered. And `/releases/latest` is defined as the newest *non*-pre-release, so every beta would have handed TestFlight testers the previous stable release's notes with nothing to indicate it had.

**What to look at first on a device:** the tally border's placement over the dim overlay, and whether the lip-sync lock behaves through a real reconnect.

This PR carries `Release-Bump: minor` and `Release-Beta: true`, so merging it publishes **v1.8.0-beta.1** as a pre-release and uploads it to TestFlight. The beta support ships in this same PR and applies to its own merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_