### PR TITLE
CI: retry + GitHub mirror fallback for the static-ffmpeg download

### DIFF
--- a/.github/actions/static-ffmpeg/action.yml
+++ b/.github/actions/static-ffmpeg/action.yml
@@ -46,8 +46,9 @@ runs:
       env:
         FFMPEG_VERSION: ${{ inputs.version }}
       run: |
-        curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
-        tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        # fetch-ffmpeg.sh retries and falls back to the GitHub mirror:
+        # ffmpeg.org resets from runners took out the v1.9.1 release.
+        bash "$GITHUB_ACTION_PATH/fetch-ffmpeg.sh"
         cd "ffmpeg-${FFMPEG_VERSION}"
         ./configure --prefix="$GITHUB_WORKSPACE/ffmpeg-static" \
           --disable-everything --disable-programs --disable-doc \
@@ -72,8 +73,9 @@ runs:
         FFMPEG_VERSION: ${{ inputs.version }}
       run: |
         brew install nasm
-        curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
-        tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        # fetch-ffmpeg.sh retries and falls back to the GitHub mirror:
+        # ffmpeg.org resets from runners took out the v1.9.1 release.
+        bash "$GITHUB_ACTION_PATH/fetch-ffmpeg.sh"
         # --enable-cross-compile on the native slice too: it only turns
         # off configure-time runtime probing, and keeps both invocations
         # identical.

--- a/.github/actions/static-ffmpeg/build-windows.sh
+++ b/.github/actions/static-ffmpeg/build-windows.sh
@@ -10,8 +10,10 @@ rm -f /usr/bin/link.exe
 
 pacman -Sy --noconfirm --needed make nasm diffutils xz
 
-curl -LO "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
-tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+# fetch-ffmpeg.sh retries and falls back to the GitHub mirror:
+# ffmpeg.org resets from the Windows runners took out the v1.9.1
+# release twice, an hour apart.
+bash "$(dirname "$0")/fetch-ffmpeg.sh"
 cd "ffmpeg-${FFMPEG_VERSION}"
 
 prefix="$(cygpath -u "$GITHUB_WORKSPACE")/ffmpeg-static"

--- a/.github/actions/static-ffmpeg/fetch-ffmpeg.sh
+++ b/.github/actions/static-ffmpeg/fetch-ffmpeg.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fetch and unpack the FFmpeg source into ./ffmpeg-$FFMPEG_VERSION.
+# ffmpeg.org first (the canonical release tarball), then the GitHub tag
+# archive: ffmpeg.org reset connections from the Windows runners for
+# over an hour straight (it failed the v1.9.1 release's Windows job
+# twice, an hour apart), and tag n<version> is the same source served
+# from infrastructure Actions runners can always reach.
+set -euo pipefail
+
+fetch() {
+	curl -fL --retry 5 --retry-delay 2 --retry-all-errors -o "$2" "$1"
+}
+
+if fetch "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
+		"ffmpeg-${FFMPEG_VERSION}.tar.xz"; then
+	tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+else
+	echo "ffmpeg.org unreachable, using the GitHub mirror" >&2
+	fetch "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${FFMPEG_VERSION}.tar.gz" \
+		"ffmpeg-github.tar.gz"
+	tar xf ffmpeg-github.tar.gz
+	mv "FFmpeg-n${FFMPEG_VERSION}" "ffmpeg-${FFMPEG_VERSION}"
+fi


### PR DESCRIPTION
## What & why

The v1.9.1 Auto Release (the #91/#93 fix) is stuck half-shipped: the tag was pushed, but the Windows build failed on `curl: (35) Recv failure: Connection reset by peer` downloading `ffmpeg-7.1.tar.xz` from ffmpeg.org — twice, an hour apart (original run and a re-run of failed jobs), while the msys2 mirror worked fine in the same jobs and Linux/macOS fetched the same file without trouble. That points at ffmpeg.org rate-limiting or resetting the shared Windows-runner egress, so plain retries aren't a reliable fix.

New `fetch-ffmpeg.sh` in the static-ffmpeg action, used by all three platform builds:

- downloads with `curl -f --retry 5 --retry-delay 2 --retry-all-errors` (a plain `--retry` does not retry on connection resets — exactly the failure seen);
- on failure, falls back to the GitHub tag archive `FFmpeg/FFmpeg@n<version>` — the same source, served from infrastructure Actions runners can always reach.

Editing the action rotates its `hashFiles`-keyed caches, so this PR's CI rebuilds FFmpeg on all three platforms and exercises the new fetch path under the current network conditions. CI-only change — no release is cut by merging this (nothing under `obs-plugin/`, `ios-app/`, or `installer/` changed).

## How it was tested

Verified in the Linux container: `actionlint` passes, the action YAML parses, both shell scripts pass `bash -n`, and `fetch-ffmpeg.sh`'s primary path was run for real (downloads and unpacks `ffmpeg-7.1` from ffmpeg.org). The mirror fallback URL couldn't be fetched end-to-end from the sandbox (its egress proxy 403s GitHub archive downloads for out-of-scope repos), but the tag-archive endpoint and its `FFmpeg-n7.1/` top-level directory are GitHub's fixed conventions, and this PR's own Windows/macOS/Linux CI jobs exercise the full fetch on real runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL)_