### PR TITLE
HDR stage 2 (zero-copy 10-bit) + Apple Log capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ blanks the source.
   ~40% less data). The app only offers resolution/frame-rate combinations
   your specific camera supports.
 - **HDR streaming (beta).** On cameras that support it, an **HDR (HLG)**
-  toggle captures and streams 10-bit HLG over HEVC; OBS renders it
+  option captures and streams 10-bit HLG over HEVC; OBS renders it
   correctly on both SDR and HDR canvases. Off by default — SDR remains
   the standard path.
+- **Apple Log (beta).** On Pro iPhones (iOS 17+), stream a flat 10-bit
+  **Apple Log** image and grade it yourself with OBS's Apply LUT filter
+  — the plugin decodes it faithfully and otherwise keeps its hands off.
+  Nothing else in this space offers it.
 - **Pick any lens** — Main, Ultra Wide, Telephoto, or Front — switchable
   live while you stream.
 - **Hold it however.** The app's UI follows the phone's rotation (unless

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -183,6 +183,15 @@ process CPU. Capture→decode latency and decoded fps are measured before
 the pipelines diverge and showed no systematic difference — those are
 set by the network and the phone's encoder, not by the render path.
 
+The table above is 8-bit. 10-bit streams (HLG / Apple Log) gained the
+same zero-copy path (D3D11 shared P010, VAAPI R16/GR1616 dmabuf) a
+release later; the sanity check applies unchanged — pixel copies must
+read 0.00 with the GPU pipeline on, and at 10 bits the eliminated
+copy traffic is 2× the 8-bit figures. A before/after bench pair for a
+10-bit config still needs to be captured and pasted here (macOS is
+excluded: VideoToolbox converts 10-bit to 8-bit BGRA itself, so HDR
+there renders via the RGBA path).
+
 ## Apple capture guidance: what we follow, what we deliberately don't
 
 The iOS capture/encode path was audited against Apple's AVFoundation and
@@ -210,12 +219,14 @@ Deliberate divergences (don't "fix" these without reading this):
 - **Video stabilization stays off** (the AVCaptureVideoDataOutput
   default). Every stabilization mode adds frames of latency; this is a
   latency-first product. Revisit only as an opt-in.
-- **The wire defaults to 8-bit 4:2:0 video-range** (`420v`). With the
-  opt-in HDR toggle the camera path switches to 10-bit HLG (`x420`
-  capture, HEVC Main10) end-to-end — but 10-bit only ever enters the
-  pipeline through that toggle. SDR capture, the screen mirror, and the
-  H.264 path stay 8-bit; keep the 8-bit paths free of 10-bit branches
-  (the decoder maps formats per-frame, so SDR costs nothing extra).
+- **The wire defaults to 8-bit 4:2:0 video-range** (`420v`). The
+  opt-in colour modes switch the camera path to 10-bit end-to-end —
+  HLG captures `x420`, Apple Log captures `x422` (its formats are the
+  10-bit-422 class; VideoToolbox does the 4:2:0 downsample inside the
+  Main10 encode) — but 10-bit only ever enters the pipeline through
+  that setting. SDR capture, the screen mirror, and the H.264 path
+  stay 8-bit; keep the 8-bit paths free of 10-bit branches (the
+  decoder maps formats per-frame, so SDR costs nothing extra).
 - **Rotation is sensor-native** (`.landscapeRight`, an effective 0°).
   The AVCaptureConnection docs warn per-frame rotation costs; we never
   rotate the stream, only the on-phone preview.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -60,14 +60,21 @@ change mid-stream resets the decoder (the next keyframe re-initializes it).
 authoritative values come from the bitstream parameter sets.
 
 An optional `"color"` field names the stream's colour mode: `"hlg"`
-(10-bit HEVC, BT.2020 primaries, HLG transfer) today, with `"log"`
-(Apple Log) reserved for a future mode. Absent = 8-bit SDR BT.709, which
-every stream was before the field existed. Like dimensions, it is
-**informational** — the decoder takes the authoritative colour
-description from the bitstream's VUI, so a receiver that ignores the
-field still renders correctly; it exists so UIs can label the stream
-without decoding it. HDR streams are HEVC-only (the iPhone encoder has
-no 10-bit H.264) and camera-only (screen broadcast stays 8-bit).
+(10-bit HEVC, BT.2020 primaries, HLG transfer) or `"log"` (10-bit
+HEVC, **Apple Log 1**: BT.2020 primaries and matrix, Apple's log curve
+— the VUI carries transfer *unspecified*, because H.273 has no code
+point for Apple Log; the receiver shows the flat log image untouched
+for LUT grading). `"log2"` (Apple Log 2, which uses Apple-Gamut
+primaries, not BT.2020) is reserved and must not be sent as `"log"`.
+Absent = 8-bit SDR BT.709, which every stream was before the field
+existed. For `"hlg"` the field is **informational** — the decoder
+takes the authoritative colour description from the bitstream's VUI;
+for `"log"` it is the *only* label (an elementary stream cannot carry
+Apple Log identity), though a receiver that ignores it still renders
+the flat image correctly since the VUI's matrix/primaries are real and
+transfer-unspecified decodes as-is. 10-bit streams are HEVC-only (the
+iPhone encoder has no 10-bit H.264) and camera-only (screen broadcast
+stays 8-bit).
 
 ### 3 — VIDEO
 Payload: one H.264 or HEVC **access unit in Annex B format** (start-code
@@ -201,6 +208,13 @@ The snapshot also carries white-balance and manual-exposure state
 `supportsManualExposure` so UIs hide what the camera lacks) and the
 capture format (`resolution`/`fps`/`codec` with `resolutions`/
 `frameRates`/`codecs` capability lists for `set_format` pickers).
+
+While a 10-bit colour pipeline is active the snapshot says so —
+`"hdr": true` for HLG, `"color": "log"` for Apple Log — and the
+`codecs` list shrinks to `["hevc"]`, which is how remote UIs refuse
+H.264 through the ordinary `set_format` validation. Both fields are
+absent on SDR streams, whose snapshots are unchanged from before
+colour modes existed.
 
 While the phone mic streams as the source's audio (packet type 10), the
 snapshot additionally carries `micEnabled: true`, the selected `mic` id,

--- a/ios-app/Sources/CameraManager.swift
+++ b/ios-app/Sources/CameraManager.swift
@@ -33,7 +33,7 @@ final class CameraManager: NSObject {
             switch color {
             case .sdr:
                 return base
-            case .hlg:
+            case .hlg, .log:
                 // 10-bit carries more data per pixel; give it headroom.
                 return base * 5 / 4
             }
@@ -173,8 +173,9 @@ final class CameraManager: NSObject {
         // Require exact dimensions and a frame-rate range covering the
         // requested rate; earlier formats (unbinned, video-range) win ties.
         // HLG additionally requires a 10-bit (x420) format that can
-        // capture BT.2020 HLG — nil (unsupported) if none exists. SDR
-        // considers every format, exactly as before colour existed.
+        // capture BT.2020 HLG; Apple Log a 10-bit 4:2:2 (x422) format
+        // that can capture .appleLog — nil (unsupported) if none exists.
+        // SDR considers every format, exactly as before colour existed.
         let candidates = device.formats.filter { format in
             let dims = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
             guard dims.width == target.width, dims.height == target.height else {
@@ -187,6 +188,17 @@ final class CameraManager: NSObject {
                 guard CMFormatDescriptionGetMediaSubType(format.formatDescription)
                         == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
                       format.supportedColorSpaces.contains(.HLG_BT2020) else {
+                    return false
+                }
+            case .log:
+                // Log-capable device formats are x422, NOT the x420 HLG
+                // uses. `.appleLog` is iOS 17+; below that there are no
+                // candidates, so Log degrades/clamps exactly like an
+                // HLG-less combo does.
+                guard #available(iOS 17.0, *) else { return false }
+                guard CMFormatDescriptionGetMediaSubType(format.formatDescription)
+                        == kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange,
+                      format.supportedColorSpaces.contains(.appleLog) else {
                     return false
                 }
             }
@@ -273,14 +285,16 @@ final class CameraManager: NSObject {
     }
 
     /// Colour column of the diagnostics table: the format's bit depth
-    /// plus the HDR colour spaces it can capture. This is the per-device
-    /// truth behind the HDR toggle — and, once Apple Log lands, behind
-    /// that too — the same way the effect flags are for Video Effects.
+    /// plus the HDR/Log colour spaces it can capture. This is the
+    /// per-device truth behind the colour picker's HDR and Apple Log
+    /// choices, the same way the effect flags are for Video Effects.
     private static func colourFlags(_ format: AVCaptureDevice.Format) -> String {
         let subtype = CMFormatDescriptionGetMediaSubType(
             format.formatDescription)
+        // x422 is the Apple Log capture subtype — 10-bit like the x420s.
         let tenBit = subtype == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
             || subtype == kCVPixelFormatType_420YpCbCr10BiPlanarFullRange
+            || subtype == kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange
         var flags = [tenBit ? "10bit" : "8bit "]
         if format.supportedColorSpaces.contains(.HLG_BT2020) {
             flags.append("HLG")
@@ -319,11 +333,26 @@ final class CameraManager: NSObject {
     }
 
     /// Whether this combo has a 10-bit HLG capture format — the UI's
-    /// gate for what the HDR toggle can actually deliver.
+    /// gate for what the HDR choice can actually deliver.
     static func hdrAvailable(lens: Lens, resolution: Resolution,
                              fps: Int32) -> Bool {
         supports(resolution: resolution, fps: fps, lens: lens, color: .hlg)
     }
+
+    /// Whether any lens on this device has an Apple Log capture format —
+    /// the UI's gate for offering the Apple Log choice at all. Always
+    /// false below iOS 17 (`.appleLog` doesn't exist there). Cached like
+    /// `VideoEncoder.hdrSupported`: it walks every lens's format table,
+    /// far too expensive to run per SwiftUI render of the picker.
+    static let appleLogCaptureAvailable: Bool = {
+        guard #available(iOS 17.0, *) else { return false }
+        return availableLenses().contains { lens in
+            guard let device = device(for: lens) else { return false }
+            return device.formats.contains {
+                $0.supportedColorSpaces.contains(.appleLog)
+            }
+        }
+    }()
 
     /// Fires on system-pressure (thermal/power) level changes, on the
     /// main queue — Streamer scales the bitrate down in response.
@@ -410,14 +439,15 @@ final class CameraManager: NSObject {
         // Format is chosen manually below; presets can't express 4K60.
         session.sessionPreset = .inputPriority
 
-        // For HLG we set the device's colour space ourselves below, so
-        // the session must not manage it (it would override our choice
-        // on input changes). For SDR, automatic is the iOS default —
-        // keeping it preserves the pre-HDR behaviour exactly.
+        // For HLG and Apple Log we set the device's colour space
+        // ourselves below, so the session must not manage it (it would
+        // override our choice on input changes). For SDR, automatic is
+        // the iOS default — keeping it preserves the pre-HDR behaviour
+        // exactly.
         switch color {
         case .sdr:
             session.automaticallyConfiguresCaptureDeviceForWideColor = true
-        case .hlg:
+        case .hlg, .log:
             session.automaticallyConfiguresCaptureDeviceForWideColor = false
         }
 
@@ -447,6 +477,12 @@ final class CameraManager: NSObject {
             break
         case .hlg:
             device.activeColorSpace = .HLG_BT2020
+        case .log:
+            if #available(iOS 17.0, *) {
+                device.activeColorSpace = .appleLog
+            }
+            // No else: format(for:) has no Log candidates below iOS 17,
+            // so configure has already thrown before reaching here.
         }
         // Min duration always caps the rate at the user's choice. The max
         // (the cadence lock, see PERFORMANCE.md) is normally pinned too —
@@ -488,31 +524,40 @@ final class CameraManager: NSObject {
         session.addOutput(output)
         videoOutput = output
 
+        // Video-range in every pipeline; only the depth/chroma differ.
+        // Apple Log delivers x422 (the Log formats' native subtype);
+        // VideoToolbox accepts x422 into a Main10 HEVC session and
+        // converts internally, so the encoder needs no pixel-format
+        // knowledge.
+        let outputPixelFormat: OSType
+        switch color {
+        case .sdr:
+            outputPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        case .hlg:
+            outputPixelFormat = kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+        case .log:
+            outputPixelFormat = kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange
+        }
         // The pixel format is chosen AFTER the output joins the session:
         // a detached output only advertises the generic 8-bit formats —
-        // x420 enters availableVideoPixelFormatTypes once the output is
-        // connected to a device whose active format is 10-bit — and
+        // x420/x422 enter availableVideoPixelFormatTypes once the output
+        // is connected to a device whose active format is 10-bit — and
         // assigning a format missing from that list raises an NSException
         // Swift cannot catch (the issue #81 TestFlight crash).
-        if color == .hlg,
-           !output.availableVideoPixelFormatTypes.contains(
-               kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange) {
+        if color != .sdr,
+           !output.availableVideoPixelFormatTypes.contains(outputPixelFormat) {
             // Degrade to SDR rather than crash — and rebuild the whole
             // graph (begin/commit pairs nest) so the format choice,
             // colour space, and wide-colour management all match: 8-bit
-            // capture behind an HLG-tagged Main10 encode would reach OBS
-            // with the wrong colours.
+            // capture behind a Main10 encode tagged for HLG or Log would
+            // reach OBS with the wrong colours.
             return try configureOnQueue(lens: lens, resolution: resolution,
                                         fps: fps,
                                         lockFrameRate: lockFrameRate,
                                         color: .sdr)
         }
-        // Video-range in both pipelines; only the bit depth differs.
         output.videoSettings = [
-            kCVPixelBufferPixelFormatTypeKey as String:
-                color == .hlg
-                    ? kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
-                    : kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            kCVPixelBufferPixelFormatTypeKey as String: outputPixelFormat
         ]
 
         if let connection = output.connection(with: .video) {

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -261,9 +261,10 @@ struct ContentView: View {
             }
 
             Picker("Codec", selection: $streamer.codec) {
-                // HDR is HEVC-only; offering H.264 would let the picker
-                // pick a value the didSet immediately reverts.
-                if !streamer.hdrEnabled {
+                // HDR and Apple Log are HEVC-only; offering H.264 would
+                // let the picker pick a value the didSet immediately
+                // reverts.
+                if streamer.colorSetting == .sdr {
                     Text(VideoCodec.h264.label).tag(VideoCodec.h264)
                 }
                 if VideoEncoder.isSupported(.hevc) {

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -46,13 +46,26 @@ struct OptionsView: View {
                 }
 
                 // Hidden entirely on devices that can't encode Main10 —
-                // a toggle that can never work is worse than none.
+                // a choice that can never work is worse than none (only
+                // "Standard" would remain). Apple Log appears only when
+                // some lens actually has a Log capture format (iOS 17+).
                 if VideoEncoder.hdrSupported {
                     Section {
-                        Toggle("HDR (10-bit HEVC)",
-                               isOn: $streamer.hdrEnabled)
+                        Picker("Color", selection: $streamer.colorSetting) {
+                            Text("Standard").tag(StreamColor.sdr)
+                            Text("HDR (HLG)").tag(StreamColor.hlg)
+                            if CameraManager.appleLogCaptureAvailable {
+                                Text("Apple Log").tag(StreamColor.log)
+                            }
+                        }
                     } footer: {
-                        Text("Streams 10-bit HLG color — OBS tone-maps it for SDR scenes, and HDR canvases get the real thing. HEVC only; takes effect when the camera next starts.")
+                        if CameraManager.appleLogCaptureAvailable {
+                            // Three sentences covering two choices — the
+                            // sanctioned exception (docs/UI_DESIGN.md).
+                            Text("HDR streams 10-bit HLG color — OBS tone-maps it for SDR scenes. Apple Log streams a flat 10-bit image made for grading with a LUT in OBS; both are HEVC-only and take effect when the camera next starts.")
+                        } else {
+                            Text("HDR streams 10-bit HLG color — OBS tone-maps it for SDR scenes, and HDR canvases get the real thing. HEVC only; takes effect when the camera next starts.")
+                        }
                     }
                 }
 

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -154,27 +154,30 @@ final class Streamer: ObservableObject {
     @Published var codec: VideoCodec {
         didSet {
             UserDefaults.standard.set(codec.rawValue, forKey: "videoCodec")
-            // HDR is 10-bit HEVC Main10 only; switching to H.264
-            // switches it off (mirrors the mic toggles' exclusivity).
-            if codec == .h264 && hdrEnabled {
-                hdrEnabled = false
+            // HLG and Apple Log are 10-bit HEVC Main10 only; switching
+            // to H.264 resets the colour to Standard (mirrors the mic
+            // toggles' exclusivity).
+            if codec == .h264 && colorSetting != .sdr {
+                colorSetting = .sdr
             }
         }
     }
-    /// Stream 10-bit HLG (HDR) instead of 8-bit BT.709. HEVC only —
-    /// enabling it forces the codec — and it degrades to SDR (never a
-    /// dead stream) when the device or the current lens/format can't
-    /// capture HLG; see `activeColor`.
-    @Published var hdrEnabled: Bool {
+    /// The colour pipeline the user chose: Standard (8-bit BT.709),
+    /// HDR (10-bit HLG), or Apple Log (10-bit, iOS 17+). Non-Standard is
+    /// HEVC only — choosing it forces the codec — and it degrades to SDR
+    /// (never a dead stream) when the device or the current lens/format
+    /// can't capture it; see `activeColor`.
+    @Published var colorSetting: StreamColor {
         didSet {
-            UserDefaults.standard.set(hdrEnabled, forKey: "hdrEnabled")
-            if hdrEnabled && codec != .hevc {
+            UserDefaults.standard.set(colorSetting.rawValue,
+                                      forKey: "streamColor")
+            if colorSetting != .sdr && codec != .hevc {
                 codec = .hevc
             }
             // The capture pixel format and the encoder profile both
             // follow the colour, so a live stream rebuilds like a
             // format change.
-            if isStreaming && hdrEnabled != oldValue {
+            if isStreaming && colorSetting != oldValue {
                 reconfigureLiveCapture(formatChanged: true)
             }
         }
@@ -184,17 +187,22 @@ final class Streamer: ObservableObject {
     var activeColor: StreamColor { color(for: resolution, fps: fps) }
 
     /// `activeColor`'s degrade rule, parameterised so remote format
-    /// requests can be validated for a combo before it's applied: HDR
-    /// falls back to SDR — never to a black stream — when the encoder
-    /// can't do Main10 or the combo has no HLG capture format.
+    /// requests can be validated for a combo before it's applied: the
+    /// chosen colour falls back to SDR — never to a black stream, and
+    /// never sideways to the other 10-bit pipeline (a Log stream that
+    /// silently turned HLG would be graded wrong; predictable beats
+    /// clever) — when the encoder can't do Main10 or the combo has no
+    /// matching capture format. Below iOS 17 Apple Log has no capture
+    /// formats at all, so `.log` can never survive this check there.
     private func color(for resolution: CameraManager.Resolution,
                        fps: Int) -> StreamColor {
-        guard hdrEnabled, VideoEncoder.hdrSupported,
+        guard colorSetting != .sdr, VideoEncoder.hdrSupported,
               CameraManager.supports(resolution: resolution, fps: Int32(fps),
-                                     lens: selectedLens, color: .hlg) else {
+                                     lens: selectedLens,
+                                     color: colorSetting) else {
             return .sdr
         }
-        return .hlg
+        return colorSetting
     }
     /// "Dim screen to save battery": governs both the Live screen's 10 s
     /// dim and the Setup screen's standby dim. The name and stored key
@@ -406,16 +414,16 @@ final class Streamer: ObservableObject {
         // capture may have degraded HLG to SDR (see configure) — and the
         // settings' intent covers the idle case.
         let color = encoder?.color ?? activeColor
-        // While HLG is active the only valid codec is HEVC; advertising
-        // just it makes remote UIs refuse h264 switches through the
-        // existing set_format validation machinery.
+        // While HLG or Apple Log is active the only valid codec is HEVC;
+        // advertising just it makes remote UIs refuse h264 switches
+        // through the existing set_format validation machinery.
         let codecs: [String]
         switch color {
         case .sdr:
             codecs = VideoCodec.allCases
                 .filter { VideoEncoder.isSupported($0) }
                 .map { $0.rawValue }
-        case .hlg:
+        case .hlg, .log:
             codecs = [VideoCodec.hevc.rawValue]
         }
         var state: [String: Any] = [
@@ -451,10 +459,18 @@ final class Streamer: ObservableObject {
             "frameRates": frameRates,
             "codecs": codecs,
         ]
-        // Absent = SDR — remote UIs key off the key's absence, and an
+        // Absent = SDR — remote UIs key off the keys' absence, and an
         // SDR snapshot must look exactly as it did before HDR existed.
-        if color == .hlg {
+        // HLG keeps the original "hdr" flag byte-for-byte; Apple Log is
+        // announced as "color": "log" instead (and never "hdr" — a Log
+        // stream is scene-referred, not display HDR).
+        switch color {
+        case .sdr:
+            break
+        case .hlg:
             state["hdr"] = true
+        case .log:
+            state["color"] = StreamColor.log.rawValue
         }
         // Mic picker (docs/PROTOCOL.md §8): only while the phone mic is
         // live as the source's audio — remote UIs key their row off
@@ -474,9 +490,9 @@ final class Streamer: ObservableObject {
     private var capabilityCache: (key: String, resolutions: [String], frameRates: [Int])?
 
     private func formatCapabilities() -> ([String], [Int]) {
-        // The colour is part of the key: flipping the HDR toggle changes
-        // which combos are supported, and a stale list would let remote
-        // UIs offer combos the HLG pipeline can't capture.
+        // The colour is part of the key: changing the colour choice
+        // changes which combos are supported, and a stale list would let
+        // remote UIs offer combos the 10-bit pipelines can't capture.
         let color = activeColor
         let key = "\(selectedLens.id)|\(resolution.rawValue)|\(color.rawValue)"
         if let cached = capabilityCache, cached.key == key {
@@ -579,9 +595,10 @@ final class Streamer: ObservableObject {
 
     /// Keeps resolution/fps within what the selected lens supports.
     func clampCaptureSettings() {
-        // Colour-aware: if the current combo can't do HLG, activeColor
-        // has already degraded to .sdr and the checks match today's —
-        // clamping never changes resolution just to preserve HDR.
+        // Colour-aware: if the current combo can't capture the chosen
+        // colour, activeColor has already degraded to .sdr and the
+        // checks match today's — clamping never changes resolution just
+        // to preserve HDR or Log.
         let color = activeColor
         let supported = { (r: CameraManager.Resolution, f: Int) in
             CameraManager.supports(resolution: r, fps: Int32(f),
@@ -624,9 +641,21 @@ final class Streamer: ObservableObject {
         let storedCodec = VideoCodec(rawValue: defaults.string(forKey: "videoCodec") ?? "")
             ?? (VideoEncoder.isSupported(.hevc) ? .hevc : .h264)
         codec = storedCodec
+        // Colour choice, stored under "streamColor". One-time migration
+        // from the boolean-era "hdrEnabled" key: true → .hlg. The old
+        // key is read only while "streamColor" is absent and is never
+        // written again — the first colour didSet persists the new key,
+        // and "hdrEnabled" just goes stale.
+        let storedColor: StreamColor
+        if let raw = defaults.string(forKey: "streamColor"),
+           let parsed = StreamColor(rawValue: raw) {
+            storedColor = parsed
+        } else {
+            storedColor = defaults.bool(forKey: "hdrEnabled") ? .hlg : .sdr
+        }
         // didSet doesn't run during init; enforce the HEVC-only rule here
         // (stored defaults could disagree after an edit or migration).
-        hdrEnabled = defaults.bool(forKey: "hdrEnabled") && storedCodec == .hevc
+        colorSetting = storedCodec == .hevc ? storedColor : .sdr
         dimWhileStreaming = defaults.object(forKey: "dimWhileStreaming") as? Bool ?? true
         allowVideoEffects = defaults.bool(forKey: "allowVideoEffects")
         sendAudioReference = defaults.bool(forKey: "sendAudioReference")
@@ -911,10 +940,11 @@ final class Streamer: ObservableObject {
         if let raw = command["codec"] as? String {
             guard let parsed = VideoCodec(rawValue: raw),
                   VideoEncoder.isSupported(parsed) else { return }
-            // Double-guard: while HDR is on the advertised codec list is
-            // HEVC-only, but a stale remote UI could still ask — refuse
-            // rather than let the didSet chain silently drop HDR.
-            guard !(hdrEnabled && parsed != .hevc) else { return }
+            // Double-guard: while HLG or Apple Log is on the advertised
+            // codec list is HEVC-only, but a stale remote UI could still
+            // ask — refuse rather than let the didSet chain silently
+            // drop the colour choice.
+            guard !(colorSetting != .sdr && parsed != .hevc) else { return }
             newCodec = parsed
         }
         guard CameraManager.supports(resolution: newResolution,

--- a/ios-app/Sources/VideoEncoder.swift
+++ b/ios-app/Sources/VideoEncoder.swift
@@ -14,9 +14,8 @@ enum VideoCodec: String, CaseIterable, Identifiable {
     }
 }
 
-/// The stream's colour pipeline. Apple Log will slot in as another case
-/// (capture colorSpace .appleLog, iOS 17+); everything downstream switches
-/// on this rather than on booleans.
+/// The stream's colour pipeline; everything downstream switches on this
+/// rather than on booleans.
 ///
 /// Lives here (not CameraManager.swift) because the broadcast extension
 /// compiles VideoEncoder.swift and StreamClient.swift — both of which
@@ -24,6 +23,11 @@ enum VideoCodec: String, CaseIterable, Identifiable {
 enum StreamColor: String {
     case sdr   // 8-bit 420v, BT.709 — every stream before 1.9
     case hlg   // 10-bit x420, BT.2020 + HLG, HEVC Main10 only
+    /// Apple Log 1 (capture colorSpace .appleLog, iOS 17+): 10-bit x422
+    /// capture, BT.2020 primaries, log-encoded transfer, HEVC Main10
+    /// only. Apple Log 2 (`.appleLog2`, Apple-Gamut primaries) is
+    /// deliberately NOT this case — it is reserved for a future "log2".
+    case log
 }
 
 /// Hardware video encoder (VideoToolbox). Emits Annex B access units;
@@ -150,6 +154,20 @@ final class VideoEncoder {
                                  value: kCVImageBufferTransferFunction_ITU_R_2100_HLG)
             VTSessionSetProperty(session, key: kVTCompressionPropertyKey_YCbCrMatrix,
                                  value: kCVImageBufferYCbCrMatrix_ITU_R_2020)
+        case .log:
+            // Streamer never pairs Apple Log with H.264 (its didSets
+            // force HEVC and `activeColor` requires `hdrSupported`).
+            assert(codec == .hevc, "Apple Log requires HEVC Main10")
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ProfileLevel,
+                                 value: kVTProfileLevel_HEVC_Main10_AutoLevel)
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ColorPrimaries,
+                                 value: kCVImageBufferColorPrimaries_ITU_R_2020)
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_YCbCrMatrix,
+                                 value: kCVImageBufferYCbCrMatrix_ITU_R_2020)
+            // DELIBERATELY no TransferFunction: Apple Log has no
+            // VUI/CoreVideo transfer constant, so leaving it unset makes
+            // the bitstream's VUI say transfer_characteristics =
+            // unspecified (2) — the only correct value for Apple Log.
         }
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AllowFrameReordering,
                              value: kCFBooleanFalse)

--- a/obs-plugin/data/nv12.effect
+++ b/obs-plugin/data/nv12.effect
@@ -171,3 +171,55 @@ technique DrawI010HLG
 		pixel_shader  = PSI010HLG(vert_in);
 	}
 }
+
+// ---------------------------------------------------------------------
+// 10-bit log (Apple Log): HEVC Main10 from the phone tagged BT.2020
+// primaries/matrix with an UNSPECIFIED transfer — the elementary stream
+// cannot carry Apple Log identity; VIDEO_CONFIG {"color":"log"} is the
+// wire-level label. Product intent (LUT-in-OBS workflow): show the
+// UNTOUCHED flat log image as ordinary SDR content so streamers grade
+// it with OBS's Apply LUT filter — Apple's and third-party Apple Log
+// LUTs expect the raw log R'G'B' after a correct BT.2020-matrix decode.
+// So: identical sampling and sample_scale to the HLG twins, the same
+// limited-range 10-bit BT.2020 NCL Y'CbCr -> R'G'B' matrix, then output
+// DIRECTLY — no HLG inverse OETF, no OOTF, no 2020->709 primaries
+// conversion, no hdr_scale. saturate() because this is display-referred
+// SDR-canvas content: the limited-range expansion can overshoot [0,1]
+// on sub-black / super-white codes, and an SDR canvas must clip them.
+
+float4 PSP010Log(VertInOut vert_in) : TARGET
+{
+	float y = y_tex.Sample(tex_sampler, vert_in.uv).r * sample_scale;
+	float2 uv = uv_tex.Sample(tex_sampler, vert_in.uv).rg * sample_scale;
+	return float4(saturate(yuv2020_to_rgb(y, uv.r - 0.5004888,
+					      uv.g - 0.5004888)),
+		      1.0);
+}
+
+float4 PSI010Log(VertInOut vert_in) : TARGET
+{
+	float y = y_tex.Sample(tex_sampler, vert_in.uv).r * sample_scale;
+	float u = uv_tex.Sample(tex_sampler, vert_in.uv).r * sample_scale;
+	float v = v_tex.Sample(tex_sampler, vert_in.uv).r * sample_scale;
+	return float4(saturate(yuv2020_to_rgb(y, u - 0.5004888,
+					      v - 0.5004888)),
+		      1.0);
+}
+
+technique DrawP010Log
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSP010Log(vert_in);
+	}
+}
+
+technique DrawI010Log
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSI010Log(vert_in);
+	}
+}

--- a/obs-plugin/src/gpu-frame.c
+++ b/obs-plugin/src/gpu-frame.c
@@ -19,6 +19,12 @@
 #ifndef DRM_FORMAT_GR88
 #define DRM_FORMAT_GR88 0x38385247
 #endif
+#ifndef DRM_FORMAT_R16
+#define DRM_FORMAT_R16 0x20363152 /* 'R','1','6',' ' little-endian */
+#endif
+#ifndef DRM_FORMAT_GR1616
+#define DRM_FORMAT_GR1616 0x32335247 /* 'G','R','3','2' little-endian */
+#endif
 
 struct gpu_frame_ctx {
 	gs_texture_t *tex[2];
@@ -58,13 +64,13 @@ bool gpu_frame_supported(const AVFrame *frame)
 	if (!frame || frame->format != AV_PIX_FMT_VAAPI ||
 	    !frame->hw_frames_ctx)
 		return false;
-	/* The dmabuf import below hardcodes 8-bit NV12 (R8 + GR88); a P010
-	 * surface (10-bit HDR hardware decode) would import as garbage.
-	 * Refuse it so those frames take the CPU path — zero-copy 10-bit
-	 * (R16/GR1616) is stage 2. */
+	/* The dmabuf import below handles 8-bit NV12 (R8 + GR88) and 10-bit
+	 * P010 (R16 + GR1616); any other surface format would import as
+	 * garbage, so refuse it and let those frames take the CPU path. */
 	const AVHWFramesContext *fctx =
 		(const AVHWFramesContext *)frame->hw_frames_ctx->data;
-	return fctx->sw_format == AV_PIX_FMT_NV12;
+	return fctx->sw_format == AV_PIX_FMT_NV12 ||
+	       fctx->sw_format == AV_PIX_FMT_P010;
 }
 
 bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
@@ -99,6 +105,18 @@ bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
 
 	uint32_t w = (uint32_t)frame->width, h = (uint32_t)frame->height;
 
+	/* Pick the per-plane import formats from the hw surface format:
+	 * NV12 -> R8 + GR88, P010 -> R16 + GR1616. Plane geometry is the
+	 * same for both (full-size luma, half-size interleaved chroma);
+	 * pitches come from the DRM descriptor either way. */
+	const AVHWFramesContext *fctx =
+		(const AVHWFramesContext *)frame->hw_frames_ctx->data;
+	bool ten_bit = fctx->sw_format == AV_PIX_FMT_P010;
+	uint32_t drm_y = ten_bit ? DRM_FORMAT_R16 : DRM_FORMAT_R8;
+	uint32_t drm_uv = ten_bit ? DRM_FORMAT_GR1616 : DRM_FORMAT_GR88;
+	enum gs_color_format gs_y = ten_bit ? GS_R16 : GS_R8;
+	enum gs_color_format gs_uv = ten_bit ? GS_RG16 : GS_R8G8;
+
 	int fds[2];
 	uint32_t strides[2], offsets[2];
 	uint64_t modifiers[2];
@@ -119,11 +137,11 @@ bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
 	}
 
 	gs_texture_t *y = gs_texture_create_from_dmabuf(
-		w, h, DRM_FORMAT_R8, GS_R8, 1, &fds[0], &strides[0],
-		&offsets[0], &modifiers[0]);
+		w, h, drm_y, gs_y, 1, &fds[0], &strides[0], &offsets[0],
+		&modifiers[0]);
 	gs_texture_t *uv = gs_texture_create_from_dmabuf(
-		w / 2, h / 2, DRM_FORMAT_GR88, GS_R8G8, 1, &fds[1],
-		&strides[1], &offsets[1], &modifiers[1]);
+		w / 2, h / 2, drm_uv, gs_uv, 1, &fds[1], &strides[1],
+		&offsets[1], &modifiers[1]);
 	if (!y || !uv) {
 		if (!ctx->warned) {
 			ctx->warned = true;
@@ -147,13 +165,15 @@ bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
 
 	if (!ctx->announced) {
 		ctx->announced = true;
-		blog(LOG_INFO, "[lenslink] gpu pipeline: zero-copy active "
-			       "(VAAPI dmabuf -> EGL)");
+		blog(LOG_INFO,
+		     "[lenslink] gpu pipeline: zero-copy active "
+		     "(VAAPI dmabuf -> EGL, %s)",
+		     ten_bit ? "P010" : "NV12");
 	}
 
 	out->tex[0] = y;
 	out->tex[1] = uv;
-	out->format = GPU_FRAME_NV12;
+	out->format = ten_bit ? GPU_FRAME_P010 : GPU_FRAME_NV12;
 	out->width = w;
 	out->height = h;
 	return true;
@@ -205,7 +225,11 @@ bool gpu_frame_supported(const AVFrame *frame)
 {
 	/* Only BGRA surfaces map to a single OBS texture; the decoder
 	 * requests BGRA output in GPU mode (see h264-decoder.c). NV12
-	 * surfaces fall back to the CPU path. */
+	 * surfaces fall back to the CPU path. For 10-bit (HDR) streams
+	 * VideoToolbox hands back 8-bit BGRA it converted itself
+	 * (display-referred), so HDR on macOS GPU-pipeline renders via
+	 * the RGBA path without our HLG shader — true 10-bit IOSurface
+	 * plane mapping is future work. */
 	if (!frame || frame->format != AV_PIX_FMT_VIDEOTOOLBOX)
 		return false;
 	CVPixelBufferRef pix = (CVPixelBufferRef)frame->data[3];
@@ -279,7 +303,7 @@ void gpu_frame_unlock(struct gpu_frame_ctx *ctx)
 }
 
 /* ------------------------------------------------------------------ */
-/* Windows: D3D11VA -> keyed-mutex shared NV12 texture pair            */
+/* Windows: D3D11VA -> keyed-mutex shared NV12/P010 texture pair       */
 /* ------------------------------------------------------------------ */
 #elif defined(_WIN32)
 
@@ -288,10 +312,12 @@ void gpu_frame_unlock(struct gpu_frame_ctx *ctx)
 #include <d3d11.h>
 
 struct gpu_frame_ctx {
-	/* OBS-side pair backed by ONE shared NV12 texture (keyed mutex). */
+	/* OBS-side pair backed by ONE shared NV12/P010 texture (keyed
+	 * mutex). */
 	gs_texture_t *tex_y;
 	gs_texture_t *tex_uv;
 	uint32_t width, height;
+	enum AVPixelFormat sw_format; /* format of the cached textures */
 	uint32_t shared_handle;
 
 	/* FFmpeg-device-side view of the same texture. */
@@ -332,6 +358,7 @@ static void win_release(struct gpu_frame_ctx *ctx)
 	ctx->ff_device = NULL;
 	ctx->shared_handle = 0;
 	ctx->width = ctx->height = 0;
+	ctx->sw_format = AV_PIX_FMT_NONE;
 }
 
 void gpu_frame_ctx_destroy(struct gpu_frame_ctx *ctx)
@@ -351,33 +378,43 @@ bool gpu_frame_supported(const AVFrame *frame)
 	if (!frame || frame->format != AV_PIX_FMT_D3D11 ||
 	    !frame->hw_frames_ctx)
 		return false;
-	/* The shared texture below is NV12 (8-bit); copying a P010 decode
-	 * surface (10-bit HDR) into it fails, leaving a black source.
-	 * Refuse so those frames take the CPU path — a shared P010 texture
-	 * (gs_texture_create_p010) is stage 2. */
+	/* The shared texture is created to match the decode surface: NV12
+	 * (8-bit) or P010 (10-bit HDR). Any other surface format has no
+	 * matching shared-texture creator, so refuse it and let those
+	 * frames take the CPU path. */
 	const AVHWFramesContext *fctx =
 		(const AVHWFramesContext *)frame->hw_frames_ctx->data;
-	return fctx->sw_format == AV_PIX_FMT_NV12;
+	return fctx->sw_format == AV_PIX_FMT_NV12 ||
+	       fctx->sw_format == AV_PIX_FMT_P010;
 }
 
 static bool win_ensure_textures(struct gpu_frame_ctx *ctx, uint32_t w,
-				uint32_t h, ID3D11Device *ff_device)
+				uint32_t h, enum AVPixelFormat sw_format,
+				ID3D11Device *ff_device)
 {
 	if (ctx->tex_y && ctx->width == w && ctx->height == h &&
-	    ctx->ff_device == ff_device)
+	    ctx->sw_format == sw_format && ctx->ff_device == ff_device)
 		return true;
 
 	win_release(ctx);
 
-	/* OBS side: an NV12 texture pair (one underlying resource, a luma
-	 * view and a chroma view) created shared with a keyed mutex. */
-	if (!gs_texture_create_nv12(&ctx->tex_y, &ctx->tex_uv, w, h,
-				    GS_SHARED_KM_TEX)) {
+	/* OBS side: an NV12 or P010 texture pair (one underlying resource,
+	 * a luma view and a chroma view) matching the decode surface,
+	 * created shared with a keyed mutex. An SDR<->HDR switch
+	 * mid-connection changes sw_format, which recreates here. */
+	bool created =
+		sw_format == AV_PIX_FMT_P010
+			? gs_texture_create_p010(&ctx->tex_y, &ctx->tex_uv,
+						 w, h, GS_SHARED_KM_TEX)
+			: gs_texture_create_nv12(&ctx->tex_y, &ctx->tex_uv,
+						 w, h, GS_SHARED_KM_TEX);
+	if (!created) {
 		if (!ctx->warned) {
 			ctx->warned = true;
 			blog(LOG_WARNING,
-			     "[lenslink] gpu pipeline: shared NV12 texture "
-			     "creation failed — using the CPU path");
+			     "[lenslink] gpu pipeline: shared %s texture "
+			     "creation failed — using the CPU path",
+			     sw_format == AV_PIX_FMT_P010 ? "P010" : "NV12");
 		}
 		return false;
 	}
@@ -391,8 +428,8 @@ static bool win_ensure_textures(struct gpu_frame_ctx *ctx, uint32_t w,
 		if (!ctx->warned) {
 			ctx->warned = true;
 			blog(LOG_WARNING,
-			     "[lenslink] gpu pipeline: shared NV12 texture "
-			     "has no shared handle — using the CPU path");
+			     "[lenslink] gpu pipeline: shared texture has "
+			     "no shared handle — using the CPU path");
 		}
 		win_release(ctx);
 		return false;
@@ -432,6 +469,7 @@ static bool win_ensure_textures(struct gpu_frame_ctx *ctx, uint32_t w,
 	ctx->ff_device = ff_device;
 	ctx->width = w;
 	ctx->height = h;
+	ctx->sw_format = sw_format;
 	return true;
 }
 
@@ -450,7 +488,8 @@ bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
 	UINT slice = (UINT)(uintptr_t)frame->data[1];
 
 	if (!win_ensure_textures(ctx, (uint32_t)frame->width,
-				 (uint32_t)frame->height, d3d->device))
+				 (uint32_t)frame->height, frames->sw_format,
+				 d3d->device))
 		return false;
 
 	/* Copy the decoder's array slice into the shared texture on the
@@ -482,13 +521,16 @@ bool gpu_frame_map(struct gpu_frame_ctx *ctx, AVFrame *frame,
 
 	if (!ctx->announced) {
 		ctx->announced = true;
-		blog(LOG_INFO, "[lenslink] gpu pipeline: zero-copy active "
-			       "(D3D11 shared NV12)");
+		blog(LOG_INFO,
+		     "[lenslink] gpu pipeline: zero-copy active "
+		     "(D3D11 shared %s)",
+		     ctx->sw_format == AV_PIX_FMT_P010 ? "P010" : "NV12");
 	}
 
 	out->tex[0] = ctx->tex_y;
 	out->tex[1] = ctx->tex_uv;
-	out->format = GPU_FRAME_NV12;
+	out->format = ctx->sw_format == AV_PIX_FMT_P010 ? GPU_FRAME_P010
+							: GPU_FRAME_NV12;
 	out->width = ctx->width;
 	out->height = ctx->height;
 	return true;

--- a/obs-plugin/src/h264-decoder.c
+++ b/obs-plugin/src/h264-decoder.c
@@ -306,16 +306,41 @@ static bool avframe_to_obs(const AVFrame *frame, struct obs_source_frame *out)
 	else if (frame->colorspace == AVCOL_SPC_SMPTE170M ||
 		 frame->colorspace == AVCOL_SPC_BT470BG)
 		cs = VIDEO_CS_601;
-	else if (frame->colorspace == AVCOL_SPC_BT2020_NCL)
-		/* HDR from newer iPhones: pick the right transfer so OBS
-		 * doesn't tone-map 10-bit video as if it were SDR 709. */
-		cs = frame->color_trc == AVCOL_TRC_ARIB_STD_B67
-			     ? VIDEO_CS_2100_HLG
-			     : VIDEO_CS_2100_PQ;
+	else if (frame->colorspace == AVCOL_SPC_BT2020_NCL) {
+		/* 10-bit from newer iPhones: pick the colourspace by the
+		 * transfer so OBS treats each stream correctly. */
+		switch (frame->color_trc) {
+		case AVCOL_TRC_ARIB_STD_B67:
+			cs = VIDEO_CS_2100_HLG; /* HDR (HLG) */
+			break;
+		case AVCOL_TRC_SMPTE2084:
+			cs = VIDEO_CS_2100_PQ; /* HDR (PQ) */
+			break;
+		default:
+			/* Apple Log / untagged BT.2020: the transfer is
+			 * unspecified in the VUI (an elementary stream cannot
+			 * carry Apple Log identity — VIDEO_CONFIG
+			 * "color":"log" is the wire-level label). The frame
+			 * still needs the BT.2020 NCL matrix and 10-bit code
+			 * ranges; VIDEO_CS_2100_PQ is only the parameter
+			 * label for video_format_get_parameters_for_format
+			 * (in libobs, the HLG and PQ colourspaces alias to
+			 * the same BT.2020 matrix/ranges). Combined with
+			 * VIDEO_TRC_DEFAULT below, libobs applies just that
+			 * matrix and displays the result as ordinary SDR —
+			 * the untouched flat log image, no tone mapping and
+			 * no primaries conversion, ready for the user's
+			 * Apply LUT filter. */
+			cs = VIDEO_CS_2100_PQ;
+			break;
+		}
+	}
 
 	/* The transfer function rides along with the frame: without it,
 	 * libobs treats 10-bit HDR video as SDR 709 (washed out / grey).
-	 * VIDEO_TRC_DEFAULT keeps today's behaviour for SDR streams. */
+	 * VIDEO_TRC_DEFAULT keeps today's behaviour for SDR streams, and
+	 * for the Apple Log path above it is what makes libobs display
+	 * the decoded R'G'B' as-is (flat log image for LUT grading). */
 	switch (frame->color_trc) {
 	case AVCOL_TRC_ARIB_STD_B67:
 		out->trc = (uint8_t)VIDEO_TRC_HLG;

--- a/obs-plugin/src/ios-camera-source.c
+++ b/obs-plugin/src/ios-camera-source.c
@@ -238,7 +238,9 @@ struct ios_camera_source {
 			  * on transition so a black source is explicable) */
 	bool render_hdr; /* current frame is HDR (HLG/PQ transfer); set on
 			  * the graphics thread when a frame is adopted and
-			  * read there by video_get_color_space */
+			  * read there by video_get_color_space and by the
+			  * draw's technique pick (10-bit + !render_hdr =
+			  * Apple Log -> Log techniques, SDR canvas) */
 
 };
 
@@ -3212,7 +3214,12 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 		}
 
 		/* HDR (HLG/PQ) frames render extended-range linear values;
-		 * video_get_color_space reports the matching canvas space. */
+		 * video_get_color_space reports the matching canvas space.
+		 * A 10-bit frame with any other transfer is the Apple Log
+		 * path: render_hdr stays false (SDR canvas is correct — the
+		 * flat log image is display-referred content for the user's
+		 * Apply LUT filter) and the draw below keys the technique
+		 * on this flag, not just the pixel format. */
 		s->render_hdr = fresh->color_trc == AVCOL_TRC_ARIB_STD_B67 ||
 				fresh->color_trc == AVCOL_TRC_SMPTE2084;
 
@@ -3258,11 +3265,14 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 	} else {
 		gs_effect_t *eff = yuv_effect();
 		if (eff) {
-			/* 10-bit frames from the phone are HLG (the app
-			 * signals BT.2020 + ARIB STD-B67); the HLG techniques
-			 * emit extended-range linear 709 to match the
-			 * GS_CS_709_EXTENDED report from
-			 * video_get_color_space. */
+			/* 10-bit frames pick their technique by transfer,
+			 * not just pixel format: HLG/PQ (render_hdr) use the
+			 * HLG techniques, which emit extended-range linear
+			 * 709 to match the GS_CS_709_EXTENDED report from
+			 * video_get_color_space; anything else is Apple Log
+			 * (transfer unspecified on the wire) and uses the
+			 * Log techniques, which emit the untouched BT.2020-
+			 * decoded R'G'B' on the SDR canvas for LUT grading. */
 			const char *tech = "Draw";
 			bool three_plane = false;
 			float scale = 0.0f;
@@ -3274,13 +3284,15 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 			case GPU_FRAME_P010:
 				/* MSB-aligned: sample ~= code/1023 already;
 				 * the exact ratio is 65535/(1023*64). */
-				tech = "DrawP010HLG";
+				tech = s->render_hdr ? "DrawP010HLG"
+						     : "DrawP010Log";
 				scale = 65535.0f / 65472.0f;
 				break;
 			case GPU_FRAME_I010:
 				/* LSB-aligned: samples read 1/64 of the
 				 * intended value. */
-				tech = "DrawI010HLG";
+				tech = s->render_hdr ? "DrawI010HLG"
+						     : "DrawI010Log";
 				three_plane = true;
 				scale = 65535.0f / 1023.0f;
 				break;
@@ -3288,12 +3300,19 @@ static void ios_camera_video_render(void *data, gs_effect_t *unused)
 				break;
 			}
 			if (scale != 0.0f) {
-				float white = obs_get_video_sdr_white_level();
 				gs_effect_set_float(g_yuv_scale, scale);
-				gs_effect_set_float(g_yuv_hdr,
-						    white > 0.0f
-							    ? 1000.0f / white
-							    : 1000.0f / 300.0f);
+				/* hdr_scale feeds only the HLG techniques;
+				 * the Log techniques are display-referred
+				 * and must not be brightness-scaled. */
+				if (s->render_hdr) {
+					float white =
+						obs_get_video_sdr_white_level();
+					gs_effect_set_float(
+						g_yuv_hdr,
+						white > 0.0f
+							? 1000.0f / white
+							: 1000.0f / 300.0f);
+				}
 			}
 			gs_effect_set_texture(g_yuv_y, s->gpu_map.tex[0]);
 			gs_effect_set_texture(g_yuv_uv, s->gpu_map.tex[1]);


### PR DESCRIPTION
## What & why

Two features, both built on the stage-1 groundwork:

**Stage 2 — zero-copy 10-bit.** The GPU pipeline's zero-copy mappers stop refusing 10-bit hardware surfaces: VAAPI P010 imports as R16 + GR1616 dmabuf planes (Linux), D3D11VA gets a keyed-mutex shared P010 texture with the cache keyed on surface format so an SDR↔HDR switch mid-connection recreates it (Windows). The draw site needed nothing — it already keys techniques and scale factors off the mapped-format enum stage 1 introduced. macOS keeps its BGRA path (VideoToolbox converts 10-bit itself), documented as a known limitation. HDR + GPU pipeline should now log `zero-copy active (D3D11 shared P010)` instead of falling back.

**Apple Log (roadmap P3, unlocked by 10-bit HEVC).** The app captures `.appleLog` (iOS 17+, runtime-gated per format — Log formats are x422, not HLG's x420) and encodes HEVC Main10 tagged BT.2020 primaries/matrix with the transfer *deliberately unset*: H.273 has no Apple Log code point, so VUI transfer=unspecified is the only correct value, and the wire's `VIDEO_CONFIG {"color":"log"}` (spec'd since stage 1) is the label. The plugin shows the **untouched flat log image** — correct BT.2020-matrix decode, then hands off — for the LUT-in-OBS grading workflow; the async path's accidental-but-correct behaviour is now explicit, and the GPU pipeline gains dedicated Log shader techniques (it would previously have HLG-linearized log frames). The Options HDR toggle becomes a **Standard / HDR (HLG) / Apple Log** picker with one-time migration from the old key; degrade is always to SDR, never sideways between HLG and Log. Apple Log 2 (Apple-Gamut primaries) is explicitly reserved as a future `"log2"` — never conflated with `"log"`.

Docs: PROTOCOL.md (`"log"` specified, `"log2"` reserved, STATE colour fields documented), README, PERFORMANCE.md.

## How it was tested

- Decode harness (real `h264-decoder.c`, three generated samples): SDR and HLG outputs byte-identical before/after; the new log-like sample (ffprobe-verified VUI: bt2020/unspecified/bt2020nc) decodes to `frames=18 format=I010 trc=default` — the flat-image path.
- Plugin builds clean with `-Wall -Wextra -Werror` (Linux, compiles the VAAPI arm for real); the Windows arm is header-verified (`gs_texture_create_p010` declared in the `_WIN32` block of graphics.h with the same shape as the NV12 creator) but needs a real-hardware run.
- Swift sources parse clean via `syntax-check.sh`; full type check in CI's macOS job.
- Needs device testing: (1) HDR + GPU pipeline on Windows — expect the P010 zero-copy announce and a **before/after bench pair** (Tools → LensLink Settings → benchmark logging, then `tools/bench-report.py`) since this container has no GPU to quote numbers from, per PERFORMANCE.md; (2) Apple Log on an iPhone 15 Pro+ — the key unknown is x422 appearing in `availableVideoPixelFormatTypes` (if not, Log degrades safely to SDR rather than crashing — the #81 guard covers it); (3) a LUT sanity pass in OBS on the log image.

<!-- Releases: Release-Bump: minor + Release-Beta: true on the final commit → v1.9.0-beta.4, uploaded to TestFlight, not marked Latest. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT

---
_Generated by [Claude Code](https://claude.ai/code/session_015dWUcqAkNNuNELnMPS4RdT)_