### PR TITLE
iOS: stop the dim-fuse gesture from eating the settings form's taps

### DIFF
--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -60,9 +60,12 @@ struct ContentView: View {
             // Before this, only streamer-visible changes reset the standby
             // dim's fuse, so a minute spent in a menu that doesn't touch
             // the streamer (the tally screen, say) read as "idle" and the
-            // screen dimmed mid-use.
-            .simultaneousGesture(DragGesture(minimumDistance: 0)
-                .onChanged { _ in lastInteraction = Date() })
+            // screen dimmed mid-use. A passive UIKit sensor, NOT a SwiftUI
+            // DragGesture(minimumDistance: 0): that gesture competed for
+            // every first touch, breaking single-tap on the menu pickers
+            // (on some iOS releases) and on the broadcast picker overlay
+            // (everywhere) — #96, #97, #99.
+            .background(TouchActivitySensor { lastInteraction = Date() })
             .sheet(isPresented: $showOptions) {
                 OptionsView()
                     .environmentObject(streamer)

--- a/ios-app/Sources/TouchActivitySensor.swift
+++ b/ios-app/Sources/TouchActivitySensor.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import UIKit
+
+/// Reports every touch-down in the window without ever competing for it.
+///
+/// The standby dim's fuse must reset on any interaction — scrolling and
+/// reading included — but doing that with a SwiftUI
+/// `DragGesture(minimumDistance: 0)` on the settings form claimed every
+/// first touch: single-tap stopped opening the menu pickers on some iOS
+/// releases, and stopped reaching the UIKit broadcast picker overlay on
+/// all of them (#96, #97, #99 — the reporters' two-finger workaround was
+/// the second touch slipping past the drag, which only tracks the first).
+///
+/// This sensor instead attaches a UIKit recognizer to the *window* that
+/// fires its callback in `touchesBegan` and immediately fails itself, so
+/// it leaves gesture arbitration before any other recognizer or view can
+/// be affected by it. Window level is load-bearing: the sensor lives in
+/// a `.background`, where hit-testing would never hand it the form's own
+/// touches.
+struct TouchActivitySensor: UIViewRepresentable {
+    var onTouch: () -> Void
+
+    func makeUIView(context: Context) -> SensorView {
+        let view = SensorView()
+        view.recognizer.onTouchDown = onTouch
+        return view
+    }
+
+    func updateUIView(_ view: SensorView, context: Context) {
+        view.recognizer.onTouchDown = onTouch
+    }
+
+    /// Follows its window: attaches the recognizer when it lands in one,
+    /// detaches when the hosting view leaves (so a dismissed screen never
+    /// leaks a recognizer on the window).
+    final class SensorView: UIView {
+        let recognizer = TouchDownReporter()
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            if let attached = recognizer.view, attached !== window {
+                attached.removeGestureRecognizer(recognizer)
+            }
+            if let window = window, recognizer.view == nil {
+                window.addGestureRecognizer(recognizer)
+            }
+        }
+    }
+
+    /// Fires the callback on touch-down, then instantly bows out
+    /// (`.failed`): it can never win, delay, or cancel another
+    /// recognizer, and it never withholds touches from UIKit views. The
+    /// three flags are belt and braces — a recognizer that fails in
+    /// `touchesBegan` never uses them, but nobody should have to
+    /// re-derive that while debugging the next touch issue. One
+    /// consequence to know: a touch that never lifts (a single continuous
+    /// minutes-long drag) reports only once, at its start — acceptable
+    /// against a 60 s fuse.
+    final class TouchDownReporter: UIGestureRecognizer {
+        var onTouchDown: () -> Void = {}
+
+        init() {
+            super.init(target: nil, action: nil)
+            cancelsTouchesInView = false
+            delaysTouchesBegan = false
+            delaysTouchesEnded = false
+        }
+
+        override func touchesBegan(_ touches: Set<UITouch>,
+                                   with event: UIEvent) {
+            onTouchDown()
+            state = .failed
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Fixes #89
Fixes #96
Fixes #97
Fixes #99

The standby dim reset its fuse via a `simultaneousGesture(DragGesture(minimumDistance: 0))` on the whole settings Form (f03e8bd, late July). A zero-distance drag competes for every first touch: menu-style pickers stopped opening on single tap on some iOS releases — the whole Camera & color section looked locked at its defaults (#96, #99, reproduced by five reporters across iPhone XR→16e on iOS 18.7/26.x) — and the `RPSystemBroadcastPickerView` overlay stopped receiving single taps everywhere, since touches a SwiftUI gesture claims are withheld from UIKit subviews (#97, regression window builds 1038→1054 matches the gesture landing). The reporters' two-finger workaround was the second touch slipping past a drag that only tracks the first.

Replaced with `TouchActivitySensor`: a window-level UIKit recognizer that fires on `touchesBegan` and immediately fails itself — it observes touch activity for the dim fuse without ever winning, delaying, or cancelling another recognizer, and never withholds touches from UIKit views. Same fuse behavior (any touch resets it), zero participation in gesture arbitration.

Carries `Release-Bump`-wise: `Release-Beta: true` — ships to TestFlight as the next 1.10.0 beta without cutting a new stable Latest.

## How it was tested

Swift parse check passes (`ios-app/syntax-check.sh`); the full type check is this PR's macOS CI job. Behavioral verification needs devices: the broadcast-row single tap reproduces on the maintainer's phone (pre-fix) and should work in the next build; the picker fix lands with TestFlight testers on the affected iOS versions (18.7.9, 26.5.2, 26.6). The dim-fuse still resets on any touch by construction (the sensor reports every touch-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeWct1Rvpqi4ptgogiwsCL)_