### PR TITLE
Fix the release-trailer precedence that swallowed #69's release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,12 +72,15 @@ jobs:
           IFS=. read -r major minor patch <<< "$version"
 
           # Every commit newly pushed to main (the merge commit AND the PR's
-          # own commits), so a trailer in any PR commit counts.
+          # own commits), so a trailer in any PR commit counts. --reverse
+          # puts them oldest-first, which is what makes "the last directive
+          # wins" below mean the newest one; git log defaults to the
+          # opposite order.
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             messages=$(git log -1 --format=%B "$AFTER")
             changed=$(git diff-tree --no-commit-id --name-only -r "$AFTER")
           else
-            messages=$(git log --format=%B "$BEFORE..$AFTER")
+            messages=$(git log --reverse --format=%B "$BEFORE..$AFTER")
             changed=$(git diff --name-only "$BEFORE" "$AFTER")
           fi
 
@@ -90,28 +93,54 @@ jobs:
             echo "ios=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Trailers only match on their own line (^…$), so prose that
+          # Read the directives in commit order, oldest first, and let the
+          # LAST one win.
+          #
+          # Scanning every commit of the PR is deliberate, but "any skip
+          # anywhere wins" made a stale trailer silently outrank a
+          # deliberate one: a docs-only first commit that suppressed its own
+          # release went on to suppress the release for the whole branch,
+          # four commits and two explicit release requests later, and the
+          # only sign was one line in this log. Last-wins reads the way
+          # people actually work — a later commit revises the earlier
+          # intent, in either direction. Asking to release clears a previous
+          # skip; asking to skip after that suppresses it again.
+          #
+          # Trailers still only match on their own line, so prose that
           # merely mentions the keywords is ignored.
-          if grep -qiE '^Release-Skip:[[:space:]]*true[[:space:]]*$' <<< "$messages"; then
-            echo "Release-Skip trailer found — no release."
+          skip=false
+          bump=patch
+          beta=false
+          shopt -s nocasematch
+          while IFS= read -r line; do
+            if [[ $line =~ ^Release-Skip:[[:space:]]*true[[:space:]]*$ ]]; then
+              skip=true
+            elif [[ $line =~ ^Release-Bump:[[:space:]]*(major|minor|patch)[[:space:]]*$ ]]; then
+              bump=${BASH_REMATCH[1],,}; skip=false
+            elif [[ $line =~ ^Release-Beta:[[:space:]]*true[[:space:]]*$ ]]; then
+              beta=true; skip=false
+            fi
+          done <<< "$messages"
+          shopt -u nocasematch
+
+          if [ "$skip" = true ]; then
+            echo "Release-Skip is the last release directive — no release."
             echo "tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if grep -qiE '^Release-Bump:[[:space:]]*major[[:space:]]*$' <<< "$messages"; then
-            major=$((major + 1)); minor=0; patch=0
-          elif grep -qiE '^Release-Bump:[[:space:]]*minor[[:space:]]*$' <<< "$messages"; then
-            minor=$((minor + 1)); patch=0
-          else
-            patch=$((patch + 1))
-          fi
+          case "$bump" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            *)     patch=$((patch + 1)) ;;
+          esac
 
           tag="v$major.$minor.$patch"
 
           # Beta: same version, suffixed, counting up within it. Probing for
           # the first free suffix (rather than counting existing ones) keeps
           # numbering right even if a beta tag was deleted by hand.
-          if grep -qiE '^Release-Beta:[[:space:]]*true[[:space:]]*$' <<< "$messages"; then
+          if [ "$beta" = true ]; then
             n=1
             while git rev-parse -q --verify "refs/tags/$tag-beta.$n" >/dev/null; do
               n=$((n + 1))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,8 +392,12 @@ jobs:
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           generate_release_notes: true
-          # A tag pushed by hand publishes a normal release, as before.
-          prerelease: ${{ inputs.prerelease || false }}
+          # The tag name is authoritative as well as the input: a -beta.N
+          # tag pushed by hand must not publish as a stable release just
+          # because it arrived without the flag set.
+          prerelease: >-
+            ${{ inputs.prerelease
+                || contains(inputs.tag_name || github.ref_name, '-beta.') }}
           files: |
             dist/LensLink-installer-windows-x64.exe
             dist/lenslink-windows-x64.zip

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,6 +16,13 @@ name: TestFlight
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Release tag to take the "What to Test" notes from. Needed when
+          that release is a pre-release, which the default lookup skips.
+        required: false
+        type: string
   # Only fires for releases published by a real user. Auto-releases are
   # published with GITHUB_TOKEN, whose events GitHub suppresses from
   # triggering workflows — auto-release.yml therefore *calls* this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,10 @@ to quote.
   (`v1.8.2-beta.1`) — still uploaded to TestFlight, but never "Latest" on
   GitHub. Betas count up within a version; merging without the trailer
   cuts the stable release. Details: `docs/DEVELOPMENT.md`.
+- Trailers are read across **every commit of the PR, last one wins**. A
+  release-suppressing trailer written for an early docs-only commit is
+  therefore revised by a later release request, rather than silently
+  killing the whole PR's release — which it did once.
 - **Never manually dispatch** `testflight.yml` or anything that creates
   releases/tags — a run uploads a real build to TestFlight / publishes a
   real release.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,6 +105,13 @@ v1.8.2                    merge without it — the beta becomes the release
 Combine it with a bump trailer to beta a bigger version:
 `Release-Bump: minor` + `Release-Beta: true` → `v1.9.0-beta.1`.
 
+A `-beta.` tag publishes as a pre-release however it was created, so a
+hand-pushed `v1.8.0-beta.1` doesn't become a stable release just because
+it arrived without the flag set. (A hand-pushed tag still won't upload to
+TestFlight — releases published with `GITHUB_TOKEN` don't trigger other
+workflows, which is why the auto-release path *calls* TestFlight directly.
+Dispatch `testflight.yml` with the tag if you need that.)
+
 Two details worth knowing. The next version is computed from **stable tags
 only** — git's version sort puts `v1.9.0-beta.2` *above* `v1.9.0`, and the
 patch field would read `0-beta.2`, which the shell can't add 1 to, so an
@@ -115,7 +122,18 @@ would otherwise hand testers the previous stable release's changelog with
 nothing to indicate it had.
 
 Because it must be a standalone line, mentioning the keywords in prose
-can't trigger a bump. Manual releases also work — push any `v*` tag:
+can't trigger a bump.
+
+**The last directive wins.** Every commit of the merged PR is scanned, in
+order, and the newest release directive is the one that counts — a later
+commit revises an earlier one, in either direction. Asking to release
+clears an earlier skip; asking to skip after that suppresses it again.
+This matters on branches that start with a docs-only commit: a
+release-suppressing trailer written for that commit alone used to outrank
+every later, deliberate request, and the only sign was one line in the
+Auto Release log (it silently swallowed v1.8.0-beta.1 once).
+
+Manual releases also work — push any `v*` tag:
 
 ```bash
 git tag v0.4.0 && git push origin v0.4.0


### PR DESCRIPTION
## What & why

#69 merged cleanly and released nothing. Its first commit was documentation-only and carried a release-suppressing trailer — correct for that commit standing alone. Auto Release scans every commit of the merged PR and checked suppression *first*, so that one line outranked the `Release-Bump` and `Release-Beta` trailers in the four commits after it. The entire visible outcome was one line in the workflow log:

```
Release-Skip trailer found — no release.
```

Directives are now read in commit order, oldest first, and **the newest one wins**. A later commit revises an earlier one in either direction: asking to release clears an earlier suppression, and asking to suppress after that suppresses again. That matches how branches actually get built, where the first commit rarely knows what the branch will become.

`git log` defaults to newest-first, so the scan reverses it. Without that, "last wins" would quietly mean "first wins" and this fix would do nothing.

Two smaller robustness fixes alongside:

- A `-beta.` tag now publishes as a pre-release however it was created, so a hand-pushed beta tag can't land as a stable release just because it arrived without the workflow input set.
- `testflight.yml` accepts an optional tag on manual dispatch — its notes lookup otherwise falls back to `/releases/latest`, which never returns a pre-release.

## How it was tested

The version harness (extracted block, run against throwaway git repos) grew a precedence section: stale-suppression-then-beta, stale-suppression-then-bump, bump-then-later-suppression, suppression/bump/suppression/beta interleaved, last-bump-of-several, and a replay of **#69's exact trailer sequence**, which now yields `v1.8.0-beta.1`. All 27 checks pass. One earlier expectation asserted the old first-wins behaviour and was updated rather than preserved — that change in behaviour is the point of the PR.

All three workflow files re-validated as YAML.

## Note on releasing

This PR touches only `.github/` and docs, which are **outside Auto Release's path filter** (`obs-plugin/`, `ios-app/`, `installer/`) — it cannot release itself, and carries no release trailer. All of #69's code is already on `main`, just untagged; the beta ships with the next merge that touches plugin or app code. See the comment below for the options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_