### PR TITLE
Plugin: static FFmpeg on Windows/macOS so OBS updates can't break loading

### DIFF
--- a/.github/actions/static-ffmpeg/action.yml
+++ b/.github/actions/static-ffmpeg/action.yml
@@ -1,0 +1,136 @@
+name: Static FFmpeg (decode-only)
+description: >-
+  Builds a minimal static FFmpeg — H.264/HEVC decode plus the platform's
+  GPU decode API, nothing else — into ffmpeg-static/ at the workspace
+  root, cached between runs. Plugin binaries link this instead of the
+  FFmpeg inside OBS: FFmpeg's library names change with its major
+  version (avcodec-61.dll, libavcodec.so.60, ...), so a plugin linked
+  against OBS's copy stops loading the moment an OBS update ships a
+  newer FFmpeg (issues #65, #91, #93). With the decoder built in, one
+  plugin release keeps working across OBS updates.
+
+inputs:
+  version:
+    description: FFmpeg release to build
+    required: false
+    default: "7.1"
+
+runs:
+  using: composite
+  steps:
+    # hashFiles of this action: editing any configure flag or build step
+    # invalidates the cache automatically — no manual key bump to forget.
+    - name: Cache static FFmpeg
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: ffmpeg-static
+        key: ffmpeg-static-${{ runner.os }}-${{ inputs.version }}-${{ hashFiles('.github/actions/static-ffmpeg/**') }}
+
+    # Unconditional (not gated on the cache): libva-dev is needed again
+    # later when the plugin links the cached static libavutil, whose
+    # VAAPI hwcontext references libva symbols.
+    - name: Install Linux build dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y nasm libva-dev libdrm-dev
+
+    # H.264/HEVC decode + VAAPI, nothing else; the only FFmpeg-related
+    # runtime needs left are libva/libva-drm, whose soname has been
+    # stable since 2017 and which every VAAPI-capable system ships.
+    - name: Build (Linux)
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FFMPEG_VERSION: ${{ inputs.version }}
+      run: |
+        curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        cd "ffmpeg-${FFMPEG_VERSION}"
+        ./configure --prefix="$GITHUB_WORKSPACE/ffmpeg-static" \
+          --disable-everything --disable-programs --disable-doc \
+          --disable-avformat --disable-avfilter --disable-swscale \
+          --disable-swresample --disable-avdevice --disable-network \
+          --disable-debug --disable-autodetect \
+          --enable-decoder=h264,hevc --enable-parser=h264,hevc \
+          --enable-vaapi --enable-hwaccel=h264_vaapi,hevc_vaapi \
+          --enable-pic --disable-shared --enable-static \
+          || { tail -n 50 ffbuild/config.log; exit 1; }
+        make -j"$(nproc)"
+        make install
+
+    # Same shape with VideoToolbox, built once per slice and merged with
+    # lipo to match the universal plugin. The linking side of this lives
+    # in CMakeLists.txt: the plugin links the CoreMedia/VideoToolbox
+    # frameworks the static hwaccel resolves against.
+    - name: Build (macOS, universal)
+      if: runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FFMPEG_VERSION: ${{ inputs.version }}
+      run: |
+        brew install nasm
+        curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        # --enable-cross-compile on the native slice too: it only turns
+        # off configure-time runtime probing, and keeps both invocations
+        # identical.
+        for arch in arm64 x86_64; do
+          mkdir -p "ffmpeg-build-$arch"
+          (cd "ffmpeg-build-$arch" && \
+           "../ffmpeg-${FFMPEG_VERSION}/configure" \
+             --prefix="$GITHUB_WORKSPACE/ffmpeg-arch-$arch" \
+             --enable-cross-compile --target-os=darwin \
+             --arch="$arch" --cc="clang -arch $arch" \
+             --extra-cflags="-mmacosx-version-min=13.0" \
+             --extra-ldflags="-mmacosx-version-min=13.0" \
+             --disable-everything --disable-programs --disable-doc \
+             --disable-avformat --disable-avfilter --disable-swscale \
+             --disable-swresample --disable-avdevice --disable-network \
+             --disable-debug --disable-autodetect \
+             --enable-decoder=h264,hevc --enable-parser=h264,hevc \
+             --enable-videotoolbox \
+             --enable-hwaccel=h264_videotoolbox,hevc_videotoolbox \
+             --enable-pic --disable-shared --enable-static \
+             || { tail -n 50 ffbuild/config.log; exit 1; } && \
+           make -j"$(sysctl -n hw.ncpu)" && make install)
+        done
+        # One header set is enough: avconfig.h is identical for both
+        # slices (same endianness and word size). No pkgconfig dir on
+        # purpose — the per-arch .pc files carry the wrong prefix, and
+        # the workflows pass explicit library paths instead.
+        mkdir -p ffmpeg-static/lib
+        cp -R ffmpeg-arch-arm64/include ffmpeg-static/include
+        for lib in libavcodec libavutil; do
+          lipo -create "ffmpeg-arch-arm64/lib/$lib.a" \
+            "ffmpeg-arch-x86_64/lib/$lib.a" \
+            -output "ffmpeg-static/lib/$lib.a"
+        done
+
+    # FFmpeg's build system is a shell script, but the compiler must be
+    # MSVC (cl.exe) so the archives link into the plugin's Visual Studio
+    # build: import the vcvars64 environment into this process, then run
+    # the build under the runner's stock MSYS2 with that environment
+    # inherited (build-windows.sh).
+    - name: Build (Windows)
+      if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        FFMPEG_VERSION: ${{ inputs.version }}
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vs = & $vswhere -latest -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+        cmd /s /c "`"$vs\VC\Auxiliary\Build\vcvars64.bat`" > nul 2>&1 && set" |
+          ForEach-Object {
+            $name, $value = $_ -split '=', 2
+            if ($name -and $value) { Set-Item -Path "env:$name" -Value $value }
+          }
+        $env:MSYS2_PATH_TYPE = "inherit"
+        $env:CHERE_INVOKING = "1"
+        $script = "${env:GITHUB_ACTION_PATH}\build-windows.sh" -replace '\\', '/'
+        C:\msys64\usr\bin\bash -l $script
+        if ($LASTEXITCODE -ne 0) { throw "static FFmpeg build failed" }

--- a/.github/actions/static-ffmpeg/build-windows.sh
+++ b/.github/actions/static-ffmpeg/build-windows.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Runs under the runner's stock MSYS2 with the MSVC (vcvars64)
+# environment inherited — see action.yml. Produces static
+# avcodec.lib/avutil.lib in $GITHUB_WORKSPACE/ffmpeg-static.
+set -euxo pipefail
+
+# MSYS2's coreutils /usr/bin/link shadows MSVC's link.exe, and FFmpeg's
+# configure --toolchain=msvc needs the latter.
+rm -f /usr/bin/link.exe
+
+pacman -Sy --noconfirm --needed make nasm diffutils xz
+
+curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+cd "ffmpeg-${FFMPEG_VERSION}"
+
+prefix="$(cygpath -u "$GITHUB_WORKSPACE")/ffmpeg-static"
+
+# Same minimal decode-only shape as the Linux/macOS builds, with the
+# Windows GPU decode APIs (D3D11VA + the DXVA2 fallback) in place of
+# VAAPI. The *_d3d11va2 hwaccels are the AV_HWDEVICE_TYPE_D3D11VA +
+# hw_device_ctx path the decoder actually uses; the *_d3d11va ones are
+# the legacy API, enabled alongside for completeness. -MD matches the
+# /MD CRT of the plugin's Release build. The linking side lives in
+# CMakeLists.txt: bcrypt/ole32/user32 resolve the static libavutil's
+# RNG and DXVA2 device setup.
+./configure --prefix="$prefix" --toolchain=msvc \
+	--extra-cflags="-MD" \
+	--disable-everything --disable-programs --disable-doc \
+	--disable-avformat --disable-avfilter --disable-swscale \
+	--disable-swresample --disable-avdevice --disable-network \
+	--disable-debug --disable-autodetect \
+	--enable-decoder=h264,hevc --enable-parser=h264,hevc \
+	--enable-d3d11va --enable-dxva2 \
+	--enable-hwaccel=h264_d3d11va,h264_d3d11va2,h264_dxva2 \
+	--enable-hwaccel=hevc_d3d11va,hevc_d3d11va2,hevc_dxva2 \
+	--disable-shared --enable-static \
+	|| { tail -n 50 ffbuild/config.log; exit 1; }
+
+make -j"$(nproc)"
+make install
+
+# The archive names configure emits have varied (libavcodec.a vs
+# avcodec.lib); pin one canonical name the workflows can rely on, and
+# fail loudly if neither shows up.
+cd "$prefix/lib"
+for lib in avcodec avutil; do
+	if [ ! -f "$lib.lib" ]; then
+		for cand in "lib$lib.a" "$lib.a" "lib$lib.lib"; do
+			if [ -f "$cand" ]; then
+				mv "$cand" "$lib.lib"
+				break
+			fi
+		done
+	fi
+	[ -f "$lib.lib" ]
+done
+ls -l

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,10 @@ jobs:
           git fetch --depth=1 origin "$BASE"
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           # A workflow edit rebuilds everything: it may change any job.
+          # .github/actions/ is in the plugin set: the static-ffmpeg
+          # composite action feeds the plugin builds.
           if echo "$CHANGED" | \
-             grep -qE '^(obs-plugin/|installer/|\.github/workflows/build\.yml)'; then
+             grep -qE '^(obs-plugin/|installer/|\.github/workflows/build\.yml|\.github/actions/)'; then
             echo "plugin=true" >> "$GITHUB_OUTPUT"
           else
             echo "plugin=false" >> "$GITHUB_OUTPUT"
@@ -130,9 +132,12 @@ jobs:
     if: needs.changes.outputs.plugin == 'true'
     runs-on: windows-2022
     env:
-      # Keep in sync with the OBS release users run: the plugin links the
-      # FFmpeg DLLs from this deps bundle, and OBS must ship the same ones.
-      # OBS 32.1.2 pins obs-deps 2025-08-23 (see its CMakePresets.json).
+      # Pins the libobs the plugin compiles/links against, and the Qt6
+      # bundle for the status-bar/dock UI. FFmpeg deliberately does NOT
+      # come from this bundle: the plugin links its own static
+      # decode-only FFmpeg (.github/actions/static-ffmpeg), so an OBS
+      # update swapping its bundled FFmpeg DLLs can't break plugin
+      # loading (issues #91, #93).
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
@@ -148,7 +153,7 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
+      - name: Download OBS prebuilt dependencies (for libobs; Qt6)
         run: |
           curl -L -o deps.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-${{ env.DEPS_TAG }}-x64.zip"
           7z x deps.zip -oobs-deps
@@ -158,6 +163,9 @@ jobs:
           # suffices for the rest of the build.
           curl -L -o deps-qt6.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-qt6-${{ env.DEPS_TAG }}-x64.zip"
           7z x -y deps-qt6.zip -oobs-deps
+
+      - name: Build static FFmpeg (H.264/HEVC decode only)
+        uses: ./.github/actions/static-ffmpeg
 
       - name: Cache libobs build
         id: cache-libobs
@@ -177,6 +185,10 @@ jobs:
             -DENABLE_AJA=OFF
           cmake --build obs-build --target libobs --config Release
 
+      # DISABLE_FIND_PACKAGE_PkgConfig: if a pkg-config on the runner
+      # ever resolved FFmpeg from the obs-deps bundle, the DLL would
+      # silently regress to importing OBS's avcodec-NN.dll; force the
+      # explicit static paths instead. The guard below backstops it.
       - name: Build plugin
         run: |
           cmake -S obs-plugin -B plugin-build -G "Visual Studio 17 2022" -A x64 `
@@ -184,10 +196,31 @@ jobs:
             -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs;${{ github.workspace }}\obs-build\config;${{ github.workspace }}\obs-studio\deps\w32-pthreads" `
             -DLIBOBS_LIBRARY="${{ github.workspace }}\obs-build\libobs\Release\obs.lib;${{ github.workspace }}\obs-build\deps\w32-pthreads\Release\w32-pthreads.lib" `
             -DOBS_FRONTEND_API_HINT="${{ github.workspace }}\obs-studio\frontend\api;${{ github.workspace }}\obs-studio\UI\obs-frontend-api" `
-            -DFFMPEG_INCLUDE_DIR="${{ github.workspace }}\obs-deps\include" `
-            -DAVCODEC_LIBRARY="${{ github.workspace }}\obs-deps\lib\avcodec.lib" `
-            -DAVUTIL_LIBRARY="${{ github.workspace }}\obs-deps\lib\avutil.lib"
+            -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON `
+            -DFFMPEG_INCLUDE_DIR="${{ github.workspace }}\ffmpeg-static\include" `
+            -DAVCODEC_LIBRARY="${{ github.workspace }}\ffmpeg-static\lib\avcodec.lib" `
+            -DAVUTIL_LIBRARY="${{ github.workspace }}\ffmpeg-static\lib\avutil.lib"
           cmake --build plugin-build --config Release
+
+      # A lenslink.dll that imports avcodec-NN.dll/avutil-NN.dll only
+      # loads while OBS ships that exact FFmpeg major — the next OBS
+      # update breaks it with LoadLibrary error 126 (issues #91, #93).
+      # The obs.dll check keeps the negative check honest: an empty or
+      # misread dependents dump would otherwise pass it vacuously.
+      - name: Verify FFmpeg linked statically
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = & $vswhere -latest -products * `
+            -find "VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe" |
+            Select-Object -First 1
+          $deps = & $dumpbin /dependents plugin-build\Release\lenslink.dll | Out-String
+          Write-Host $deps
+          if ($deps -match "avcodec|avutil") {
+            throw "lenslink.dll imports OBS's FFmpeg DLLs (breaks on OBS updates)"
+          }
+          if ($deps -notmatch "obs\.dll") {
+            throw "obs.dll import missing - dependents dump looks wrong"
+          }
 
       - name: Package (drop into C:\Program Files\obs-studio)
         run: |
@@ -219,9 +252,13 @@ jobs:
     if: needs.changes.outputs.plugin == 'true'
     runs-on: macos-15
     env:
-      # Keep in sync with the OBS release users run (same pins as the
-      # Windows job): the plugin links the FFmpeg dylibs from this deps
-      # bundle, and OBS must ship the same ones.
+      # Pins the libobs the plugin compiles/links against, and the Qt6
+      # bundle for the status-bar/dock UI (same pins as the Windows
+      # job). FFmpeg deliberately does NOT come from this bundle: the
+      # plugin links its own static decode-only FFmpeg
+      # (.github/actions/static-ffmpeg), so an OBS update swapping its
+      # bundled FFmpeg dylibs can't break plugin loading (issues #91,
+      # #93 hit exactly that on Windows).
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
@@ -237,7 +274,7 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
+      - name: Download OBS prebuilt dependencies (for libobs; Qt6)
         run: |
           curl -L -o deps.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-${{ env.DEPS_TAG }}-universal.tar.xz"
           mkdir obs-deps
@@ -245,6 +282,9 @@ jobs:
           # Qt6 for the status-bar/dock UI (see the Windows job note).
           curl -L -o deps-qt6.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-qt6-${{ env.DEPS_TAG }}-universal.tar.xz"
           tar -xJf deps-qt6.tar.xz -C obs-deps
+
+      - name: Build static FFmpeg (H.264/HEVC decode only)
+        uses: ./.github/actions/static-ffmpeg
 
       # "macos" in the key: cache keys are not runner-scoped, and the
       # Windows job already uses libobs-<ref>-<tag> for its MSVC build.
@@ -274,6 +314,10 @@ jobs:
             -DENABLE_BROWSER=OFF -DENABLE_SCRIPTING=OFF
           cmake --build obs-build --target libobs --config Release
 
+      # DISABLE_FIND_PACKAGE_PkgConfig: the runner ships a pkg-config,
+      # and CMake feeds it CMAKE_PREFIX_PATH (obs-deps) — without this
+      # the build could silently resolve OBS's shared FFmpeg instead of
+      # the static one. The guard below backstops it.
       - name: Build plugin
         run: |
           cmake -S obs-plugin -B plugin-build \
@@ -285,10 +329,25 @@ jobs:
             -DOBS_FRONTEND_API_HINT="$PWD/obs-studio/frontend/api;$PWD/obs-studio/UI/obs-frontend-api" \
             -DLIBOBS_INCLUDE_DIR="$PWD/obs-studio/libobs;$PWD/obs-build/config" \
             -DLIBOBS_LIBRARY="$PWD/obs-build/libobs/Release/libobs.framework" \
-            -DFFMPEG_INCLUDE_DIR="$PWD/obs-deps/include" \
-            -DAVCODEC_LIBRARY="$PWD/obs-deps/lib/libavcodec.dylib" \
-            -DAVUTIL_LIBRARY="$PWD/obs-deps/lib/libavutil.dylib"
+            -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON \
+            -DFFMPEG_INCLUDE_DIR="$PWD/ffmpeg-static/include" \
+            -DAVCODEC_LIBRARY="$PWD/ffmpeg-static/lib/libavcodec.a" \
+            -DAVUTIL_LIBRARY="$PWD/ffmpeg-static/lib/libavutil.a"
           cmake --build plugin-build
+
+      # A lenslink.so referencing libavcodec.NN.dylib only loads while
+      # OBS ships that exact FFmpeg major — the next OBS update breaks
+      # it (the macOS twin of Windows issues #91, #93). The libobs check
+      # keeps the negative check honest. Plain `if grep`, not `! grep`:
+      # a `!` line that isn't last is non-fatal under bash -e.
+      - name: Verify FFmpeg linked statically
+        run: |
+          otool -L plugin-build/lenslink.so | tee deps.log
+          if grep -E "libav(codec|util)" deps.log; then
+            echo "::error::lenslink.so links OBS's shared FFmpeg dylibs"
+            exit 1
+          fi
+          grep -q "libobs" deps.log
 
       # Assemble the .plugin bundle on PRs too, so a broken Info.plist or
       # layout change can't reach a release build. Takes seconds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,48 +36,22 @@ jobs:
   plugin-linux:
     name: OBS plugin (Linux)
     runs-on: ubuntu-latest
-    env:
-      FFMPEG_VERSION: "7.1"
     steps:
       - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake pkg-config libobs-dev qt6-base-dev \
-            nasm libva-dev libdrm-dev
+          sudo apt-get install -y cmake pkg-config libobs-dev qt6-base-dev
 
-      # The release tarball has to run on every distro, but linking the
-      # runner's shared FFmpeg pins an FFmpeg-major soname
-      # (libavcodec.so.60) that rolling distros no longer ship — the
-      # plugin then fails to load at all (issue #65). So releases link a
-      # minimal static FFmpeg (H.264/HEVC decode + VAAPI, nothing else);
-      # the only FFmpeg-related runtime needs left are libva/libva-drm,
-      # whose soname has been stable since 2017 and which every
-      # VAAPI-capable system already ships.
-      - name: Cache static FFmpeg
-        id: cache-ffmpeg
-        uses: actions/cache@v6
-        with:
-          path: ffmpeg-static
-          key: ffmpeg-static-${{ env.FFMPEG_VERSION }}-decode-vaapi-v1
-
-      - name: Build static FFmpeg (H.264/HEVC decode + VAAPI only)
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
-          tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
-          cd "ffmpeg-${FFMPEG_VERSION}"
-          ./configure --prefix="$GITHUB_WORKSPACE/ffmpeg-static" \
-            --disable-everything --disable-programs --disable-doc \
-            --disable-avformat --disable-avfilter --disable-swscale \
-            --disable-swresample --disable-avdevice --disable-network \
-            --disable-debug --disable-autodetect \
-            --enable-decoder=h264,hevc --enable-parser=h264,hevc \
-            --enable-vaapi --enable-hwaccel=h264_vaapi,hevc_vaapi \
-            --enable-pic --disable-shared --enable-static
-          make -j"$(nproc)"
-          make install
+      # The release tarball has to run on every distro, but linking a
+      # shared FFmpeg pins an FFmpeg-major soname (libavcodec.so.60)
+      # that rolling distros no longer ship — the plugin then fails to
+      # load at all (issue #65; the same failure hit Windows as #91/#93
+      # when an OBS update moved its bundled FFmpeg). So all release
+      # builds link the minimal static FFmpeg this action builds.
+      - name: Build static FFmpeg (H.264/HEVC decode only)
+        uses: ./.github/actions/static-ffmpeg
 
       # The grep guard: the status-bar/dock UI degrades *silently* when Qt6
       # or obs-frontend-api.h is missing (that's how releases shipped
@@ -102,10 +76,16 @@ jobs:
 
       # Fail the release if the binary regressed to soname-coupled shared
       # FFmpeg (the exact breakage of issue #65), or lost its VAAPI link.
+      # Plain `if grep`, not `! grep`: a `!` line that isn't the last
+      # command is non-fatal under the runner's bash -e, so the old
+      # negated form could never fail the step.
       - name: Verify FFmpeg linked statically
         run: |
           readelf -d obs-plugin/build/lenslink.so | tee needed.log
-          ! grep -E "NEEDED.*(libavcodec|libavutil)" needed.log
+          if grep -E "NEEDED.*(libavcodec|libavutil)" needed.log; then
+            echo "::error::lenslink.so links shared FFmpeg (issue #65)"
+            exit 1
+          fi
           grep -qE "NEEDED.*libva\.so" needed.log
 
       - name: Package (extract into ~/.config/obs-studio/plugins)
@@ -124,6 +104,9 @@ jobs:
     name: OBS plugin (Windows)
     runs-on: windows-2022
     env:
+      # libobs + Qt6 pins only — FFmpeg is linked statically (see the
+      # static-ffmpeg action step), so these no longer have to track the
+      # FFmpeg inside the OBS release users run (issues #91, #93).
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
@@ -139,7 +122,7 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
+      - name: Download OBS prebuilt dependencies (for libobs; Qt6)
         run: |
           curl -L -o deps.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-${{ env.DEPS_TAG }}-x64.zip"
           7z x deps.zip -oobs-deps
@@ -147,6 +130,9 @@ jobs:
           # plugin's status-bar/dock UI — keep in sync with build.yml.
           curl -L -o deps-qt6.zip "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/windows-deps-qt6-${{ env.DEPS_TAG }}-x64.zip"
           7z x -y deps-qt6.zip -oobs-deps
+
+      - name: Build static FFmpeg (H.264/HEVC decode only)
+        uses: ./.github/actions/static-ffmpeg
 
       - name: Cache libobs build
         id: cache-libobs
@@ -169,6 +155,8 @@ jobs:
       # The Select-String guard: the status-bar/dock UI degrades *silently*
       # when Qt6 or obs-frontend-api.h is missing (that's how releases
       # shipped without it once) — a release build must fail instead.
+      # DISABLE_FIND_PACKAGE_PkgConfig + the static FFmpeg paths: keep in
+      # sync with build.yml (see the note there).
       - name: Build plugin
         run: |
           $version = "${{ inputs.tag_name || github.ref_name }}".TrimStart("v")
@@ -178,14 +166,34 @@ jobs:
             -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs;${{ github.workspace }}\obs-build\config;${{ github.workspace }}\obs-studio\deps\w32-pthreads" `
             -DLIBOBS_LIBRARY="${{ github.workspace }}\obs-build\libobs\Release\obs.lib;${{ github.workspace }}\obs-build\deps\w32-pthreads\Release\w32-pthreads.lib" `
             -DOBS_FRONTEND_API_HINT="${{ github.workspace }}\obs-studio\frontend\api;${{ github.workspace }}\obs-studio\UI\obs-frontend-api" `
-            -DFFMPEG_INCLUDE_DIR="${{ github.workspace }}\obs-deps\include" `
-            -DAVCODEC_LIBRARY="${{ github.workspace }}\obs-deps\lib\avcodec.lib" `
-            -DAVUTIL_LIBRARY="${{ github.workspace }}\obs-deps\lib\avutil.lib" `
+            -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON `
+            -DFFMPEG_INCLUDE_DIR="${{ github.workspace }}\ffmpeg-static\include" `
+            -DAVCODEC_LIBRARY="${{ github.workspace }}\ffmpeg-static\lib\avcodec.lib" `
+            -DAVUTIL_LIBRARY="${{ github.workspace }}\ffmpeg-static\lib\avutil.lib" `
             | Tee-Object -FilePath configure.log
           if (-not (Select-String -Quiet -SimpleMatch "frontend UI enabled" -Path configure.log)) {
             throw "status-bar/dock UI missing from this release build (Qt6/obs-frontend-api not found)"
           }
           cmake --build plugin-build --config Release
+
+      # A release DLL importing avcodec-NN.dll/avutil-NN.dll only loads
+      # while OBS ships that exact FFmpeg major — the next OBS update
+      # breaks it with LoadLibrary error 126 (issues #91, #93). The
+      # obs.dll check keeps the negative check honest.
+      - name: Verify FFmpeg linked statically
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = & $vswhere -latest -products * `
+            -find "VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe" |
+            Select-Object -First 1
+          $deps = & $dumpbin /dependents plugin-build\Release\lenslink.dll | Out-String
+          Write-Host $deps
+          if ($deps -match "avcodec|avutil") {
+            throw "lenslink.dll imports OBS's FFmpeg DLLs (breaks on OBS updates)"
+          }
+          if ($deps -notmatch "obs\.dll") {
+            throw "obs.dll import missing - dependents dump looks wrong"
+          }
 
       - name: Package (extract into C:\Program Files\obs-studio)
         run: |
@@ -217,6 +225,9 @@ jobs:
     name: OBS plugin (macOS)
     runs-on: macos-15
     env:
+      # libobs + Qt6 pins only — FFmpeg is linked statically (see the
+      # static-ffmpeg action step), so these no longer have to track the
+      # FFmpeg inside the OBS release users run (issues #91, #93).
       OBS_REF: "32.1.2"
       DEPS_TAG: "2025-08-23"
     steps:
@@ -232,7 +243,7 @@ jobs:
           ref: ${{ env.OBS_REF }}
           path: obs-studio
 
-      - name: Download OBS prebuilt dependencies (FFmpeg, Qt6)
+      - name: Download OBS prebuilt dependencies (for libobs; Qt6)
         run: |
           curl -L -o deps.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-${{ env.DEPS_TAG }}-universal.tar.xz"
           mkdir obs-deps
@@ -240,6 +251,9 @@ jobs:
           # Qt6 for the status-bar/dock UI — keep in sync with build.yml.
           curl -L -o deps-qt6.tar.xz "https://github.com/obsproject/obs-deps/releases/download/${{ env.DEPS_TAG }}/macos-deps-qt6-${{ env.DEPS_TAG }}-universal.tar.xz"
           tar -xJf deps-qt6.tar.xz -C obs-deps
+
+      - name: Build static FFmpeg (H.264/HEVC decode only)
+        uses: ./.github/actions/static-ffmpeg
 
       # "macos" in the key: cache keys are not runner-scoped, and the
       # Windows job already uses libobs-<ref>-<tag> for its MSVC build.
@@ -272,6 +286,8 @@ jobs:
       # The grep guard: the status-bar/dock UI degrades *silently* when Qt6
       # or obs-frontend-api.h is missing (that's how releases shipped
       # without it once) — a release build must fail instead.
+      # DISABLE_FIND_PACKAGE_PkgConfig + the static FFmpeg paths: keep in
+      # sync with build.yml (see the note there).
       - name: Build plugin
         run: |
           set -o pipefail
@@ -285,12 +301,27 @@ jobs:
             -DOBS_FRONTEND_API_HINT="$PWD/obs-studio/frontend/api;$PWD/obs-studio/UI/obs-frontend-api" \
             -DLIBOBS_INCLUDE_DIR="$PWD/obs-studio/libobs;$PWD/obs-build/config" \
             -DLIBOBS_LIBRARY="$PWD/obs-build/libobs/Release/libobs.framework" \
-            -DFFMPEG_INCLUDE_DIR="$PWD/obs-deps/include" \
-            -DAVCODEC_LIBRARY="$PWD/obs-deps/lib/libavcodec.dylib" \
-            -DAVUTIL_LIBRARY="$PWD/obs-deps/lib/libavutil.dylib" \
+            -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON \
+            -DFFMPEG_INCLUDE_DIR="$PWD/ffmpeg-static/include" \
+            -DAVCODEC_LIBRARY="$PWD/ffmpeg-static/lib/libavcodec.a" \
+            -DAVUTIL_LIBRARY="$PWD/ffmpeg-static/lib/libavutil.a" \
             | tee configure.log
           grep -q "frontend UI enabled" configure.log
           cmake --build plugin-build
+
+      # A release binary referencing libavcodec.NN.dylib only loads while
+      # OBS ships that exact FFmpeg major — the next OBS update breaks it
+      # (the macOS twin of Windows issues #91, #93). The libobs check
+      # keeps the negative check honest. Plain `if grep`, not `! grep`:
+      # a `!` line that isn't last is non-fatal under bash -e.
+      - name: Verify FFmpeg linked statically
+        run: |
+          otool -L plugin-build/lenslink.so | tee deps.log
+          if grep -E "libav(codec|util)" deps.log; then
+            echo "::error::lenslink.so links OBS's shared FFmpeg dylibs"
+            exit 1
+          fi
+          grep -q "libobs" deps.log
 
       # Ad-hoc signature only: without an Apple Developer ID the bundle
       # can't be notarized, so users clear the quarantine flag once (the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,14 +139,26 @@ Manual releases also work — push any `v*` tag:
 git tag v0.4.0 && git push origin v0.4.0
 ```
 
-The **Linux** release job builds its own minimal static FFmpeg
-(H.264/HEVC decode + VAAPI, cached between runs) and links it into
-`lenslink.so`, because a tarball linked against the runner's shared
-FFmpeg only loads on distros shipping that same FFmpeg major
-(issue #65 — `libavcodec.so.60` missing on Arch). The job verifies the
-binary has no `libavcodec`/`libavutil` `NEEDED` entries before
-packaging. Local/source builds are unaffected — they link the system
-FFmpeg via pkg-config, which always matches the machine they run on.
+All three plugin builds link a minimal static FFmpeg — H.264/HEVC
+decode plus the platform's GPU decode API (VAAPI / D3D11VA+DXVA2 /
+VideoToolbox), nothing else — built and cached by
+[`.github/actions/static-ffmpeg`](../.github/actions/static-ffmpeg/action.yml).
+FFmpeg's library names change with its major version
+(`libavcodec.so.60`, `avcodec-61.dll`, `libavcodec.61.dylib`), so a
+plugin linked against a shared FFmpeg stops loading the moment its host
+stops shipping that exact major: on Linux that was issue #65 (rolling
+distros moved on), on Windows issues #91/#93 (an OBS point release
+updated its bundled FFmpeg and `lenslink.dll` failed with `LoadLibrary
+… error 126`). With the decoder built in, a plugin release keeps
+loading across OBS updates — what stays dynamically linked (libobs,
+Qt6) keeps stable library names and ABI across OBS releases. Every job
+verifies the built module has no `avcodec`/`avutil` runtime dependency
+before packaging (`readelf` / `dumpbin /dependents` / `otool -L`).
+Local/source builds are unaffected — they link the system FFmpeg via
+pkg-config, which always matches the machine they run on. The
+`OBS_REF`/`DEPS_TAG` pins in the workflows now only choose the libobs
+and Qt6 the plugin builds against; they no longer have to track the
+FFmpeg inside whatever OBS release users run.
 
 ### Release notes
 

--- a/obs-plugin/CMakeLists.txt
+++ b/obs-plugin/CMakeLists.txt
@@ -81,13 +81,22 @@ target_compile_definitions(${PROJECT_NAME}
 if(WIN32)
   # dxguid: gpu-frame.c references IID_ID3D11Texture2D/IID_IDXGIKeyedMutex,
   # which are extern GUIDs resolved from this static lib in C builds.
-  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 dxguid)
+  # bcrypt/ole32/user32: referenced by the static decode-only FFmpeg that
+  # release builds link (avutil's BCryptGenRandom RNG, DXVA2 device
+  # setup); no-ops when linking a shared FFmpeg.
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 dxguid bcrypt ole32
+                                                user32)
 endif()
 
 if(APPLE)
   # GPU pipeline: gpu-frame.c reads the decoder's CVPixelBuffers
   # (CVPixelBufferGetIOSurface & co) to bind their IOSurfaces as textures.
-  target_link_libraries(${PROJECT_NAME} PRIVATE "-framework CoreVideo")
+  # CoreFoundation/CoreMedia/VideoToolbox: resolve the VideoToolbox
+  # hwaccel of the static decode-only FFmpeg that release builds link;
+  # harmless system frameworks when linking a shared FFmpeg.
+  target_link_libraries(${PROJECT_NAME} PRIVATE "-framework CoreVideo"
+    "-framework CoreFoundation" "-framework CoreMedia"
+    "-framework VideoToolbox")
 endif()
 
 # --- frontend UI (status bar + dock; optional) -------------------------------


### PR DESCRIPTION
## What & why

Fixes #91
Fixes #93

Both issues are the same failure: `LoadLibrary failed for 'lenslink.dll' … error 126` on OBS 32.2.1. The Windows (and macOS) builds linked the FFmpeg from the obs-deps bundle pinned at build time, and FFmpeg library names are major-versioned (`avcodec-61.dll`, `libavcodec.61.dylib`) — so the moment an OBS update ships a newer FFmpeg, the plugin's imports no longer resolve and it stops loading. Error 126 names `lenslink.dll` but the missing module is actually the transitive FFmpeg DLL. Linux hit the same class in #65 and already links a minimal static FFmpeg; this PR ports that fix so one plugin release keeps working across OBS updates instead of needing a rebuild per OBS FFmpeg bump.

- New `.github/actions/static-ffmpeg` composite action builds a minimal decode-only static FFmpeg per platform — H.264/HEVC decode plus the platform's GPU decode API (VAAPI / D3D11VA+DXVA2 / VideoToolbox), cached between runs. All six plugin jobs (PR CI and release, three OSes) link it, so PR CI exercises exactly what releases ship.
- "Verify FFmpeg linked statically" guard steps (`dumpbin /dependents`, `otool -L`, `readelf -d`) fail any build whose module regains an avcodec/avutil runtime dependency. This also fixes the existing Linux guard: its `! grep` line was non-fatal under the runner's `bash -e` (a `!`-negated command that isn't last never fails the step), so it could never actually catch a regression.
- `CMakeLists.txt` links the system pieces the static FFmpeg resolves against — `bcrypt`/`ole32`/`user32` on Windows, CoreFoundation/CoreMedia/VideoToolbox frameworks on macOS; no-ops for local shared-FFmpeg builds, which are unchanged.
- `OBS_REF`/`DEPS_TAG` now pin only libobs and Qt6, whose library names and ABI stay stable across OBS releases — they no longer have to track the FFmpeg inside whatever OBS version users run.

Merging auto-cuts the patch release whose Windows build resolves the two reports.

## How it was tested

Build/CI change — no live-stream behavior touched (the decoder code is unchanged; it's the same FFmpeg sources now linked statically, as Linux releases already ship). Verified in the Linux container: built the action's exact static FFmpeg 7.1 and linked the plugin with the release flags — `-Wall -Wextra -Werror` clean, frontend UI enabled, `readelf` shows no `libavcodec`/`libavutil` NEEDED entries with libva still linked, ~1,500 decoder symbols embedded and none dynamically exported (3.4 MB module). The regular shared-FFmpeg dev build also stays clean. `actionlint` passes on both workflows. The Windows (MSVC-toolchain FFmpeg under MSYS2) and macOS (universal + lipo) paths can only compile on this PR's CI — that run is the real test for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL)_