### PR TITLE
Fix "What to Test" attribute name; port the video-effects experiment (supersedes #64)

### DIFF
--- a/.github/scripts/testflight_whats_to_test.py
+++ b/.github/scripts/testflight_whats_to_test.py
@@ -4,7 +4,8 @@
 Runs right after the TestFlight upload: waits for App Store Connect to
 finish processing the build (matched by CFBundleVersion), writes the
 latest GitHub release's "What's Changed" section — converted to plain
-text — into the build's betaBuildLocalizations `whatsToTest` attribute
+text — into the build's betaBuildLocalizations `whatsNew` attribute
+(Apple's API name for the field the UI labels "What to Test")
 (exactly what testers see under "What to Test" in the TestFlight app),
 then assigns the build to the beta groups named in ASC_BETA_GROUPS.
 External groups are submitted for beta app review automatically — the
@@ -27,7 +28,7 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from testflight_feedback import ASC_BASE, asc_get, asc_token, gh, request
 
-MAX_LEN = 4000        # ASC limit for whatsToTest
+MAX_LEN = 4000        # ASC limit for whatsNew ("What to Test")
 POLL_SECONDS = 60
 POLL_LIMIT = 30       # ~30 min; processing usually takes 5-15
 
@@ -185,12 +186,12 @@ def main():
             f"{ASC_BASE}/v1/betaBuildLocalizations/{loc_id}", token,
             method="PATCH",
             body={"data": {"type": "betaBuildLocalizations", "id": loc_id,
-                           "attributes": {"whatsToTest": text}}})
+                           "attributes": {"whatsNew": text}}})
     else:
         status, resp = request(
             f"{ASC_BASE}/v1/betaBuildLocalizations", token, method="POST",
             body={"data": {"type": "betaBuildLocalizations",
-                           "attributes": {"whatsToTest": text,
+                           "attributes": {"whatsNew": text,
                                           "locale": "en-US"},
                            "relationships": {"build": {"data": {
                                "type": "builds", "id": build_id}}}}})

--- a/README.md
+++ b/README.md
@@ -308,12 +308,16 @@ are the places to watch.
 - **Control Center's Video Effects (Portrait, Studio Light…) are missing
   or greyed out while streaming:** those system effects are toggled by
   you in Control Center while an app uses the camera — but iOS only
-  offers them on certain cameras and capture formats: mostly the front
-  camera, at moderate settings (think 1080p at 30 fps, not 4K/60), on
-  hardware that supports each effect. Center Stage is iPad-only.
-  LensLink picks an effect-capable format whenever your
-  resolution/frame-rate choice allows one; if the panel is still empty,
-  drop the frame rate or resolution, or switch to the front camera.
+  offers them on certain cameras and capture formats, typically the
+  front camera at moderate settings (think 1080p, not 4K); on many
+  iPhones the rear cameras offer none at all, while newer hardware
+  extends more effects to more cameras. The app's **Options → Camera
+  diagnostics** table shows exactly what your device offers per camera
+  and format. LensLink picks an effect-capable format whenever your
+  resolution/frame-rate choice allows one; if the panel is still empty
+  on a format the table says supports effects, try **Options → Allow
+  system video effects** (experimental — lets iOS vary the frame rate,
+  which the effects may require).
   Apple's Camera-app filters and Photographic Styles aren't available
   to any third-party camera app — for creative looks, add filters to
   the source in OBS instead (right-click the source → **Filters**).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -201,8 +201,12 @@ Deliberate divergences (don't "fix" these without reading this):
   lets auto-exposure sag the frame rate in low light, like the Camera
   app's Auto FPS. A sagging cadence hurts the encoder's rate control,
   OBS timing, and the lip-sync/latency math; we hold cadence and let the
-  image get noisier instead. The thermal throttle above is the one
-  sanctioned exception.
+  image get noisier instead. Two sanctioned exceptions: the thermal
+  throttle above, and the opt-in **Allow system video effects** toggle
+  (Options), which leaves the max duration at the format default —
+  the Control Center effects appear to require that downward
+  flexibility, and the toggle exists to prove or disprove exactly that.
+  The thermal path keeps max unlocked too while the toggle is on.
 - **Video stabilization stays off** (the AVCaptureVideoDataOutput
   default). Every stabilization mode adds frames of latency; this is a
   latency-first product. Revisit only as an opt-in.

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -278,6 +278,7 @@ final class CameraManager: NSObject {
     var onSystemPressure: ((AVCaptureDevice.SystemPressureState.Level) -> Void)?
     private var pressureObservation: NSKeyValueObservation?
     private var configuredFps: Int32 = 30
+    private var configuredFrameRateLock = true
     private var fpsThrottled = false
 
     private func systemPressureChanged(on device: AVCaptureDevice) {
@@ -306,7 +307,15 @@ final class CameraManager: NSObject {
         do {
             try device.lockForConfiguration()
             device.activeVideoMinFrameDuration = duration
-            device.activeVideoMaxFrameDuration = duration
+            // Min alone caps the rate; pinning max too is the cadence
+            // lock. When the video-effects experiment has unlocked max,
+            // keep it unlocked through thermal throttling as well — the
+            // throttle's goal (a lower ceiling) is met by min, and
+            // re-pinning max here would silently end the experiment
+            // after one pressure episode.
+            if configuredFrameRateLock {
+                device.activeVideoMaxFrameDuration = duration
+            }
             device.unlockForConfiguration()
         } catch {
             print("Frame-rate throttle failed: \(error.localizedDescription)")
@@ -318,16 +327,18 @@ final class CameraManager: NSObject {
     /// keep the throwing API).
     func configure(lens: Lens,
                    resolution: Resolution,
-                   fps: Int32) throws {
+                   fps: Int32,
+                   lockFrameRate: Bool = true) throws {
         try sessionQueue.sync {
             try configureOnQueue(lens: lens, resolution: resolution,
-                                 fps: fps)
+                                 fps: fps, lockFrameRate: lockFrameRate)
         }
     }
 
     private func configureOnQueue(lens: Lens,
                                   resolution: Resolution,
-                                  fps: Int32) throws {
+                                  fps: Int32,
+                                  lockFrameRate: Bool) throws {
         let position = lens.position
         session.beginConfiguration()
         defer { session.commitConfiguration() }
@@ -357,9 +368,18 @@ final class CameraManager: NSObject {
 
         try device.lockForConfiguration()
         device.activeFormat = format
+        // Min duration always caps the rate at the user's choice. The max
+        // (the cadence lock, see PERFORMANCE.md) is normally pinned too —
+        // but the "Allow system video effects" experiment leaves it at the
+        // format default, giving iOS the downward flexibility the Control
+        // Center effects appear to demand: the reproducing iPhone 15 Pro
+        // shows effect-capable formats chosen and active, yet a blank
+        // Video Effects panel — the lock is the last variable standing.
         let frameDuration = CMTime(value: 1, timescale: fps)
         device.activeVideoMinFrameDuration = frameDuration
-        device.activeVideoMaxFrameDuration = frameDuration
+        if lockFrameRate {
+            device.activeVideoMaxFrameDuration = frameDuration
+        }
         device.unlockForConfiguration()
         activeDevice = device
 
@@ -368,6 +388,7 @@ final class CameraManager: NSObject {
         // .shutdown iOS stops capture on its own (surfaced through the
         // interruption observers above).
         configuredFps = fps
+        configuredFrameRateLock = lockFrameRate
         fpsThrottled = false
         pressureObservation?.invalidate()
         pressureObservation = device.observe(\.systemPressureState,

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -39,6 +39,13 @@ struct OptionsView: View {
                 }
 
                 Section {
+                    Toggle("Allow system video effects",
+                           isOn: $streamer.allowVideoEffects)
+                } footer: {
+                    Text("Experimental: lets iOS lower the frame rate on its own, which the Control Center video effects (Portrait, Studio Light) may require. Takes effect when the camera next starts.")
+                }
+
+                Section {
                     NavigationLink(destination: TallyLightOptionsView()) {
                         Text("Tally light")
                     }

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -86,7 +86,8 @@ final class Streamer: ObservableObject {
         do {
             try camera.configure(lens: selectedLens,
                                  resolution: resolution,
-                                 fps: Int32(fps))
+                                 fps: Int32(fps),
+                                 lockFrameRate: !allowVideoEffects)
         } catch {
             // Never swallow this: a failed reconfigure leaves the session
             // without input/output — a black stream labelled "Live".
@@ -150,6 +151,13 @@ final class Streamer: ObservableObject {
     /// nobody's preference resets.
     @Published var dimWhileStreaming: Bool {
         didSet { UserDefaults.standard.set(dimWhileStreaming, forKey: "dimWhileStreaming") }
+    }
+    /// Experiment: leave the max frame duration unlocked so iOS may lower
+    /// the rate on its own — which the Control Center video effects appear
+    /// to require (see CameraManager.configure). Applies when the camera
+    /// next starts.
+    @Published var allowVideoEffects: Bool {
+        didSet { UserDefaults.standard.set(allowVideoEffects, forKey: "allowVideoEffects") }
     }
     /// Send phone-mic audio as a lip-sync calibration reference (never
     /// played out — the plugin correlates it against your real mic).
@@ -537,6 +545,7 @@ final class Streamer: ObservableObject {
         codec = VideoCodec(rawValue: defaults.string(forKey: "videoCodec") ?? "")
             ?? (VideoEncoder.isSupported(.hevc) ? .hevc : .h264)
         dimWhileStreaming = defaults.object(forKey: "dimWhileStreaming") as? Bool ?? true
+        allowVideoEffects = defaults.bool(forKey: "allowVideoEffects")
         sendAudioReference = defaults.bool(forKey: "sendAudioReference")
         // didSet doesn't run during init; enforce the exclusivity here.
         sendMicAudio = defaults.bool(forKey: "sendMicAudio")
@@ -880,7 +889,8 @@ final class Streamer: ObservableObject {
         do {
             try camera.configure(lens: selectedLens,
                                  resolution: resolution,
-                                 fps: Int32(fps))
+                                 fps: Int32(fps),
+                                 lockFrameRate: !allowVideoEffects)
             try encoder.start()
         } catch {
             status = .error(error.localizedDescription)


### PR DESCRIPTION
## What & why

Two changes riding one beta.

**"What to Test" has failed on every upload since it was written** — invisibly, behind `continue-on-error`, until the v1.8.0 run surfaced it. Apple's UI labels the field "What to Test" but the API attribute on `betaBuildLocalizations` is **`whatsNew`**; the script used the label as the attribute name and ASC answered `409 ENTITY_ERROR.ATTRIBUTE.UNKNOWN` every time. Renamed at both call sites (PATCH of an existing localization, POST of a new one).

**The "Allow system video effects" experiment from #64**, ported onto current main (its branch predated four betas and a release and had gone stale). Field data from the reproducing iPhone 15 Pro shows effect-capable formats being *chosen and active* on the front camera with the Video Effects panel blank anyway — and rear formats advertising no effects at all. The last variable separating LensLink from effect-working apps is the hard frame-duration lock, so the toggle (Options, default **off**) keeps the minimum duration — the chosen rate stays the ceiling — but leaves the max at the format default, giving iOS the downward flexibility the effects appear to require.

One flaw fixed relative to #64 as written: the **thermal-throttle path re-pinned the max duration**, which would have silently ended the experiment after a single `.critical` pressure episode; `applyFrameRate` now respects the lock flag (the throttle's goal — a lower ceiling — is met by the min duration alone). The Options footer is rewritten to the microcopy rules, and the README troubleshooting entry now reflects the diagnostics-table reality: modern iPhones expose no rear-camera effects, and the per-device truth lives in Options → Camera diagnostics.

## How it was tested

The script fix went through a local mock of the ASC API that implements **Apple's actual contract** — `whatsNew` accepted; any other attribute gets the production 409 shape — with ES256 JWT verification (aud + kid). Fourteen checks: the fixed script passes the PATCH path and the POST path end-to-end (processing-poll included, `time.sleep` stubbed per the repo's verify recipe), and the **pre-fix script against the same mock reproduces the production failure verbatim** — 409 naming `whatsToTest`, groups still assigned, exit 1 — which is what makes the green runs evidential.

Swift parses clean (type check in macOS CI). The experiment itself is device-tested by design: front camera, 1080p/30, Control Center with the toggle **off** (baseline: blank panel) then **on** (hypothesis: panel populates). Either result is informative — populated means the cadence lock was the gate and the toggle graduates to a documented feature; still blank means the lock is exonerated and the next bisect is a vanilla-session probe.

Merging publishes **v1.8.1-beta.1** (patch bump + `Release-Beta: true`) — internal TestFlight only under the new group split, and the first production run of the `whatsNew` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_