### PR TITLE
Copy edit, tally swatch fix, and a well-behaved standby dim

### DIFF
--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -179,6 +179,31 @@ Native system font (SF on Apple, `system-ui` on web).
 | Label / caption | 13 regular               | Secondary text, field labels |
 | Numeric readout | 13–15 **monospaced digits** | Zoom `2.0×`, exposure `+0.3`, latency `57 ms` — monospaced so values don't jitter while dragging |
 
+### Microcopy (hints, footers, captions)
+
+Explanatory text is a cost the reader pays on every visit. The rules:
+
+- **A hint earns its place by adding a consequence or constraint the
+  control's label can't carry** — a precondition ("while the app is open
+  and idle"), a cost ("the phone stays awake"), a boundary ("iOS mutes
+  DRM audio"). A hint that restates the label, or describes what the
+  reader can see, gets deleted, not shortened.
+- **At most two sentences** — three only when one footer covers two
+  controls (the Microphone section). Anything longer belongs in the
+  README, one tap away.
+- Sentence case; no exclamation marks; no "please". Em-dash asides over
+  nested parentheses. Numbers as numerals ("10 seconds").
+- **American English** in user-facing copy ("color"), matching the
+  platform's own language. (These docs may write "colour"; the UI must
+  not.)
+- Name OBS-side things exactly as OBS shows them: a "LensLink Camera"
+  source, the Phone IP field.
+- Overlay/status lines follow the pattern *state — action*: "Streaming —
+  tap to wake", "Not visible by name in OBS — tap to allow…".
+- Diagnostics (probe results, extension checks) are exempt from the
+  length rules — a failed check should say exactly what to do next — but
+  follow the `✓ / ✗ + state — action` pattern.
+
 ---
 
 ## 4. Spacing, radius, sizing

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -65,7 +65,11 @@ While remote start is armed the phone holds its idle timer (auto-lock
 would suspend the listener and kill remote start), so the Setup screen
 reuses the Live screen's near-black tap-to-wake dim overlay — on a
 60-second fuse instead of 10, with the icon in `connectAmber` rather
-than `liveGreen` (armed, not live).
+than `liveGreen` (armed, not live). Both dims answer to the one "Dim
+screen to save battery" toggle, and the standby dim never fires while
+the user is interacting: any touch resets the fuse, and it can't trigger
+while a sheet is open (the overlay would sit behind the sheet with its
+tap-to-wake unreachable).
 
 The status **word and colour are defined once** (`Streamer.Status.displayName`
 / `.tint` in the app) and reused by every view; the web panel maps the

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -191,7 +191,7 @@ struct ContentView: View {
                         UIApplication.shared.open(url)
                     }
                 } label: {
-                    Label("Not visible by name in OBS — tap to allow Local Network access in Settings. Connecting by IP still works.",
+                    Label("Not visible by name in OBS — tap to allow Local Network in Settings. Connecting by IP still works.",
                           systemImage: "wifi.exclamationmark")
                         .font(.footnote)
                         .foregroundColor(.secondary)
@@ -199,7 +199,7 @@ struct ContentView: View {
             }
             DisclosureGroup("How to connect", isExpanded: $showConnectionHelp) {
                 Label {
-                    Text("Install the LensLink plugin in OBS Studio (see the GitHub link below), then add the source you want — camera or screen — from **Sources → +**.")
+                    Text("Install the LensLink plugin in OBS (GitHub link below), then add a **LensLink Camera** or **LensLink Screen** source.")
                         .font(.callout)
                         .foregroundColor(.secondary)
                 } icon: {
@@ -207,11 +207,11 @@ struct ContentView: View {
                 }
                 Label {
                     if let ip = wifiIP {
-                        Text("Point it at this phone: enter \(Text(ip).bold()) as the Phone IP (same Wi-Fi), or plug in a USB cable and set Connection to \"USB cable\" (Windows needs iTunes).")
+                        Text("Enter \(Text(ip).bold()) as the source's Phone IP (same Wi-Fi) — or plug in USB and set Connection to \"USB cable\" (Windows needs iTunes).")
                             .font(.callout)
                             .foregroundColor(.secondary)
                     } else {
-                        Text("No Wi-Fi address found — connect to Wi-Fi, or plug in a USB cable and set the source's Connection to \"USB cable\" (Windows needs iTunes).")
+                        Text("No Wi-Fi address — join Wi-Fi, or plug in USB and set the source's Connection to \"USB cable\" (Windows needs iTunes).")
                             .font(.callout)
                             .foregroundColor(.secondary)
                     }
@@ -338,7 +338,7 @@ struct ContentView: View {
         } header: {
             Text("Screen mirror")
         } footer: {
-            Text("Streams your whole screen, with app audio, to a \"LensLink Screen\" source in OBS. DRM audio (Apple Music, Netflix) is muted by iOS during broadcasts.")
+            Text("Streams your whole screen, with app audio, to a \"LensLink Screen\" source in OBS. iOS mutes DRM audio (Apple Music, Netflix).")
         }
         .onAppear {
             // Whether the extension survived sideloading — the broadcast

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -52,10 +52,19 @@ struct ContentView: View {
                 tailSection
             }
             .tint(Theme.accent)
+            // Every touch is activity — scrolling and reading included.
+            // Before this, only streamer-visible changes reset the standby
+            // dim's fuse, so a minute spent in a menu that doesn't touch
+            // the streamer (the tally screen, say) read as "idle" and the
+            // screen dimmed mid-use.
+            .simultaneousGesture(DragGesture(minimumDistance: 0)
+                .onChanged { _ in lastInteraction = Date() })
             .sheet(isPresented: $showOptions) {
                 OptionsView()
                     .environmentObject(streamer)
             }
+            // Opening or closing the sheet is activity too.
+            .onChange(of: showOptions) { _ in lastInteraction = Date() }
 
             if dimmed {
                 dimOverlay
@@ -85,7 +94,12 @@ struct ContentView: View {
         .task {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
-                if streamer.standbyActive && !dimmed &&
+                // Gated on the dim setting (one switch governs both dims)
+                // and on no sheet being up: the overlay would sit behind
+                // the sheet with its tap-to-wake unreachable, leaving the
+                // screen dark with no visible way back.
+                if streamer.standbyActive && streamer.dimWhileStreaming &&
+                    !showOptions && !dimmed &&
                     Date().timeIntervalSince(lastInteraction) > Self.dimAfterSeconds {
                     dim()
                 } else if !streamer.standbyActive && dimmed {

--- a/ios-app/Sources/DesignSystem.swift
+++ b/ios-app/Sources/DesignSystem.swift
@@ -61,6 +61,17 @@ extension Color {
     }
 }
 
+extension UIColor {
+    /// Same palette as Color(hex:), for the places SwiftUI colour
+    /// modifiers don't reach (rendered UIImages in menus).
+    convenience init(hex: UInt32) {
+        self.init(red: CGFloat((hex >> 16) & 0xFF) / 255,
+                  green: CGFloat((hex >> 8) & 0xFF) / 255,
+                  blue: CGFloat(hex & 0xFF) / 255,
+                  alpha: 1)
+    }
+}
+
 /// A circular 44 pt glass control button (icon only). `active` fills it
 /// with the accent colour (e.g. flashlight on).
 struct ControlButton: View {

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -15,14 +15,14 @@ struct OptionsView: View {
                     Toggle("Remote start from OBS",
                            isOn: $streamer.remoteStartEnabled)
                 } footer: {
-                    Text("While the app is open and idle, OBS can start the camera for you — automatically when its source connects, or from the source's \"Start camera on the phone\" button. The phone stays awake while it waits (the screen dims after a minute — tap to wake); locking it or leaving the app ends remote start. Siri works too: \"Start streaming with LensLink.\"")
+                    Text("While the app is open and idle, OBS can start the camera for you. The phone stays awake while it waits — locking it or leaving the app ends remote start. Siri: \"Start streaming with LensLink.\"")
                 }
 
                 Section {
                     Toggle("Dim screen while streaming",
                            isOn: $streamer.dimWhileStreaming)
                 } footer: {
-                    Text("The screen dims after 10 seconds of streaming to save battery; tap it to wake.")
+                    Text("Dims 10 seconds into streaming to save battery — tap to wake.")
                 }
 
                 Section {
@@ -35,7 +35,7 @@ struct OptionsView: View {
                 } footer: {
                     // One capture, two jobs — Streamer enforces the
                     // exclusivity; this footer is where users learn it.
-                    Text("**Send phone mic** streams this phone's microphone as the camera source's audio in OBS — a wireless mic.\n\n**Auto lip-sync** sends the mic purely as a timing reference so the plugin can auto-align your real microphone — it's never streamed or heard.\n\nOne mic, one role: turning one on turns the other off.")
+                    Text("**Send phone mic** makes this phone the camera's audio in OBS — a wireless mic. **Auto lip-sync** sends the mic only as a timing reference for aligning your real microphone; it's never heard. One mic, one role — turning one on turns the other off.")
                 }
 
                 Section {
@@ -43,7 +43,7 @@ struct OptionsView: View {
                         Text("Tally light")
                     }
                 } footer: {
-                    Text("The coloured border around the Live screen. Choose which statuses light it, in which colours, and which takes priority.")
+                    Text("The colored border around the Live screen while streaming.")
                 }
 
                 Section {
@@ -51,7 +51,7 @@ struct OptionsView: View {
                         Text("Camera diagnostics")
                     }
                 } footer: {
-                    Text("The camera's capture formats and which system video effects (Control Center) each supports — copy it into a bug report when an effect you expect is missing.")
+                    Text("The camera's formats and which Control Center video effects each supports — paste into a bug report if an effect is missing.")
                 }
             }
             .navigationTitle("Options")

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -19,10 +19,10 @@ struct OptionsView: View {
                 }
 
                 Section {
-                    Toggle("Dim screen while streaming",
+                    Toggle("Dim screen to save battery",
                            isOn: $streamer.dimWhileStreaming)
                 } footer: {
-                    Text("Dims 10 seconds into streaming to save battery — tap to wake.")
+                    Text("Dims 10 seconds into streaming, or a minute into remote-start standby — tap to wake. Never while you're using the app.")
                 }
 
                 Section {

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -144,6 +144,10 @@ final class Streamer: ObservableObject {
     @Published var codec: VideoCodec {
         didSet { UserDefaults.standard.set(codec.rawValue, forKey: "videoCodec") }
     }
+    /// "Dim screen to save battery": governs both the Live screen's 10 s
+    /// dim and the Setup screen's standby dim. The name and stored key
+    /// predate the standby dim being brought under it — the key stays so
+    /// nobody's preference resets.
     @Published var dimWhileStreaming: Bool {
         didSet { UserDefaults.standard.set(dimWhileStreaming, forKey: "dimWhileStreaming") }
     }

--- a/ios-app/Sources/TallyLightOptions.swift
+++ b/ios-app/Sources/TallyLightOptions.swift
@@ -20,15 +20,6 @@ enum TallyStatus: String, Codable, CaseIterable {
         }
     }
 
-    var explanation: String {
-        switch self {
-        case .onAir: return "The camera is in OBS's live output."
-        case .preview: return "Visible in OBS (preview or a projector) but not live."
-        case .connectionLost: return "Streaming, but the link to OBS dropped."
-        case .calibrating: return "Auto lip-sync is measuring or re-measuring."
-        case .syncLocked: return "Auto lip-sync has locked on."
-        }
-    }
 }
 
 /// The border colours a status can be given. "None" means the status
@@ -130,7 +121,7 @@ final class TallySettings: ObservableObject {
     }
 }
 
-/// Options → Tally light: colour per status, drag to set priority.
+/// Options → Tally light: color per status, drag to set priority.
 struct TallyLightOptionsView: View {
     @ObservedObject private var settings = TallySettings.shared
 
@@ -139,12 +130,7 @@ struct TallyLightOptionsView: View {
             Section {
                 ForEach($settings.entries) { $entry in
                     HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(entry.status.displayName)
-                            Text(entry.status.explanation)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
+                        Text(entry.status.displayName)
                         Spacer()
                         Picker("", selection: $entry.color) {
                             ForEach(TallyColor.allCases, id: \.self) { c in
@@ -169,7 +155,7 @@ struct TallyLightOptionsView: View {
             } header: {
                 Text("Statuses, highest priority first")
             } footer: {
-                Text("The border around the Live screen shows the colour of the highest status in this list that's currently true. Set a status to Off and it's skipped — lower statuses show through. Tap Edit to reorder.")
+                Text("The highest status here that's currently true sets the border color; Off skips it. Tap Edit to reorder.")
             }
 
             Section {

--- a/ios-app/Sources/TallyLightOptions.swift
+++ b/ios-app/Sources/TallyLightOptions.swift
@@ -50,6 +50,50 @@ enum TallyColor: String, Codable, CaseIterable {
         case .white: return .white
         }
     }
+
+    /// The same values as UIColor, for the menu dots: SwiftUI tint/
+    /// foreground modifiers are ignored inside Menu/Picker items (every
+    /// symbol renders in the accent colour), but an original-rendering
+    /// UIImage keeps its pixels. Hexes must match the Theme tokens above.
+    private var uiColor: UIColor? {
+        switch self {
+        case .none: return nil
+        case .red: return UIColor(hex: 0xFF3B30)
+        case .amber: return UIColor(hex: 0xFF9F0A)
+        case .green: return UIColor(hex: 0x30D158)
+        case .blue: return UIColor(hex: 0x3D7BFF)
+        case .purple: return UIColor(hex: 0xBF5AF2)
+        case .white: return .white
+        }
+    }
+
+    /// A pre-rendered swatch that survives menu rendering: a filled dot in
+    /// the actual colour, or a stroked slashed circle for Off.
+    var dotImage: UIImage {
+        let side: CGFloat = 16
+        let rect = CGRect(x: 0, y: 0, width: side, height: side)
+        let image = UIGraphicsImageRenderer(size: rect.size).image { ctx in
+            let g = ctx.cgContext
+            if let fill = uiColor {
+                fill.setFill()
+                g.fillEllipse(in: rect.insetBy(dx: 1, dy: 1))
+                if self == .white {
+                    // A white dot on a white menu needs an edge.
+                    UIColor.separator.setStroke()
+                    g.setLineWidth(1)
+                    g.strokeEllipse(in: rect.insetBy(dx: 1.5, dy: 1.5))
+                }
+            } else {
+                UIColor.secondaryLabel.setStroke()
+                g.setLineWidth(1.5)
+                g.strokeEllipse(in: rect.insetBy(dx: 1.5, dy: 1.5))
+                g.move(to: CGPoint(x: 3.5, y: side - 3.5))
+                g.addLine(to: CGPoint(x: side - 3.5, y: 3.5))
+                g.strokePath()
+            }
+        }
+        return image.withRenderingMode(.alwaysOriginal)
+    }
 }
 
 /// One row of the tally configuration: a status and the colour it shows.
@@ -137,10 +181,8 @@ struct TallyLightOptionsView: View {
                                 Label {
                                     Text(c.displayName)
                                 } icon: {
-                                    Image(systemName: c == .none
-                                          ? "circle.slash" : "circle.fill")
+                                    Image(uiImage: c.dotImage)
                                 }
-                                .tint(c.color)
                                 .tag(c)
                             }
                         }


### PR DESCRIPTION
## What & why

**The copy edit.** Every hint, footer, and caption in the app went through one filter: *does this add a consequence or constraint the control's label can't carry?* A hint that restates its label or describes what's on screen was deleted, not shortened.

Deleted outright:
- The five per-row captions in Tally light ("On air — The camera is in OBS's live output" told nobody anything).
- The tally footer's second sentence, which described the screen the reader was about to open.

Tightened while keeping every distinct fact:
- **Remote start** — precondition, awake cost, end conditions, and the Siri phrase at half the length.
- **Microphone** — three paragraphs → three sentences; still covers both toggles and the one-mic-one-role rule.
- **Dim**, **Camera diagnostics**, both **How to connect** steps, the **Local Network** notice, and the **Screen mirror** DRM note.

The rules now live in `docs/UI_DESIGN.md` as a Microcopy section: hints must earn their place, two sentences max, sentence case, numerals, em-dash asides, *state — action* pattern for overlays, exact OBS-side names, American English in UI copy. Diagnostics are exempt from the length rules — a failed check should say exactly what to do next.

**The swatch fix** (device feedback): the tally color picker's dots all rendered accent-blue. SwiftUI discards tint/foreground modifiers on symbols inside Menu/Picker items. The swatches are now pre-rendered `UIImage`s, which menus display with their real pixels — each dot is the exact hex it paints the border, white gets a hairline edge, Off is a slashed outline.

**The standby dim, tamed** (device feedback): the Setup screen dims a minute into remote-start standby — deliberate, it's what makes holding the phone awake for remote start affordable — but it fired while the app was actively in use, because only streamer-visible changes reset the fuse (a minute in the tally menu read as "idle"), and it could fire *under an open sheet*, leaving the screen near-black with the tap-to-wake target unreachable behind the sheet. Now: any touch on the form resets the fuse (zero-distance simultaneous gesture, so scrolls count), opening/closing the Options sheet counts as activity, the dim is blocked while a sheet is up, and the whole thing answers to the dim toggle — renamed **"Dim screen to save battery"** since it now governs both dims. Stored key unchanged, so nobody's preference resets. A mounted, untouched phone still dims; the battery guard survives.

## How it was tested

Copy, one picker-rendering change, and dim-gating logic — Swift parses clean, full type check in macOS CI. Device checks that matter: the swatches show their real colors; sitting in the tally menu for over a minute no longer dims; the screen can't go dark while the Options sheet is open; a phone left untouched in standby still dims after a minute; and the shortened copy reads right in place.

Merging publishes **v1.8.0-beta.4** (`Release-Bump: minor` + `Release-Beta: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT