### PR TITLE
Release v1.8.0: version the app from the release tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -173,10 +173,10 @@ jobs:
   # workflows (GitHub's recursion guard), so the TestFlight upload would
   # silently not happen for auto-releases.
   # Only when the push touched ios-app/: the version stream is repo-wide,
-  # but a plugin- or installer-only release would otherwise upload a
-  # byte-identical app (MARKETING_VERSION is static; only the injected
-  # build number changes) — burning a macOS runner, an App Store Connect
-  # build number, and a tester update notification for nothing.
+  # but a plugin- or installer-only release would otherwise upload an app
+  # whose code hasn't changed (only the injected version/build number
+  # would differ) — burning a macOS runner, an App Store Connect build
+  # number, and a tester update notification for nothing.
   # Betas upload here too — TestFlight *is* the beta channel, so a
   # pre-release that skipped it would defeat the point. The tag is passed
   # explicitly because the "What to Test" lookup otherwise falls back to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,13 +352,19 @@ jobs:
       - name: Build unsigned device IPA
         run: |
           set -o pipefail
+          # Same version-from-tag rule as testflight.yml, so the sideload
+          # IPA reports the release it came from instead of a static 1.0.
+          version="${{ inputs.tag_name || github.ref_name }}"
+          version="${version#v}"
+          version="${version%%-*}"
           xcodebuild build \
             -project LensLink.xcodeproj \
             -scheme LensLink \
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -derivedDataPath DerivedData \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="$version"
           mkdir -p Payload
           cp -R DerivedData/Build/Products/Release-iphoneos/LensLink.app Payload/
           zip -ry LensLink-unsigned.ipa Payload

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -114,9 +114,22 @@ jobs:
       - name: Archive (unsigned)
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # The release tag, whichever trigger delivered it. Empty on a
+          # bare manual dispatch — the project.yml default applies then.
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
           set -o pipefail
           BUILD_NUMBER="${{ steps.buildnum.outputs.build_number }}"
+          # TestFlight's "Version" comes from the tag: v1.8.2 -> 1.8.2,
+          # and a beta strips to its base version (v1.8.2-beta.3 -> 1.8.2;
+          # ASC rejects suffixed version strings) — betas of a version are
+          # told apart by build number, which is the TestFlight convention.
+          APP_VERSION="${RELEASE_TAG#v}"
+          APP_VERSION="${APP_VERSION%%-*}"
+          VERSION_OVERRIDE=""
+          if [ -n "$APP_VERSION" ]; then
+            VERSION_OVERRIDE="MARKETING_VERSION=$APP_VERSION"
+          fi
           # Archive WITHOUT signing. Automatic signing here defaults to a
           # *development* profile (get-task-allow=1), which needs a
           # registered device this CI account has none of. The export step
@@ -131,7 +144,8 @@ jobs:
             DEVELOPMENT_TEAM="$TEAM_ID" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            $VERSION_OVERRIDE
         working-directory: ios-app
 
       - name: Export & upload to TestFlight

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -192,14 +192,33 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           ASC_KEY_P8: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
           BUNDLE_ID: com.exaltedpixels.LensLinkCamera
-          ASC_BETA_GROUPS: ${{ vars.ASC_BETA_GROUPS }}
+          # Group assignment splits by channel: ASC_BETA_GROUPS is for
+          # STABLE releases only (the name predates pre-releases and stays
+          # for compatibility); pre-releases use ASC_PRERELEASE_GROUPS,
+          # normally unset — a beta then reaches only the internal group,
+          # with no variable-juggling between beta and release pushes.
+          STABLE_GROUPS: ${{ vars.ASC_BETA_GROUPS }}
+          PRERELEASE_GROUPS: ${{ vars.ASC_PRERELEASE_GROUPS }}
+          IS_PRERELEASE: >-
+            ${{ contains(inputs.tag || github.event.release.tag_name, '-beta.')
+                || github.event.release.prerelease == true }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Empty for a release-triggered or manual run, where the script
           # falls back to /releases/latest as before.
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
+          # Selected in shell, not a ${{ && || }} chain: an unset
+          # pre-release variable would make the "ternary" fall through to
+          # the stable groups — exactly the assignment a beta must not do.
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            ASSIGN_GROUPS="$PRERELEASE_GROUPS"
+            echo "pre-release: assigning to [${ASSIGN_GROUPS:-internal only}]"
+          else
+            ASSIGN_GROUPS="$STABLE_GROUPS"
+          fi
           # Reuses the venv the build-number step set up.
-          BUILD_NUMBER="${{ steps.buildnum.outputs.build_number }}" \
+          ASC_BETA_GROUPS="$ASSIGN_GROUPS" \
+            BUILD_NUMBER="${{ steps.buildnum.outputs.build_number }}" \
             "$RUNNER_TEMP/asc-venv/bin/python" \
             .github/scripts/testflight_whats_to_test.py
 

--- a/docs/TESTFLIGHT.md
+++ b/docs/TESTFLIGHT.md
@@ -80,8 +80,14 @@ repository variable**:
 
 | Variable | Value |
 |---|---|
-| `ASC_BETA_GROUPS` | comma-separated TestFlight group names, exactly as they appear in App Store Connect (e.g. `Friends, Public Beta`) |
+| `ASC_BETA_GROUPS` | comma-separated TestFlight group names, exactly as they appear in App Store Connect (e.g. `Friends, Public Beta`). **Stable releases only.** |
+| `ASC_PRERELEASE_GROUPS` | same format, used for `-beta.N` pre-releases instead. Normally unset: a beta then reaches only internal testers, and nobody has to clear `ASC_BETA_GROUPS` before a beta and restore it after. |
 
+- Which variable applies is decided per upload from the release tag
+  (`-beta.` in the tag, or a release flagged pre-release). A bare manual
+  dispatch with no tag counts as stable.
+- `ASC_BETA_GROUPS` keeps its historical name for compatibility — read
+  it as "the groups a finished release goes to", not "beta groups".
 - **Internal groups** (App Store Connect team members) get the build
   immediately. (For internal groups you can also skip all of this and
   enable the group's built-in "automatic distribution" toggle in App

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -69,8 +69,11 @@ targets:
         SWIFT_VERSION: "5.0"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "1" # CI overrides with the run number
+        # CI overrides MARKETING_VERSION from the release tag (v1.8.2 ->
+        # 1.8.2, betas stripped to their base version) so TestFlight shows
+        # the real version; this value only covers local Xcode builds.
+        MARKETING_VERSION: "1.8.0"
+        CURRENT_PROJECT_VERSION: "1" # CI overrides with the next ASC build number
         # AppIntents (Siri shortcuts) is iOS 16+; the deployment target is
         # 15, so it must be weak-linked or the app won't launch on iOS 15.
         OTHER_LDFLAGS: "-weak_framework AppIntents"
@@ -110,5 +113,5 @@ targets:
         TARGETED_DEVICE_FAMILY: "1,2"
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
-        MARKETING_VERSION: "1.0"
+        MARKETING_VERSION: "1.8.0" # must match the app's; CI overrides both
         CURRENT_PROJECT_VERSION: "1" # matched to the app by CI


### PR DESCRIPTION
## What & why

**This is the v1.8.0 release PR.** Everything meant for 1.8.0 is already on `main` from the beta train (beta.1–beta.4: lip-sync lock + reference gating, tally light + customization, recalibrate on both surfaces, the copy edit, and the release/build-number plumbing). Auto Release reads trailers per merge, so cutting the stable release needs one more merge that touches `ios-app/` and carries `Release-Bump: minor` **without** `Release-Beta` — this PR is that merge, with two real changes as its vehicle:

**1. The app versions itself from the release tag.** TestFlight has shown every build as "Version 1.0" since the project's first day — `MARKETING_VERSION` was hardcoded. Both CI build paths now derive it from the tag: `v1.8.2` → `1.8.2`, betas strip to their base version (`v1.8.2-beta.3` → `1.8.2`; App Store Connect rejects suffixed version strings — betas distinguish themselves by build number). The sideload IPA gets the same treatment. `project.yml`'s value becomes `1.8.0` on both targets (the extension must match the app) and now only covers local Xcode builds.

**2. TestFlight group assignment splits by channel.** `ASC_BETA_GROUPS` was applied on every upload, forcing manual variable-clearing to keep betas internal-only. Now: stable releases assign to `ASC_BETA_GROUPS` (name kept for compatibility — read it as "the groups a finished release goes to"), pre-releases assign to a new, normally-unset `ASC_PRERELEASE_GROUPS`, and unset means a beta reaches internal testers only. Channel comes from the tag (`-beta.` or the release's pre-release flag); a bare manual dispatch counts as stable. Selection is done in shell, not a `${{ && || }}` chain — an unset variable would make that "ternary" fall through to the stable groups, exactly the assignment a beta must not make.

Also retires a stale comment in `auto-release.yml` that claimed "MARKETING_VERSION is static."

## How it was tested

All workflow files re-validate as YAML; `project.yml` parses. The tag→version derivation was exercised for stable/beta/empty (`v1.8.0` → `1.8.0`, `v1.8.2-beta.3` → `1.8.2`, bare dispatch → project default). The group selection truth table was exercised directly: beta+unset → nothing (script skips assignment), beta+set → pre-release groups, stable → `ASC_BETA_GROUPS` either way. The script's empty-means-skip path already existed and is unchanged.

First-run checks after merge: the TestFlight build should read **Version 1.8.0** in App Store Connect, and — this being a stable release — it should auto-assign to the `ASC_BETA_GROUPS` groups as before.

## What merging does

Publishes **v1.8.0** as a normal release — "Latest" on GitHub for the first time since v1.7.3, README badge updates — and TestFlight receives it as **Version 1.8.0** with the next ASC-derived build number, distributed to your configured groups. The four betas stay on the releases page, marked pre-release, as the trail that led here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT