### PR TITLE
Fix web-panel Recalibrate (400 on bodyless POST) and add configurable tally light

### DIFF
--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -71,22 +71,35 @@ The status **word and colour are defined once** (`Streamer.Status.displayName`
 / `.tint` in the app) and reused by every view; the web panel maps the
 plugin's status string to the same palette.
 
-### Tally (on air)
+### Tally (screen border)
 
-| State   | Token          | Hex       | Treatment |
-|---------|----------------|-----------|-----------|
-| Live    | `tallyLive`    | `#FF3B30` | 6 pt border around the whole Live screen |
-| Preview | `tallyPreview` | `#FF9F0A` | 4 pt border (same as `connectAmber`) |
-| Neither | —              | —         | No border drawn |
+A border around the whole Live screen, driven by a **user-ordered
+priority list** of statuses (Options → Tally light): the highest status
+in the list that is currently true and has a colour lights the border.
+"Off" removes a status from consideration — lower ones show through.
 
-The tally answers one question — *am I on air?* — and must never be
-ambiguous, so it is **its own indicator**, not a mode of the status dot,
-and it carries no other meaning. It's a border rather than a dot because
-it has to read at arm's length from a phone mounted behind a monitor, and
-it draws **above the dim overlay**: the screen dims after ten seconds
-exactly when the operator is furthest away. An unlit tally is as
-meaningful as a lit one, so "not on air" draws nothing at all rather than
-a grey border that could be mistaken for a dark red one.
+| Status (default order) | Default colour | Meaning |
+|---|---|---|
+| On air | Red `tallyLive` `#FF3B30`, 6 pt | in OBS's live output |
+| In preview | Amber `connectAmber` `#FF9F0A`, 4 pt | visible but not live |
+| Connection lost | Off | streaming, link to OBS dropped |
+| Calibrating lip-sync | Off | measuring / re-measuring |
+| Lip-sync locked | Off | calibration locked on |
+
+Assignable colours: Red `#FF3B30`, Amber `#FF9F0A`, Green `#30D158`,
+Blue `#3D7BFF`, Purple `tallyPurple` `#BF5AF2`, White, or Off. The
+defaults reproduce the pre-customization behaviour exactly. On air keeps
+the heaviest stroke (6 pt vs 4 pt) whatever its colour, so live stays
+the most emphatic state.
+
+The tally's core answer — *am I on air?* — must never be ambiguous, so
+it is **its own indicator**, not a mode of the status dot. It's a border
+rather than a dot because it has to read at arm's length from a phone
+mounted behind a monitor, and it draws **above the dim overlay**: the
+screen dims after ten seconds exactly when the operator is furthest
+away. By default an unlit tally is as meaningful as a lit one — "not on
+air" draws nothing rather than a grey border that could be mistaken for
+a dark red one.
 
 `tallyLive` is deliberately separate from `errorRed` despite both being
 red today: on air is not an error, and the two must stay independently

--- a/ios-app/Sources/DesignSystem.swift
+++ b/ios-app/Sources/DesignSystem.swift
@@ -16,9 +16,11 @@ enum Theme {
     /// Tally. Deliberately its own token rather than `errorRed`: on air is
     /// not an error, and the two must stay independently adjustable even
     /// though both are red today. Preview borrows `connectAmber` — same
-    /// "linked, not yet live" meaning it already carries.
+    /// "linked, not yet live" meaning it already carries. Purple exists
+    /// only as a user-assignable tally colour (mirrors iOS systemPurple).
     static let tallyLive = Color(hex: 0xFF3B30)
     static let tallyPreview = connectAmber
+    static let tallyPurple = Color(hex: 0xBF5AF2)
 
     // Over-video surfaces
     static let glassPanel = Color.black.opacity(0.55)

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -39,6 +39,14 @@ struct OptionsView: View {
                 }
 
                 Section {
+                    NavigationLink(destination: TallyLightOptionsView()) {
+                        Text("Tally light")
+                    }
+                } footer: {
+                    Text("The coloured border around the Live screen. Choose which statuses light it, in which colours, and which takes priority.")
+                }
+
+                Section {
                     NavigationLink(destination: CameraDiagnosticsView()) {
                         Text("Camera diagnostics")
                     }

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -127,16 +127,48 @@ struct StreamingView: View {
     }
 
     /// Tally: a border round the whole screen, readable at arm's length
-    /// from behind a monitor where a small dot wouldn't be. Red is on air,
-    /// amber is in preview, and nothing is drawn otherwise — an unlit
-    /// tally has to be as unambiguous as a lit one.
-    @ViewBuilder private var tallyBorder: some View {
+    /// from behind a monitor where a small dot wouldn't be. Which statuses
+    /// light it, in which colours and priority order, is the user's call
+    /// (Options → Tally light); the defaults are red on air, amber in
+    /// preview, nothing otherwise — an unlit tally has to be as
+    /// unambiguous as a lit one.
+    @ObservedObject private var tallySettings = TallySettings.shared
+
+    /// Everything currently true about the stream, for the priority list
+    /// to pick from.
+    private var activeTallyStatuses: Set<TallyStatus> {
+        var active: Set<TallyStatus> = []
         switch streamer.tally {
-        case .live:
-            tallyEdge(Theme.tallyLive, width: 6)
-        case .preview:
-            tallyEdge(Theme.tallyPreview, width: 4)
-        case .off:
+        case .live: active.insert(.onAir)
+        case .preview: active.insert(.preview)
+        case .off: break
+        }
+        // Mid-stream link drop: the client auto-reconnects (status flips
+        // to .connecting) or died outright (.error). Either way the phone
+        // is capturing into a void, which is worth a glance-able warning
+        // if the user assigned one.
+        if streamer.isStreaming {
+            if case .error = streamer.status {
+                active.insert(.connectionLost)
+            } else if streamer.status == .connecting {
+                active.insert(.connectionLost)
+            }
+        }
+        switch streamer.syncState {
+        case .measuring, .relocking: active.insert(.calibrating)
+        case .locked: active.insert(.syncLocked)
+        case .off: break
+        }
+        return active
+    }
+
+    @ViewBuilder private var tallyBorder: some View {
+        if let light = tallySettings.activeLight(for: activeTallyStatuses) {
+            // On air keeps the heaviest stroke; everything informational
+            // stays lighter so live remains the most emphatic state even
+            // in user-chosen colours.
+            tallyEdge(light.color, width: light.status == .onAir ? 6 : 4)
+        } else {
             EmptyView()
         }
     }
@@ -165,7 +197,7 @@ struct StreamingView: View {
             .ignoresSafeArea()
             .allowsHitTesting(false)
             .transition(.opacity)
-            .animation(.easeInOut(duration: 0.15), value: streamer.tally)
+            .animation(.easeInOut(duration: 0.15), value: colour)
     }
 
     private var statusBar: some View {

--- a/ios-app/Sources/TallyLightOptions.swift
+++ b/ios-app/Sources/TallyLightOptions.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+/// Which app conditions the tally border can announce. The raw values are
+/// the persistence format — renaming one silently resets that row to its
+/// default, so don't.
+enum TallyStatus: String, Codable, CaseIterable {
+    case onAir
+    case preview
+    case connectionLost
+    case calibrating
+    case syncLocked
+
+    var displayName: String {
+        switch self {
+        case .onAir: return "On air"
+        case .preview: return "In preview"
+        case .connectionLost: return "Connection lost"
+        case .calibrating: return "Calibrating lip-sync"
+        case .syncLocked: return "Lip-sync locked"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .onAir: return "The camera is in OBS's live output."
+        case .preview: return "Visible in OBS (preview or a projector) but not live."
+        case .connectionLost: return "Streaming, but the link to OBS dropped."
+        case .calibrating: return "Auto lip-sync is measuring or re-measuring."
+        case .syncLocked: return "Auto lip-sync has locked on."
+        }
+    }
+}
+
+/// The border colours a status can be given. "None" means the status
+/// doesn't light the border at all — priority then falls through to the
+/// next status in the list.
+enum TallyColor: String, Codable, CaseIterable {
+    case none
+    case red
+    case amber
+    case green
+    case blue
+    case purple
+    case white
+
+    var displayName: String { rawValue == "none" ? "Off" : rawValue.capitalized }
+
+    /// Border colour; nil for `.none`. Values come from the shared status
+    /// palette (docs/UI_DESIGN.md) so the border speaks the same colour
+    /// language as everything else.
+    var color: Color? {
+        switch self {
+        case .none: return nil
+        case .red: return Theme.tallyLive
+        case .amber: return Theme.connectAmber
+        case .green: return Theme.liveGreen
+        case .blue: return Theme.accent
+        case .purple: return Theme.tallyPurple
+        case .white: return .white
+        }
+    }
+}
+
+/// One row of the tally configuration: a status and the colour it shows.
+/// Array order IS the priority order — first matching row with a colour
+/// wins.
+struct TallyEntry: Codable, Equatable, Identifiable {
+    var status: TallyStatus
+    var color: TallyColor
+    var id: String { status.rawValue }
+}
+
+/// Persistent tally-light configuration. The defaults reproduce the
+/// original fixed behaviour exactly (red on air, amber preview, nothing
+/// else), so nobody sees a change until they opt into one.
+/// Not @MainActor: it's referenced from view property initializers, which
+/// aren't isolated, and everything it touches (UserDefaults) is
+/// thread-safe; in practice only the UI writes it.
+final class TallySettings: ObservableObject {
+    static let shared = TallySettings()
+    private static let key = "tallyConfig"
+
+    static let defaults: [TallyEntry] = [
+        TallyEntry(status: .onAir, color: .red),
+        TallyEntry(status: .preview, color: .amber),
+        TallyEntry(status: .connectionLost, color: .none),
+        TallyEntry(status: .calibrating, color: .none),
+        TallyEntry(status: .syncLocked, color: .none),
+    ]
+
+    @Published var entries: [TallyEntry] {
+        didSet {
+            if let data = try? JSONEncoder().encode(entries) {
+                UserDefaults.standard.set(data, forKey: Self.key)
+            }
+        }
+    }
+
+    private init() {
+        var loaded = Self.defaults
+        if let data = UserDefaults.standard.data(forKey: Self.key),
+           let saved = try? JSONDecoder().decode([TallyEntry].self,
+                                                 from: data) {
+            // Merge, don't replace: statuses added in a later version keep
+            // their default colour and slot in at their default position
+            // relative to what survived.
+            loaded = saved.filter { entry in
+                Self.defaults.contains { $0.status == entry.status }
+            }
+            for def in Self.defaults where !loaded.contains(where: {
+                $0.status == def.status
+            }) {
+                loaded.append(def)
+            }
+        }
+        entries = loaded
+    }
+
+    /// The border colour for the current conditions: the first (highest
+    /// priority) entry whose status is active and isn't "Off". Also
+    /// reports the winning status, for width decisions.
+    func activeLight(for active: Set<TallyStatus>)
+        -> (status: TallyStatus, color: Color)? {
+        for entry in entries where active.contains(entry.status) {
+            if let color = entry.color.color {
+                return (entry.status, color)
+            }
+        }
+        return nil
+    }
+}
+
+/// Options → Tally light: colour per status, drag to set priority.
+struct TallyLightOptionsView: View {
+    @ObservedObject private var settings = TallySettings.shared
+
+    var body: some View {
+        List {
+            Section {
+                ForEach($settings.entries) { $entry in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.status.displayName)
+                            Text(entry.status.explanation)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Picker("", selection: $entry.color) {
+                            ForEach(TallyColor.allCases, id: \.self) { c in
+                                Label {
+                                    Text(c.displayName)
+                                } icon: {
+                                    Image(systemName: c == .none
+                                          ? "circle.slash" : "circle.fill")
+                                }
+                                .tint(c.color)
+                                .tag(c)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .fixedSize()
+                    }
+                }
+                .onMove { from, to in
+                    settings.entries.move(fromOffsets: from, toOffset: to)
+                }
+            } header: {
+                Text("Statuses, highest priority first")
+            } footer: {
+                Text("The border around the Live screen shows the colour of the highest status in this list that's currently true. Set a status to Off and it's skipped — lower statuses show through. Tap Edit to reorder.")
+            }
+
+            Section {
+                Button("Reset to defaults") {
+                    settings.entries = TallySettings.defaults
+                }
+                .disabled(settings.entries == TallySettings.defaults)
+            }
+        }
+        .navigationTitle("Tally light")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { EditButton() }
+    }
+}

--- a/obs-plugin/src/web-control.c
+++ b/obs-plugin/src/web-control.c
@@ -584,7 +584,12 @@ static void handle_client(socket_t client)
 	if (strncmp(request, "POST ", 5) == 0) {
 		const char *cl = find_header(request, "Content-Length");
 		content_length = cl ? (size_t)strtoul(cl, NULL, 10) : 0;
-		if (content_length == 0 || content_length > MAX_CONTROL_BODY) {
+		/* A zero-length body is legal here: action-only endpoints
+		 * (/api/recalibrate) POST with no body at all, and rejecting
+		 * that generically 400'd them before routing — the panel's
+		 * Recalibrate button died of exactly that. Endpoints that
+		 * *need* a body enforce it themselves below. */
+		if (content_length > MAX_CONTROL_BODY) {
 			respond(client, "400 Bad Request", "text/plain",
 				"bad length");
 			return;
@@ -700,7 +705,13 @@ static void handle_client(socket_t client)
 
 	if (strncmp(request, "POST /api/autostart", 19) == 0) {
 		/* Body: {"on":true|false}. Toggles the source's auto-start
-		 * property (same value the properties checkbox edits). */
+		 * property (same value the properties checkbox edits). An
+		 * empty body must not silently read as "false". */
+		if (content_length == 0) {
+			respond(client, "400 Bad Request", "text/plain",
+				"body required");
+			return;
+		}
 		pthread_mutex_lock(&g_reg.mutex);
 		struct ios_camera_source *s = locked_pick_source(request);
 		if (s)
@@ -727,6 +738,11 @@ static void handle_client(socket_t client)
 	}
 
 	if (strncmp(request, "POST /api/control", 17) == 0) {
+		if (content_length == 0) {
+			respond(client, "400 Bad Request", "text/plain",
+				"body required");
+			return;
+		}
 		pthread_mutex_lock(&g_reg.mutex);
 		struct ios_camera_source *s = locked_pick_source(request);
 		if (s)


### PR DESCRIPTION
## What & why

**The dead Recalibrate button.** The panel posts to `/api/recalibrate` with no body, and the server rejected every zero-length POST with `400` *before routing* — the handler never ran, nothing logged, and the pill's optimistic "Recalibrating" flip was reverted by the next 1 Hz poll. Exactly the reported symptoms. The blanket length check existed to protect the two endpoints that read their body; it now only caps oversized bodies, and `/api/control` / `/api/autostart` enforce "body required" themselves (an empty autostart body would otherwise silently read as **off** — worse than a 400).

**Configurable tally light** (Options → Tally light). The border is now driven by a user-ordered priority list instead of the fixed live/preview mapping:

| Status (default order) | Default |
|---|---|
| On air | Red |
| In preview | Amber |
| Connection lost mid-stream | Off |
| Calibrating lip-sync | Off |
| Lip-sync locked | Off |

Each status takes one of six colours (red, amber, green, blue, purple, white) or **Off**; the highest true status with a colour lights the border, and Off falls through to the next — so e.g. "amber border when the link drops, green while calibrated, red always wins when live" is a few taps. Drag to reorder (Edit), reset-to-defaults button included. Defaults reproduce the shipped behaviour exactly, so nothing changes until someone opts in. On air keeps the heaviest stroke (6 pt vs 4 pt) regardless of colour. Config persists as JSON; loading merges against defaults so future statuses appear with sane values instead of vanishing.

## How it was tested

The web bug shipped because I tested the panel JS and the plugin's reset logic but never the HTTP hop between them. That seam is now covered directly: an integration harness compiles the **real `web-control.c`** against stub source callbacks and drives it with curl over real HTTP — eleven checks, all passing:

- bodyless `POST /api/recalibrate` → 204, and the stub records the recalibrate call (with and without `?src=`)
- `/api/control` and `/api/autostart` still 204 with a body, now 400 without one; oversize body still 400
- control body arrives at the stub byte-intact; `GET /`, `/api/status` (with the `sync` field) unaffected; forged `Host:` header still 403

Also: plugin builds clean with `-Wall -Wextra -Werror`; Swift parses clean (type check in macOS CI); panel JS unchanged this round. The tally options UI needs device eyes: the reorder + colour menus, and that existing users see zero visual change until they touch the settings.

Merging publishes **v1.8.0-beta.3** (`Release-Bump: minor` + `Release-Beta: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_