### PR TITLE
Device-feedback fixes, recalibrate control, and lip-sync reference gating

### DIFF
--- a/.github/scripts/testflight_next_build.py
+++ b/.github/scripts/testflight_next_build.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Pick the next TestFlight build number by asking App Store Connect.
+
+Prints `build_number=<N>` to GITHUB_OUTPUT (and stdout), where N is one
+more than the highest build number ever uploaded for the app — across
+every version and state, expired builds included, since ASC's uniqueness
+rule spans them all.
+
+Why ask ASC instead of counting something local: the old scheme derived
+the number from GITHUB_RUN_NUMBER, which is a *per-workflow* counter —
+an upload dispatched directly (run number of testflight.yml) and one
+called from auto-release (run number of auto-release.yml) count in two
+unrelated sequences. The first manual dispatch shipped build 1011 into a
+history that was already at 1039, and TestFlight never offered it to
+testers as an update because auto-update follows the highest number.
+The source of truth for "highest so far" is ASC, so ask it.
+
+If ASC can't be reached, falls back to epoch seconds: unreadable but
+strictly increasing, so a degraded run can never repeat the low-number
+mistake. (It can't collide upward either — a timestamp exceeds any
+counter-era number, and later timestamps exceed earlier ones.)
+
+Environment:
+  ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_P8   App Store Connect API key
+  BUNDLE_ID                                 app bundle id
+  GITHUB_OUTPUT                             provided by Actions (optional)
+"""
+
+import os
+import sys
+import time
+import urllib.parse
+
+from testflight_feedback import ASC_BASE, asc_token, request
+
+
+def highest_build_number(token, app_id):
+    """Max numeric build number across all of the app's builds."""
+    url = (f"{ASC_BASE}/v1/builds?"
+           + urllib.parse.urlencode({
+               "filter[app]": app_id,
+               "fields[builds]": "version",
+               "limit": 200,
+           }))
+    highest = 0
+    while url:
+        status, data = request(url, token)
+        if status != 200:
+            raise RuntimeError(f"ASC builds query -> {status}")
+        for build in data.get("data", []):
+            version = build.get("attributes", {}).get("version", "")
+            # Numeric max, not ASC's sort order: version is a string, and
+            # a lexicographic "999" would outrank "1039".
+            if version.isdigit():
+                highest = max(highest, int(version))
+        url = (data.get("links") or {}).get("next")
+    return highest
+
+
+def emit(build_number, source):
+    print(f"build number {build_number} ({source})")
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"build_number={build_number}\n")
+
+
+def main():
+    bundle_id = os.environ["BUNDLE_ID"]
+    try:
+        token = asc_token()
+        status, apps = request(
+            f"{ASC_BASE}/v1/apps?"
+            + urllib.parse.urlencode({"filter[bundleId]": bundle_id,
+                                      "fields[apps]": "bundleId"}),
+            token)
+        if status != 200 or not apps.get("data"):
+            raise RuntimeError(f"no app for {bundle_id} (HTTP {status})")
+        highest = highest_build_number(token, apps["data"][0]["id"])
+        emit(highest + 1, f"ASC reports highest existing build {highest}")
+        return 0
+    except Exception as e:  # noqa: BLE001 — any failure takes the fallback
+        print(f"::warning::could not determine next build number from "
+              f"App Store Connect ({e}) — falling back to a timestamp")
+        emit(int(time.time()), "timestamp fallback")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -88,14 +88,35 @@ jobs:
           mkdir -p ~/private_keys
           echo "$KEY_P8" > ~/private_keys/AuthKey_${KEY_ID}.p8
 
+      # Highest existing build in App Store Connect + 1. Derived from ASC
+      # rather than GITHUB_RUN_NUMBER because run numbers are per-workflow
+      # counters: a directly-dispatched upload and one called from
+      # auto-release count in unrelated sequences, and the first manual
+      # dispatch shipped build 1011 into a history already at 1039 —
+      # which TestFlight then never offered as an update (auto-update
+      # follows the highest number). Falls back to epoch seconds if ASC
+      # is unreachable: ugly, but strictly increasing.
+      - name: Next build number (App Store Connect)
+        id: buildnum
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_P8: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          BUNDLE_ID: com.exaltedpixels.LensLinkCamera
+        run: |
+          # Homebrew python3 is PEP 668 "externally managed" — venv it.
+          # The "What to Test" step reuses this venv.
+          python3 -m venv "$RUNNER_TEMP/asc-venv"
+          "$RUNNER_TEMP/asc-venv/bin/pip" install --quiet PyJWT cryptography
+          "$RUNNER_TEMP/asc-venv/bin/python" \
+            .github/scripts/testflight_next_build.py
+
       - name: Archive (unsigned)
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -o pipefail
-          # Build number must strictly increase per upload; the run number
-          # is monotonic. Offset keeps it clear of any earlier manual builds.
-          BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 ))
+          BUILD_NUMBER="${{ steps.buildnum.outputs.build_number }}"
           # Archive WITHOUT signing. Automatic signing here defaults to a
           # *development* profile (get-task-allow=1), which needs a
           # registered device this CI account has none of. The export step
@@ -163,12 +184,8 @@ jobs:
           # falls back to /releases/latest as before.
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          # The runner's default python3 is Homebrew's, which is
-          # PEP 668 "externally managed" and refuses pip installs —
-          # use a throwaway venv.
-          python3 -m venv "$RUNNER_TEMP/asc-venv"
-          "$RUNNER_TEMP/asc-venv/bin/pip" install --quiet PyJWT cryptography
-          BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 1000 )) \
+          # Reuses the venv the build-number step set up.
+          BUILD_NUMBER="${{ steps.buildnum.outputs.build_number }}" \
             "$RUNNER_TEMP/asc-venv/bin/python" \
             .github/scripts/testflight_whats_to_test.py
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -79,6 +79,11 @@ should add as close to zero as possible.
   stretch that is 6 correlations instead of 120 — and, more importantly,
   120 offset updates instead of none, since tracking no longer waits on
   someone talking.
+- Once locked, the plugin also tells the phone to **stop the reference
+  entirely** (`{"cmd":"reference","on":false}`): a live mic capture and
+  ~256 kbit/s that teach the correlation nothing more, gone — including
+  iOS's persistent mic indicator. It's requested back briefly around
+  each periodic verification, and while measuring/relocking.
 - Effect parameter handles are resolved **once**, with the effect, not per
   render (`yuv_effect()`). `video_render` runs per source per rendered
   frame on the graphics thread — the thread the whole compositor waits

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -138,6 +138,24 @@ whenever the connection drops, so a stale "live" can't outlive the OBS
 that set it. Screen-mirror connections receive it too and ignore it: the
 broadcast extension has no UI.
 
+`reference` gates the lip-sync reference (packet type 9):
+
+```json
+{ "cmd": "reference", "on": false }
+```
+
+The reference costs the phone a live mic capture and ~256 kbit/s for as
+long as it runs, but once the plugin's calibration has locked the mic
+latency it has nothing left to learn — so the plugin sends `on: false`
+after locking, and `on: true` while measuring/relocking and briefly
+around each periodic re-verification. Same on-change + re-announce
+contract as `tally`. The app only ever honours it *within* the user's own
+settings: `on: true` never starts a capture whose **Auto lip-sync
+reference** toggle is off, and `on: false` never touches a mic capture
+serving as source audio (type 10). An older app ignores the command and
+streams continuously, which the plugin handles fine; a plugin that never
+sends it gets today's always-on behaviour.
+
 Unknown commands are ignored, so new ones can be added compatibly. The
 plugin's embedded web panel (http://localhost:9980) generates these.
 
@@ -218,6 +236,20 @@ connection state). The plugin echoes it into the OBS log (prefixed
 `[lenslink][phone]`) when the source's **Verbose diagnostics** option is on,
 so both ends of the pipeline appear together — the broadcast extension has
 no console of its own. Purely informational; a receiver may ignore it.
+
+### 12 — REQUEST (app → plugin)
+CONTROL's mirror image: one UTF-8 JSON command per packet, directed at
+the plugin itself rather than the camera. Commands:
+
+```json
+{ "cmd": "recalibrate" }
+```
+
+`recalibrate` asks the plugin to discard its locked lip-sync mic latency
+and measure afresh (the app's sync pill tap; the web panel does the same
+thing via `POST /api/recalibrate`, no packet involved). Unknown commands
+are ignored, so new ones stay compatible; a plugin older than this type
+logs an unknown-type warning and carries on.
 
 ## Discovery (Bonjour)
 

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -47,6 +47,20 @@ yourself (internal testing group) and it lands on your phone via the
 TestFlight app immediately — external tester groups need a one-time beta
 review by Apple.
 
+## Build numbers come from App Store Connect
+
+Each upload's build number is **the highest build ASC has ever seen for
+the app, plus one** (`testflight_next_build.py`), regardless of version
+or state — expired builds included, since ASC's uniqueness rule spans
+them all. It used to be derived from `GITHUB_RUN_NUMBER`, which is a
+*per-workflow* counter: an upload dispatched by hand and one called from
+auto-release counted in two unrelated sequences, and the first manual
+dispatch shipped build 1011 into a history already at 1039 — a build
+TestFlight then never offered to testers, because auto-update follows
+the highest number. If ASC can't be queried, the workflow falls back to
+epoch seconds: unreadable, but strictly increasing, so a degraded run
+can never repeat that mistake.
+
 ## "What to Test" fills itself in
 
 After each upload, the workflow waits for App Store Connect to finish

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -93,6 +93,13 @@ red today: on air is not an error, and the two must stay independently
 adjustable. Preview reuses `connectAmber` — it means the same thing the
 amber statuses do, "linked, not yet live".
 
+The border's corners are **rounded** (continuous curve, ~58 pt) on
+devices whose display corners are rounded — a sharp-cornered stroke gets
+physically clipped by the panel and visibly breaks at all four corners.
+Squared displays (SE, iPads) keep square corners; erring on the large
+side is fine, curving early looks intentional where getting clipped
+looks broken.
+
 ### Lip-sync calibration (dot + label)
 
 | State      | Token          | Hex       | Label            |
@@ -102,16 +109,28 @@ amber statuses do, "linked, not yet live".
 | Locked     | `liveGreen`    | `#30D158` | "Sync locked"    |
 | Relocking  | `connectAmber` | `#FF9F0A` | "Recalibrating"  |
 
-Shown on the Live screen beside the status pill, and in the web panel's
-header as a second pill. Blue reads as *working on it*, green as *done*,
-amber as *attention, transitional* — the same reading those colours carry
-elsewhere in the product. Nothing is drawn when auto-calibrate isn't
-running, so setups that don't use it never see a readout they'd have to
-learn to ignore.
+Shown on the Live screen on **its own row under the status bar** (the
+top bar's three buttons left too little width — "Sync lo…" is worse than
+nothing), and in the web panel's header as a second pill. Blue reads as
+*working on it*, green as *done*, amber as *attention, transitional* —
+the same reading those colours carry elsewhere in the product. Nothing
+is drawn when auto-calibrate isn't running, so setups that don't use it
+never see a readout they'd have to learn to ignore — and the web panel
+also hides it while no phone is connected, because the plugin's lock
+survives disconnects by design and "Lip-sync locked" beside "Trying to
+reach the phone" reads as stale.
+
+**Recalibrate** lives with the readout, shown only in the locked state
+(the one state where it does anything): on the phone, the pill itself is
+tappable and gains a small `arrow.clockwise`; on the web panel it's a
+small button inside the pill. Both flip optimistically to the amber
+"Recalibrating" wording — the next state push corrects them if the
+request was lost.
 
 The plugin owns these states (`lipsync-cal.h`) and pushes them to the app
 in the `tally` command's `sync` field; the web panel reads the same value
-from `/api/status`.
+from `/api/status`. Recalibration requests flow back as a REQUEST packet
+(app) or `POST /api/recalibrate` (panel).
 
 ### Surfaces (dark / over-video)
 | Token          | Value                                   | Use |

--- a/ios-app/Sources/Protocol.swift
+++ b/ios-app/Sources/Protocol.swift
@@ -42,6 +42,12 @@ enum OBSCProtocol {
         /// ends of the pipeline appear together (the broadcast extension has
         /// no console of its own).
         case diag = 11
+        /// Plugin-directed request, app → plugin: UTF-8 JSON, one command
+        /// per packet — CONTROL's mirror image (e.g. "recalibrate"). The
+        /// plugin ignores commands it doesn't understand, so new ones stay
+        /// backwards-compatible; an old plugin logs an unknown-type warning
+        /// and carries on.
+        case request = 12
     }
 
     /// What a connection is streaming, sent in the HELLO / video config.

--- a/ios-app/Sources/StreamClient.swift
+++ b/ios-app/Sources/StreamClient.swift
@@ -187,6 +187,14 @@ final class StreamClient {
         send(OBSCProtocol.packet(type: .diag, payload: payload))
     }
 
+    /// Sends a plugin-directed request (REQUEST packet, CONTROL's mirror
+    /// image): one JSON command, e.g. ["cmd": "recalibrate"].
+    func sendRequest(_ command: [String: Any]) {
+        guard let payload = try? JSONSerialization.data(withJSONObject: command)
+        else { return }
+        send(OBSCProtocol.packet(type: .request, payload: payload))
+    }
+
     private func listen(on port: UInt16, advertise: Bool = true) {
         guard let nwPort = NWEndpoint.Port(rawValue: port),
               let listener = try? NWListener(using: Self.tcpParameters(), on: nwPort) else {

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -461,6 +461,16 @@ final class Streamer: ObservableObject {
     @Published private(set) var tally: Tally = .off
     @Published private(set) var syncState: SyncState = .off
 
+    /// Asks the plugin to drop its locked mic latency and calibrate afresh
+    /// (the sync pill's tap). Optimistically shows "Recalibrating" so the
+    /// tap has immediate feedback; the plugin's next tally push corrects it
+    /// if the request was lost.
+    func requestRecalibrate() {
+        guard syncState == .locked else { return }
+        syncState = .relocking
+        client.sendRequest(["cmd": "recalibrate"])
+    }
+
     /// Per-second stream health for the Live screen's optional overlay.
     /// Sampled by the adaptive-bitrate loop (already 1 Hz), so the overlay
     /// costs nothing beyond what's measured anyway.
@@ -698,6 +708,24 @@ final class Streamer: ObservableObject {
             syncState = (command["sync"] as? String)
                 .flatMap(SyncState.init(rawValue:)) ?? .off
             return
+        case "reference":
+            // The plugin stops the lip-sync reference once its calibration
+            // locks (a live mic capture and ~256 kbit/s that teach it
+            // nothing more) and asks for it back for periodic re-checks.
+            // This only ever modulates a reference the user enabled: it
+            // never starts a capture whose Options toggle is off, and
+            // never touches the phone-mic-as-source capture (type 10) —
+            // that one belongs to the "Send phone mic to OBS" setting.
+            guard sendAudioReference, !sendMicAudio else { return }
+            let on = command["on"] as? Bool ?? true
+            if !on {
+                if micCapturePurpose == .lipSyncReference {
+                    stopMicCapture()
+                }
+            } else if audioReference == nil, isStreaming {
+                Task { await startMicCapture(purpose: .lipSyncReference) }
+            }
+            return
         default:
             break
         }
@@ -891,6 +919,10 @@ final class Streamer: ObservableObject {
         }
     }
 
+    /// What the current mic capture is for, so a remote "reference off"
+    /// can never stop a capture serving the phone-mic-as-source role.
+    private var micCapturePurpose: AudioReference.Purpose?
+
     /// Captures the phone mic — as the lip-sync calibration reference
     /// (packet type 9, never heard) or as the source's playable audio
     /// (packet type 10, same wire format as screen-mirror audio).
@@ -912,12 +944,20 @@ final class Streamer: ObservableObject {
         do {
             try capture.start()
             audioReference = capture
+            micCapturePurpose = purpose
             // The STATE snapshot gates its mic fields on capture being
             // up; resend now that it is.
             scheduleStateSend()
         } catch {
             print("Mic capture failed: \(error.localizedDescription)")
         }
+    }
+
+    private func stopMicCapture() {
+        audioReference?.stop()
+        audioReference = nil
+        micCapturePurpose = nil
+        scheduleStateSend()
     }
 
     /// Adaptive bitrate: back off quickly when the link drops frames,
@@ -1011,6 +1051,7 @@ final class Streamer: ObservableObject {
         encoder = nil
         audioReference?.stop()
         audioReference = nil
+        micCapturePurpose = nil
 
         // Back to standby (if enabled and foreground) so OBS can start the
         // camera again without touching the phone. The plugin only

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -53,6 +53,12 @@ struct StreamingView: View {
 
             VStack {
                 statusBar
+                // Its own row: sharing the top bar with three buttons
+                // truncated the words ("Sync lo…"), and an unreadable
+                // status is worse than none.
+                if syncLabel != nil {
+                    syncPill
+                }
                 if showHealth, let health = streamer.health {
                     healthPill(health)
                 }
@@ -135,10 +141,26 @@ struct StreamingView: View {
         }
     }
 
+    /// Corner radius for the tally border. Modern iPhones have rounded
+    /// display corners that physically clip a sharp-cornered stroke, so the
+    /// border visibly broke at all four corners. There's no public API for
+    /// the exact panel radius; a generous continuous curve covers every
+    /// current device (their radii run ~40–55 pt) and errs by curving
+    /// slightly *inside* the corner rather than getting cut off. Squared
+    /// devices (SE, iPads) are detected by their zero bottom safe-area
+    /// inset and keep square corners.
+    private static let tallyCornerRadius: CGFloat = {
+        let bottomInset = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.windows.first }
+            .first?.safeAreaInsets.bottom ?? 0
+        return bottomInset > 0 ? 58 : 0
+    }()
+
     private func tallyEdge(_ colour: Color, width: CGFloat) -> some View {
         // allowsHitTesting(false): the border sits over the preview, and
         // tap-to-focus near the screen edge must still reach it.
-        Rectangle()
+        RoundedRectangle(cornerRadius: Self.tallyCornerRadius,
+                         style: .continuous)
             .strokeBorder(colour, lineWidth: width)
             .ignoresSafeArea()
             .allowsHitTesting(false)
@@ -157,19 +179,6 @@ struct StreamingView: View {
                     .lineLimit(1)
             }
             .glassPill()
-
-            if let sync = syncLabel {
-                HStack(spacing: Theme.Space.s) {
-                    Circle()
-                        .fill(sync.colour)
-                        .frame(width: 8, height: 8)
-                    Text(sync.text)
-                        .font(.caption)
-                        .lineLimit(1)
-                }
-                .glassPill()
-                .foregroundColor(Theme.textSecondary)
-            }
 
             Spacer()
 
@@ -209,6 +218,39 @@ struct StreamingView: View {
         case .relocking:
             return ("Recalibrating", Theme.connectAmber)
         }
+    }
+
+    /// Tapping while locked asks the plugin to throw away the measured mic
+    /// latency and calibrate afresh — for when you changed audio gear and
+    /// don't want to wait for the periodic check to notice. The arrow only
+    /// appears when the tap does something.
+    private var syncPill: some View {
+        HStack {
+            Button {
+                touched()
+                streamer.requestRecalibrate()
+            } label: {
+                HStack(spacing: Theme.Space.s) {
+                    if let sync = syncLabel {
+                        Circle()
+                            .fill(sync.colour)
+                            .frame(width: 8, height: 8)
+                        Text(sync.text)
+                            .font(.caption)
+                            .lineLimit(1)
+                        if streamer.syncState == .locked {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.caption2)
+                        }
+                    }
+                }
+                .glassPill()
+                .foregroundColor(Theme.textSecondary)
+            }
+            .disabled(streamer.syncState != .locked)
+            Spacer()
+        }
+        .padding(.top, Theme.Space.s)
     }
 
     /// One-line health readout under the status bar: encoder output rate,

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -172,6 +172,19 @@ struct ios_camera_source {
 	uint64_t cal_verified_ns; /* last correlation run while locked */
 	enum lipsync_cal_state cal_state;
 
+	/* Recalibrate requested (app's sync pill via REQUEST, or the web
+	 * panel via /api/recalibrate). A flag rather than a direct reset:
+	 * requests arrive on the web/network threads, but the calibration
+	 * history is dial-loop territory, so the dial loop consumes it. */
+	volatile bool cal_reset_requested;
+
+	/* Reference-audio gating (stage 2): while locked, the phone is told
+	 * to stop capturing/streaming the lip-sync reference; it's asked back
+	 * on briefly for each periodic verification. Dial-loop thread only. */
+	bool verify_pending;         /* reference requested for a verify */
+	uint64_t verify_started_ns;  /* when it was requested */
+	uint64_t ref_pkts_at_verify; /* reference packets seen at request */
+
 	/* Remote-control commands queued for the device (JSON strings),
 	 * pushed by the web control thread, drained by the stream thread.
 	 * Guarded by status_mutex. */
@@ -563,6 +576,10 @@ struct client_state {
 	bool tally_program;
 	bool tally_preview;
 	int tally_sync;
+	/* Last reference-gating command pushed (same per-connection
+	 * re-announce contract as tally). */
+	bool ref_valid;
+	bool ref_on;
 	uint64_t next_decoder_attempt; /* cooldown after create failure */
 	enum AVCodecID codec_id;
 	char name[128];
@@ -882,12 +899,15 @@ static void apply_calibrated_offset(struct ios_camera_source *s,
  *    agree) before latching the mic's latency.
  *  - Locked. The latched figure is a property of the audio gear, so the
  *    offset just tracks the video latency from here on — no correlation,
- *    and no dependence on the streamer making noise. The correlation
- *    re-runs only every CAL_VERIFY_INTERVAL_NS, purely to notice if the
- *    audio path changed underneath us (a re-plugged interface, a headset
- *    taking over) and re-measure if so.
+ *    and no dependence on the streamer making noise. Every
+ *    CAL_VERIFY_INTERVAL_NS the latched figure is re-confirmed, purely to
+ *    notice if the audio path changed underneath us (a re-plugged
+ *    interface, a headset taking over). Because the phone's reference is
+ *    stopped while locked (reference_tick), a verification first asks for
+ *    it back and waits for enough fresh overlap before correlating.
  */
 static void apply_auto_calibrated(struct ios_camera_source *s,
+				  struct client_state *c,
 				  int64_t video_latency_ns)
 {
 	char name[256];
@@ -911,8 +931,36 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	if (locked) {
 		apply_calibrated_offset(s, video_latency_ns, locked_mic, name,
 					video_delay, applied, true, 0);
-		if (!lipsync_cal_due_for_verify(now, s->cal_verified_ns))
+
+		if (!s->verify_pending) {
+			if (!lipsync_cal_due_for_verify(now,
+							s->cal_verified_ns))
+				return;
+			/* Confirmation due. The reference has been off since
+			 * the lock, so request it (reference_tick sends the
+			 * command on this state change) and come back once
+			 * there's audio to correlate. */
+			s->verify_pending = true;
+			s->verify_started_ns = now;
+			s->ref_pkts_at_verify = c->ref_audio_packets;
 			return;
+		}
+
+		/* Verify in flight. Wait out the command round-trip plus a
+		 * ring's worth (~6 s) of fresh reference; if none arrives —
+		 * app toggle off, or an older app that ignores the command
+		 * but whose stream predates the request — give up quietly
+		 * and try again next interval. */
+		bool have_audio = c->ref_audio_packets > s->ref_pkts_at_verify;
+		if (now - s->verify_started_ns < 10000000000ULL)
+			return;
+		if (!have_audio) {
+			if (now - s->verify_started_ns > 30000000000ULL) {
+				s->verify_pending = false;
+				s->cal_verified_ns = now;
+			}
+			return;
+		}
 	}
 
 	/* Hold the mutex only for a snapshot: the correlation is ~1.8M
@@ -931,6 +979,7 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	 * the next verification interval. */
 	if (!ok) {
 		if (locked) {
+			s->verify_pending = false;
 			s->cal_verified_ns = now;
 			return;
 		}
@@ -941,6 +990,7 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	}
 	if (conf < CAL_MIN_CONFIDENCE) {
 		if (locked) {
+			s->verify_pending = false;
 			s->cal_verified_ns = now;
 			return;
 		}
@@ -953,6 +1003,7 @@ static void apply_auto_calibrated(struct ios_camera_source *s,
 	}
 
 	if (locked) {
+		s->verify_pending = false;
 		s->cal_verified_ns = now;
 		if (!lipsync_cal_reading_invalidates(mic_delay, locked_mic))
 			return; /* still the same audio path */
@@ -1161,6 +1212,43 @@ const char *ios_camera_sync_state(struct ios_camera_source *s)
 	return cal_state_name(state);
 }
 
+/* Web panel's Recalibrate button. Just raises the flag — the dial loop
+ * owns the calibration history and performs the actual reset. */
+void ios_camera_recalibrate(struct ios_camera_source *s)
+{
+	s->cal_reset_requested = true;
+}
+
+/* Consumes a recalibrate request (dial-loop thread): drop the lock and
+ * the correlation history so calibration starts from scratch, exactly as
+ * if the audio source had just been selected. tally_tick runs right after
+ * in the same loop pass, so the phone's pill flips without extra plumbing. */
+static void recal_tick(struct ios_camera_source *s)
+{
+	if (!s->cal_reset_requested)
+		return;
+	s->cal_reset_requested = false;
+
+	pthread_mutex_lock(&s->lipsync_mutex);
+	if (s->lipsync)
+		lipsync_reset(s->lipsync);
+	pthread_mutex_unlock(&s->lipsync_mutex);
+	s->cal_count = 0;
+	s->verify_pending = false;
+
+	pthread_mutex_lock(&s->status_mutex);
+	bool was_enabled = s->audio_sync && s->auto_calibrate;
+	s->cal_locked = false;
+	s->cal_locked_mic_ns = 0;
+	s->cal_state = was_enabled ? LS_CAL_MEASURING : LS_CAL_OFF;
+	pthread_mutex_unlock(&s->status_mutex);
+
+	if (was_enabled)
+		blog(LOG_INFO,
+		     "[lenslink] auto lip-sync: recalibration requested — "
+		     "measuring afresh");
+}
+
 /*
  * Tally: tells the phone whether it's on program ("live"), merely visible
  * somewhere ("preview"), or neither — plus how lip-sync calibration is
@@ -1196,6 +1284,42 @@ static void tally_tick(struct ios_camera_source *s, struct client_state *c)
 		 program ? "true" : "false", preview ? "true" : "false",
 		 cal_state_name((enum lipsync_cal_state)sync));
 	send_control_cmd(c, json);
+}
+
+/*
+ * Reference-audio gating. The lip-sync reference costs the phone a live
+ * mic capture (with iOS's orange indicator) and ~256 kbit/s for as long
+ * as it runs — but once the mic latency is locked, the correlation has
+ * nothing left to learn from it. So the phone is told to stop it while
+ * locked, and asked for it back while measuring/relocking and for the
+ * duration of each periodic verification.
+ *
+ * Sent on change only, re-announced per connection (same contract as
+ * tally). An older app ignores the command and keeps streaming — exactly
+ * the pre-gating behaviour — and an app whose reference toggle is off
+ * ignores "on", which the verify path treats as a quiet timeout.
+ */
+static void reference_tick(struct ios_camera_source *s,
+			   struct client_state *c)
+{
+	if (c->is_screen)
+		return;
+
+	pthread_mutex_lock(&s->status_mutex);
+	bool calibrating = s->audio_sync && s->auto_calibrate &&
+			   s->audio_source[0];
+	bool locked = s->cal_locked;
+	pthread_mutex_unlock(&s->status_mutex);
+
+	/* verify_pending is dial-loop state — same thread as this tick. */
+	bool want = calibrating && (!locked || s->verify_pending);
+
+	if (c->ref_valid && c->ref_on == want)
+		return;
+	c->ref_valid = true;
+	c->ref_on = want;
+	send_control_cmd(c, want ? "{\"cmd\":\"reference\",\"on\":true}"
+				 : "{\"cmd\":\"reference\",\"on\":false}");
 }
 
 /* Asks the device to emit a fresh keyframe immediately. The screen
@@ -1275,7 +1399,7 @@ static void latency_tick(struct ios_camera_source *s, struct client_state *c)
 			/* Auto-calibrate measures the mic latency directly;
 			 * the manual path assumes a fixed device latency. */
 			if (auto_cal)
-				apply_auto_calibrated(s, avg);
+				apply_auto_calibrated(s, c, avg);
 			else
 				apply_audio_sync(s, avg);
 		}
@@ -1646,12 +1770,21 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 		/* Reference-absent check: the mic role is fixed for the
 		 * stream's lifetime (the app starts capture with the
 		 * stream), so a few seconds of live video with no type-9
-		 * packet is conclusive, not just early. */
+		 * packet is conclusive, not just early. Two expected
+		 * absences don't count: a locked source told the phone to
+		 * stop the reference itself, and a connection we've asked
+		 * to keep it off. Only an absence we *didn't* ask for means
+		 * the app's toggle is off. */
 		if (!c->ref_absent_handled && !c->is_screen &&
 		    c->ref_audio_packets == 0 && c->first_frame_ns &&
 		    os_gettime_ns() - c->first_frame_ns > 5000000000ULL) {
 			c->ref_absent_handled = true;
-			lipsync_reference_absent(s);
+			pthread_mutex_lock(&s->status_mutex);
+			bool locked = s->cal_locked;
+			pthread_mutex_unlock(&s->status_mutex);
+			bool asked_off = c->ref_valid && !c->ref_on;
+			if (!locked && !asked_off)
+				lipsync_reference_absent(s);
 		}
 		bool keyframe = (hdr->flags & OBSC_FLAG_KEYFRAME) != 0;
 		if (keyframe)
@@ -1895,6 +2028,20 @@ static bool handle_packet(struct ios_camera_source *s, struct client_state *c,
 			     (const char *)payload);
 		}
 		break;
+	case OBSC_PKT_REQUEST: {
+		/* One JSON command, CONTROL's mirror image. The command set is
+		 * tiny and flat, so a substring probe on a bounded copy stands
+		 * in for a JSON parser the plugin otherwise doesn't need (and
+		 * memmem isn't portable to Windows); unknown commands fall
+		 * through silently, keeping new ones compatible. */
+		char req[257];
+		size_t len = hdr->payload_size < 256 ? hdr->payload_size : 256;
+		memcpy(req, payload, len);
+		req[len] = '\0';
+		if (strstr(req, "\"recalibrate\""))
+			s->cal_reset_requested = true;
+		break;
+	}
 	default:
 		blog(LOG_WARNING, "[lenslink] unknown packet type %d",
 		     hdr->type);
@@ -2259,9 +2406,11 @@ static void dial_loop(struct ios_camera_source *s)
 				break;
 			if (client.out.len > 0)
 				client_flush(&client);
+			recal_tick(s);
 			latency_tick(s, &client);
 			control_tick(s, &client);
 			tally_tick(s, &client);
+			reference_tick(s, &client);
 			diag_tick(s, &client);
 			stats_tick(s, &client);
 			if (client.out.failed)

--- a/obs-plugin/src/protocol.h
+++ b/obs-plugin/src/protocol.h
@@ -51,6 +51,10 @@ enum obsc_packet_type {
 	 * useful because the broadcast extension has no console of its own.
 	 * Purely informational; ignored when diagnostics logging is off. */
 	OBSC_PKT_DIAG = 11,
+	/* Plugin-directed request, app → plugin. UTF-8 JSON, one command per
+	 * packet — CONTROL's mirror image (e.g. {"cmd":"recalibrate"}).
+	 * Unknown commands are ignored, so new ones stay compatible. */
+	OBSC_PKT_REQUEST = 12,
 };
 
 /* Reference-audio format (fixed). */

--- a/obs-plugin/src/web-control.c
+++ b/obs-plugin/src/web-control.c
@@ -82,11 +82,18 @@ static const char control_page[] =
 	"<header><h1>LensLink</h1>"
 	"<div class='pill'><span class='dot' id='dot'></span>"
 	"<span id='status'>connecting&hellip;</span></div>"
-	/* Lip-sync calibration stage — hidden unless auto-calibrate is on,
-	 * so it never nags setups that don't use it. */
+	/* Lip-sync calibration stage — hidden unless auto-calibrate is on
+	 * AND a phone is connected: the plugin keeps its lock across
+	 * reconnects (by design), but claiming "locked" beside a "trying to
+	 * reach the phone" status reads as stale nonsense. The Recalibrate
+	 * button appears only while locked — the one state where it acts. */
 	"<div class='pill' id='syncpill' style='display:none'>"
 	"<span class='dot' id='syncdot'></span>"
-	"<span id='sync'></span></div></header>"
+	"<span id='sync'></span>"
+	"<button id='recal' style='display:none;border:0;cursor:pointer;"
+	"background:var(--glass2,rgba(255,255,255,.12));color:inherit;"
+	"border-radius:999px;font-size:12px;padding:2px 10px;margin-left:4px'>"
+	"Recalibrate</button></div></header>"
 	/* Source tabs: hidden until more than one camera source is live.
 	 * Every API call carries the selected source's ?src= id. */
 	"<div class='seg' id='srctabs' "
@@ -193,6 +200,7 @@ static const char control_page[] =
 	 * resolve to window.status, not the element. */
 	"const $=id=>document.getElementById(id);"
 	"const syncEl=$('sync'),syncdotEl=$('syncdot'),syncpillEl=$('syncpill'),"
+	"recalEl=$('recal'),"
 	"dotEl=$('dot'),statusEl=$('status'),zoomEl=$('zoom'),zvEl=$('zv'),"
 	"expEl=$('exposure'),evEl=$('ev'),afEl=$('af'),mfEl=$('mf'),lensEl=$('lens'),"
 	"fhintEl=$('fhint'),flashlightEl=$('flashlight'),flipEl=$('flip'),lensselEl=$('lenssel'),"
@@ -285,6 +293,11 @@ static const char control_page[] =
 	"temperature:+wbtempEl.value}),60);"
 	"wbtempEl.oninput=()=>{touch();wbvEl.textContent=wbtempEl.value+'K';dWb()};"
 	"micselEl.onchange=()=>send({cmd:'mic',id:micselEl.value});"
+	/* Optimistic flip to 'relocking'; the 1 Hz poll corrects if lost. */
+	"recalEl.onclick=()=>{recalEl.style.display='none';"
+	"syncEl.textContent='Recalibrating lip-sync';"
+	"syncdotEl.style.background=COL.amber;"
+	"fetch('/api/recalibrate'+q(),{method:'POST'})};"
 	"function statusColor(t){t=(t||'').toLowerCase();"
 	/* Standby/starting are amber (ready, not live) — test before the
 	 * generic 'connected' match, which their wording also contains. */
@@ -312,12 +325,17 @@ static const char control_page[] =
 	"b.onclick=()=>{src=x.id;lastTouch=0;poll()};return b}))}"
 	"const s=await(await fetch('/api/status'+q())).json();"
 	"statusEl.textContent=s.status||'idle';dotEl.style.background=statusColor(s.status);"
-	/* Lip-sync stage: same words and colours as the phone's own light. */
+	/* Lip-sync stage: same words and colours as the phone's own light.
+	 * Only meaningful while a phone is connected — the plugin's lock
+	 * survives disconnects, but showing it next to a "trying to reach
+	 * the phone" status would read as stale. */
 	"const SYNC={measuring:['Measuring lip-sync',COL.accent],"
 	"locked:['Lip-sync locked',COL.live],"
 	"relocking:['Recalibrating lip-sync',COL.amber]};"
-	"const sy=SYNC[s.sync];syncpillEl.style.display=sy?'':'none';"
-	"if(sy){syncEl.textContent=sy[0];syncdotEl.style.background=sy[1]}"
+	"const sy=s.connected?SYNC[s.sync]:null;"
+	"syncpillEl.style.display=sy?'':'none';"
+	"if(sy){syncEl.textContent=sy[0];syncdotEl.style.background=sy[1];"
+	"recalEl.style.display=s.sync==='locked'?'':'none'}"
 	/* Live controls only when a camera stream is actually connected;
 	 * standby gets the Start panel; screen mirror gets the note; not
 	 * connected shows just the status pill. */
@@ -689,6 +707,19 @@ static void handle_client(socket_t client)
 			ios_camera_set_auto_start(
 				s,
 				strstr(request + body_offset, "true") != NULL);
+		pthread_mutex_unlock(&g_reg.mutex);
+		respond(client, s ? "204 No Content" : "503 Service Unavailable",
+			"text/plain", s ? NULL : "no sources");
+		return;
+	}
+
+	if (strncmp(request, "POST /api/recalibrate", 21) == 0) {
+		/* Drops the locked lip-sync mic figure and measures afresh —
+		 * the panel's Recalibrate button. No body. */
+		pthread_mutex_lock(&g_reg.mutex);
+		struct ios_camera_source *s = locked_pick_source(request);
+		if (s)
+			ios_camera_recalibrate(s);
 		pthread_mutex_unlock(&g_reg.mutex);
 		respond(client, s ? "204 No Content" : "503 Service Unavailable",
 			"text/plain", s ? NULL : "no sources");

--- a/obs-plugin/src/web-control.h
+++ b/obs-plugin/src/web-control.h
@@ -28,6 +28,9 @@ bool ios_camera_auto_start(struct ios_camera_source *s);
 /* Lip-sync calibration stage: "off", "measuring", "locked" or "relocking"
  * (docs/UI_DESIGN.md). Returns a static string — no ownership. */
 const char *ios_camera_sync_state(struct ios_camera_source *s);
+/* Requests a fresh lip-sync calibration (drops the locked mic figure).
+ * Safe from any thread; the dial loop performs the reset. */
+void ios_camera_recalibrate(struct ios_camera_source *s);
 void ios_camera_set_auto_start(struct ios_camera_source *s, bool on);
 
 /* One server, many sources. Camera sources register at create and


### PR DESCRIPTION
## What & why

Follow-up to v1.8.0-beta.1 from the first on-device feedback, plus stage 2 of the lip-sync work.

**Rendering fixes (from the screenshot).** The sync pill shared the top bar with three buttons and truncated to "Sync lo…" — it now sits on its own row under the status bar where the full wording always fits. The tally border was a sharp rectangle that modern iPhones' rounded display corners physically clip, breaking it at all four corners; it's now a continuous-curve rounded rectangle (~58 pt) on rounded-display devices (detected via the bottom safe-area inset) and stays square on squared displays. The web panel also stops claiming "Lip-sync locked" while no phone is connected — the plugin's lock survives disconnects by design, but showing it beside "Trying to reach the phone" reads as stale.

**Recalibrate.** Both remote surfaces can force a fresh measurement: the app's sync pill becomes tappable while locked (new REQUEST packet, type 12 — CONTROL's mirror image), and the web panel gets a Recalibrate button in its pill (`POST /api/recalibrate`). Both raise a flag the dial loop consumes, since the calibration history belongs to that thread. Both UIs flip optimistically to "Recalibrating"; the next state push corrects them if the request was lost.

**Reference gating (stage 2).** Once the mic latency is locked, the phone's reference — a live mic capture with iOS's persistent orange indicator, plus ~256 kbit/s — teaches the correlation nothing more. The plugin sends `{"cmd":"reference","on":false}` after locking and requests it back while measuring/relocking and around each periodic verification, which is now a handshake: request, wait ~10 s for fresh overlap, correlate, release. No audio within 30 s (toggle off, or an older app) gives up quietly and retries next interval. The app honours the command only within the user's own settings — "on" never starts a capture whose Options toggle is off, "off" never touches the phone-mic-as-source capture. The reference-absent cleanup now recognises *expected* absence; without that, a reconnect under a lock would have cleared the calibration five seconds in.

Both directions stay compatible: an older app ignores the commands and streams continuously; an older plugin logs one unknown-type warning per recalibrate tap and carries on.

## How it was tested

Linux container — code-level verification only; the rendering fixes need eyes on a device (Windows OBS + iPhone, Wi-Fi, was the beta.1 setup).

- Plugin builds clean with `-Wall -Wextra -Werror`; Swift parses clean (type check is macOS CI's job).
- The calibration policy harness's model gained the verify handshake and new scenarios: silence now yields **zero** correlations (each attempt hears nothing and gives up) instead of six; a device swap is detected across the request→warmup→correlate handshake; a toggle-off verify times out with the lock kept and the offset still tracking. 36 checks pass.
- The web panel's embedded JS was re-extracted (comment-aware — a quoted phrase in a new C comment fooled the old extractor, not the compiler) and parses; the pill/button gating table was exercised for connected × sync-state combinations.

**What to check on a device first:** border corners on the phone from the screenshot; the pill wording no longer truncating; a recalibrate tap flowing through (pill → amber → green with a fresh figure in the OBS log); and that after "locked", the orange mic indicator on the phone goes away, comes back briefly ~every 90 s, then disappears again.

Merging publishes **v1.8.0-beta.2** to the pre-release channel and TestFlight (`Release-Bump: minor` + `Release-Beta: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_