### PR TITLE
Release v1.8.1: add the missing Reactions availability key

### DIFF
--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -50,6 +50,10 @@ targets:
         # from effects regardless; see the Camera diagnostics table.)
         NSCameraPortraitEffectEnabled: true
         NSCameraStudioLightEnabled: true
+        # Reactions has TWO keys: this one makes the effect available at
+        # all (its absence is why Reactions alone stayed missing on the
+        # first pass), the Gestures one governs the hand-gesture trigger.
+        NSCameraReactionEffectsEnabled: true
         NSCameraReactionEffectGesturesEnabled: true
         NSLocalNetworkUsageDescription: >-
           LensLink connects to OBS Studio on your local network to send the


### PR DESCRIPTION
## What & why

**This is the v1.8.1 stable-promotion PR.** Everything on `main` past v1.8.0 is device-tested: the `whatsNew` "What to Test" fix (proven on the beta.1/beta.2 uploads), the "Allow system video effects" toggle, and the Video Effects Info.plist opt-ins — Portrait and Studio Light confirmed working on the 15 Pro at 1080p60.

The change riding it: Reactions stayed absent from the now-working panel because Apple splits it across **two** keys — `NSCameraReactionEffectGesturesEnabled` (added last beta) only governs the hand-gesture trigger, while availability itself is `NSCameraReactionEffectsEnabled`, now added. Both effects that matter for streaming already work; this completes the set.

## How it was tested

`project.yml` parses; the two shipped effects are user-confirmed on-device. Reactions availability is verified the same way the other keys were — on the device after this build lands (low stakes either way; the user considers Reactions optional).

## What merging does

No beta trailer → Auto Release cuts **v1.8.1** as a normal release: "Latest" on GitHub, TestFlight as Version 1.8.1 with the next ASC build number, auto-assigned to the stable test groups under the channel split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_