### PR TITLE
Declare the Video Effects Info.plist opt-ins — the panel was empty by policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,15 +309,17 @@ are the places to watch.
   or greyed out while streaming:** those system effects are toggled by
   you in Control Center while an app uses the camera — but iOS only
   offers them on certain cameras and capture formats, typically the
-  front camera at moderate settings (think 1080p, not 4K); on many
+  front camera at moderate settings (nothing above 1920×1440); on many
   iPhones the rear cameras offer none at all, while newer hardware
   extends more effects to more cameras. The app's **Options → Camera
   diagnostics** table shows exactly what your device offers per camera
-  and format. LensLink picks an effect-capable format whenever your
-  resolution/frame-rate choice allows one; if the panel is still empty
-  on a format the table says supports effects, try **Options → Allow
-  system video effects** (experimental — lets iOS vary the frame rate,
-  which the effects may require).
+  and format, and LensLink picks an effect-capable format whenever your
+  resolution/frame-rate choice allows one. If an effect toggle shows but
+  greys out, drop the frame rate — effects can cap the capture rate, and
+  **Options → Allow system video effects** lets iOS vary it. (Versions
+  before 1.8.1 never showed the panel at all: iOS only populates it for
+  apps that declare each effect in their Info.plist, which LensLink now
+  does.)
   Apple's Camera-app filters and Photographic Styles aren't available
   to any third-party camera app — for creative looks, add filters to
   the source in OBS instead (right-click the source → **Filters**).

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -41,6 +41,16 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         NSCameraUsageDescription: >-
           LensLink streams your camera to OBS on your computer.
+        # Control Center's Video Effects panel (Portrait, Studio Light,
+        # Reactions) populates automatically only for VoIP/conferencing
+        # apps; a plain camera app must opt in per effect with these keys,
+        # or the panel stays EMPTY no matter what the active format's
+        # capability flags say — which it did, on every device, until
+        # these were added. (iOS also excludes formats above 1920x1440
+        # from effects regardless; see the Camera diagnostics table.)
+        NSCameraPortraitEffectEnabled: true
+        NSCameraStudioLightEnabled: true
+        NSCameraReactionEffectGesturesEnabled: true
         NSLocalNetworkUsageDescription: >-
           LensLink connects to OBS Studio on your local network to send the
           camera feed.


### PR DESCRIPTION
## What & why

Root cause of the blank Control Center Video Effects panel, found after beta.1's frame-lock experiment came back negative: **iOS only auto-populates that panel for VoIP/conferencing apps.** A plain camera app must declare each effect in its Info.plist — `NSCameraPortraitEffectEnabled`, `NSCameraStudioLightEnabled`, `NSCameraReactionEffectGesturesEnabled` — or the panel stays empty regardless of what the active format's capability flags advertise. LensLink never declared any of them.

This explains every observation at once:
- effect-capable formats provably chosen and active on the front camera, panel blank anyway;
- blank on **every** camera and setting;
- the beta.1 frame-duration experiment changing nothing — the lock was never reachable as a cause behind the missing declarations.

Apple's other documented gate corroborates the 15 Pro diagnostics table: **formats above 1920×1440 are excluded from effects**, and the flagless front-camera rows are exactly the ones above that line.

The "Allow system video effects" toggle stays: with the panel now populated, effects that cap the capture rate can grey out at 60 fps, and the toggle is what lets iOS vary the rate to run them. README troubleshooting rewritten around the real mechanism.

## How it was tested

`project.yml` parses; the keys ride the app target's `info.properties` into the generated Info.plist. Honest caveat: the mechanism is confirmed by Apple's developer documentation/forums, but the end-to-end proof is the device — **front camera, 1080p/30, Control Center**: the panel should now show Portrait/Studio Light/Reactions toggles. If it populates, this was the whole story; if toggles appear but grey at 60 fps, flip **Allow system video effects** — that's the case the beta.1 toggle exists for.

Merging publishes **v1.8.1-beta.2**, internal TestFlight only.

Sources for the mechanism: [Apple Developer Forums — enabling the Portrait effect in a third-party camera app](https://developer.apple.com/forums/thread/706199), [9to5Mac — iOS 15 portrait video effects in third-party apps](https://9to5mac.com/2021/06/08/ios-15-portrait-video-audio-effects/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_