### PR TITLE
iOS: pick what the Live screen becomes when it goes idle

### DIFF
--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -302,8 +302,8 @@ Long explanations don't belong on this screen: each module's footer is at
 most a sentence or two, so the form stays close to one screenful.
 
 **Options sheet.** The behaviour toggles live in a sheet (`OptionsView`)
-so the main screen stays short: **Remote start from OBS**, **Dim screen
-while streaming**, and a **Microphone** group (**Send phone mic to OBS** /
+so the main screen stays short: **Remote start from OBS**, **Idle view**
+(Standard / Clean feed / Dim screen), and a **Microphone** group (**Send phone mic to OBS** /
 **Auto lip-sync reference** — mutually exclusive; turning one on turns the
 other off). Each toggle sits in its own section with a short footer
 directly beneath it — never one combined wall-of-text footer for all of
@@ -312,9 +312,12 @@ them.
 ### 6.2 App — Live screen
 Full-screen black; camera preview `resizeAspect`; content over it:
 
-- **Top bar:** status pill (dot + word, left) · Stats button · Dim button ·
+- **Top bar:** status pill (dot + word, left) · Stats button · Idle button ·
   Stop button (red). Glass chips. With Stats on, a health pill (fps ·
-  Mb/s · dropped) sits under the bar, leading-aligned.
+  Mb/s · dropped) sits under the bar, leading-aligned. The Idle button
+  engages the idle view now instead of waiting out the fuse, and carries
+  that view's icon (`eye.slash` for Clean feed, `moon.fill` for Dim
+  screen); in Standard, which has no idle view, it isn't drawn.
 - **Bottom panel** (`glassPanel`, radius 16): zoom row, exposure rows
   (AE/Manual segmented sharing the bias-slider row; ISO + Shutter rows in
   Manual), white-balance row (AWB/Lock + temperature slider), then a
@@ -323,9 +326,21 @@ Full-screen black; camera preview `resizeAspect`; content over it:
 - **Gestures:** pinch anywhere = zoom; tap = focus/expose at point. In
   **AF** the focus row carries no inline label — tap-to-focus is a gesture,
   not on-screen text (a label there crowded the row and wrapped badly).
-- **Dim overlay:** after 10 s idle (if enabled) the screen goes near-black
-  with a small "Streaming — tap to wake" hint and lowered brightness; any
-  tap restores.
+- **Idle view:** what the screen becomes 10 s after the last touch, the
+  user's choice in Options → Idle view. Any tap brings the controls back
+  and restarts the fuse.
+  - **Standard** — nothing happens; the controls stay up all stream.
+  - **Clean feed** — the preview alone: status pill, sync pill and control
+    panel fade out over 0.2 s. Two things deliberately stay, because
+    neither is a control: the tally border, and the health pill when Stats
+    is on — the Stats button *is* the "clean, but keep the numbers" switch,
+    so no second setting exists for it. A transparent tap catcher covers
+    the screen, so the waking tap is only a wake (never also a focus pull)
+    and the letterbox bars wake it too.
+  - **Dim screen** — near-black overlay with a small "Streaming — tap to
+    wake" hint, brightness at 5%, and preview rendering stopped. The only
+    idle view that also applies to the Setup screen, which dims a minute
+    into remote-start standby.
 
 ### 6.3 Web control panel
 Dark page (`pageBg`), single centered column (max ~440 px):

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -114,11 +114,14 @@ struct ContentView: View {
         .task {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
-                // Gated on the dim setting (one switch governs both dims)
-                // and on no sheet being up: the overlay would sit behind
-                // the sheet with its tap-to-wake unreachable, leaving the
-                // screen dark with no visible way back.
-                if streamer.standbyActive && streamer.dimWhileStreaming &&
+                // Gated on the idle view being Dim screen — Clean feed
+                // has nothing to mean on a settings form, so only the
+                // dimming choice reaches this screen — and on no sheet
+                // being up: the overlay would sit behind the sheet with
+                // its tap-to-wake unreachable, leaving the screen dark
+                // with no visible way back.
+                if streamer.standbyActive
+                    && streamer.idleAppearance == .dim &&
                     !showOptions && !showDocs && !dimmed &&
                     Date().timeIntervalSince(lastInteraction) > Self.dimAfterSeconds {
                     dim()

--- a/ios-app/Sources/DocumentationView.swift
+++ b/ios-app/Sources/DocumentationView.swift
@@ -46,7 +46,7 @@ struct DocumentationView: View {
 
             Section {
                 Text("**Remote start from OBS**: while the app is open and idle, OBS can start the camera for you. The phone stays awake while it waits — locking it or leaving the app ends remote start. Siri: \"Start streaming with LensLink.\"")
-                Text("**Dim screen to save battery**: dims 10 seconds into streaming, or a minute into remote-start standby — tap to wake. Never while you're using the app.")
+                Text("**Idle view** is what the Live screen becomes 10 seconds after you last touch it, for a phone that's mounted and out of reach. **Standard** leaves the controls up. **Clean feed** hides everything but the picture — turn Stats on before you stop touching it to keep the health readout. **Dim screen** blanks the screen and drops the brightness to save battery, and is the only one that also dims remote-start standby, a minute in. Any tap brings the controls back.")
                 Text("**Allow system video effects** is experimental: it lets iOS lower the frame rate on its own, which the Control Center video effects (Portrait, Studio Light) may require. Takes effect when the camera next starts.")
             } header: {
                 Text("Options")

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -19,8 +19,15 @@ struct OptionsView: View {
                 Section {
                     Toggle("Remote start from OBS",
                            isOn: $streamer.remoteStartEnabled)
-                    Toggle("Dim screen to save battery",
-                           isOn: $streamer.dimWhileStreaming)
+                    // What the Live screen becomes 10 seconds after you
+                    // stop touching it. Inline picker: three short labels
+                    // that fit one row and read as one choice, where a
+                    // pushed screen would hide two of the three.
+                    Picker("Idle view", selection: $streamer.idleAppearance) {
+                        ForEach(Streamer.IdleAppearance.allCases) { view in
+                            Text(view.displayName).tag(view)
+                        }
+                    }
                     Toggle("Allow system video effects",
                            isOn: $streamer.allowVideoEffects)
                 }

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -49,9 +49,52 @@ final class Streamer: ObservableObject {
         }
     }
 
+    /// What the Live screen shows once the 10 s idle fuse burns down —
+    /// the phone is mounted and nobody is touching it, so the screen can
+    /// stop being a control panel. Any touch brings the controls back and
+    /// restarts the fuse.
+    enum IdleAppearance: String, CaseIterable, Identifiable {
+        /// Nothing happens: the controls stay up for the whole stream.
+        case standard
+        /// Clean feed — the preview alone, no chips, panel or hints, so
+        /// the mounted phone reads as a monitor. The tally border stays
+        /// (knowing you're on air is not a control), and the health pill
+        /// stays if Stats is on, which is how you keep numbers on a
+        /// clean screen.
+        case clean
+        /// Near-black tap-to-wake overlay with the brightness dropped —
+        /// the battery saver.
+        case dim
+
+        var id: String { rawValue }
+
+        /// UI label, American English per docs/UI_DESIGN.md.
+        var displayName: String {
+            switch self {
+            case .standard: return "Standard"
+            case .clean: return "Clean feed"
+            case .dim: return "Dim screen"
+            }
+        }
+    }
+
     /// Shared instance: the SwiftUI scene, the Siri App Intents, and the
     /// lenslink:// URL handler must all drive the same streamer.
     static let shared = Streamer()
+
+    /// Reads the idle-view preference, migrating the "dimWhileStreaming"
+    /// switch this setting replaced: it was on by default, so an absent
+    /// value means `.dim` too, and only someone who had turned it off
+    /// lands on `.standard`.
+    private static func storedIdleAppearance(
+        _ defaults: UserDefaults) -> IdleAppearance {
+        if let raw = defaults.string(forKey: "idleAppearance"),
+           let stored = IdleAppearance(rawValue: raw) {
+            return stored
+        }
+        let dimmed = defaults.object(forKey: "dimWhileStreaming") as? Bool
+        return (dimmed ?? true) ? .dim : .standard
+    }
 
     // Settings (persisted to UserDefaults)
     @Published var resolution: CameraManager.Resolution {
@@ -319,12 +362,14 @@ final class Streamer: ObservableObject {
         }
         return colorSetting
     }
-    /// "Dim screen to save battery": governs both the Live screen's 10 s
-    /// dim and the Setup screen's standby dim. The name and stored key
-    /// predate the standby dim being brought under it — the key stays so
-    /// nobody's preference resets.
-    @Published var dimWhileStreaming: Bool {
-        didSet { UserDefaults.standard.set(dimWhileStreaming, forKey: "dimWhileStreaming") }
+    /// What the Live screen becomes once you stop touching it, and
+    /// whether the Setup screen's standby dim runs at all (only `.dim`
+    /// does — a form has no feed to keep clean).
+    @Published var idleAppearance: IdleAppearance {
+        didSet {
+            UserDefaults.standard.set(idleAppearance.rawValue,
+                                      forKey: "idleAppearance")
+        }
     }
     /// Experiment: leave the max frame duration unlocked so iOS may lower
     /// the rate on its own — which the Control Center video effects appear
@@ -818,7 +863,7 @@ final class Streamer: ObservableObject {
         let storedDistance = defaults.double(forKey: "greenScreenMaxDistance")
         greenScreenMaxDistance =
             (0.5...5.0).contains(storedDistance) ? storedDistance : 0
-        dimWhileStreaming = defaults.object(forKey: "dimWhileStreaming") as? Bool ?? true
+        idleAppearance = Streamer.storedIdleAppearance(defaults)
         allowVideoEffects = defaults.bool(forKey: "allowVideoEffects")
         sendAudioReference = defaults.bool(forKey: "sendAudioReference")
         // didSet doesn't run during init; enforce the exclusivity here.

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -2,21 +2,29 @@ import SwiftUI
 import AVFoundation
 
 /// Full-screen live view shown while streaming: camera preview with
-/// tap-to-focus and pinch-to-zoom, camera controls, and optional
-/// battery-saving dimming.
+/// tap-to-focus and pinch-to-zoom, camera controls, and — once the idle
+/// fuse burns down — whichever idle view the user picked (Options →
+/// Idle view): controls left up, a clean feed, or a dimmed screen.
 struct StreamingView: View {
     @EnvironmentObject private var streamer: Streamer
 
-    @State private var dimmed = false
+    /// The idle view is engaged: the fuse burned down (or the idle
+    /// button was tapped) and `idleAppearance` is doing whatever it does.
+    /// Never true for `.standard`, which has no idle view.
+    @State private var idle = false
     @State private var lastInteraction = Date()
     @State private var pinchBaseZoom: CGFloat = 1
     @State private var previousBrightness: CGFloat = UIScreen.main.brightness
+    /// Whether `previousBrightness` is a level we still owe the system.
+    /// Tracked rather than derived from the current mode: the mode can
+    /// change while the screen is dimmed, and the restore must survive it.
+    @State private var brightnessLowered = false
     /// Stream health pill (fps · Mb/s · dropped). Persisted: someone who
     /// turns it on is debugging and wants it next stream too. The streamer
     /// reads the same key to decide whether to sample health at all.
     @AppStorage(StreamerDefaults.showHealth) private var showHealth = false
 
-    private static let dimAfterSeconds: TimeInterval = 10
+    private static let idleAfterSeconds: TimeInterval = 10
 
     var body: some View {
         ZStack {
@@ -52,23 +60,50 @@ struct StreamingView: View {
             .ignoresSafeArea()
 
             VStack {
-                statusBar
-                // Its own row: sharing the top bar with three buttons
-                // truncated the words ("Sync lo…"), and an unreadable
-                // status is worse than none.
-                if syncLabel != nil {
-                    syncPill
+                if showsControls {
+                    statusBar
+                    // Its own row: sharing the top bar with three buttons
+                    // truncated the words ("Sync lo…"), and an unreadable
+                    // status is worse than none.
+                    if syncLabel != nil {
+                        syncPill
+                    }
                 }
-                if showHealth, let health = streamer.health {
+                // Survives the clean feed when Stats is on: numbers are a
+                // readout, not a control, and the Stats button is exactly
+                // the "optionally, with health" switch (docs/UI_DESIGN.md
+                // §6.2). Hidden under the dim overlay, which covers it.
+                if showHealth, !dimmed, let health = streamer.health {
                     healthPill(health)
                 }
                 Spacer()
-                controlPanel
+                if showsControls {
+                    controlPanel
+                }
             }
             .padding()
+            .animation(.easeInOut(duration: 0.2), value: showsControls)
 
             if dimmed {
                 dimOverlay
+            }
+            if cleanFeed {
+                // Invisible tap catcher over the whole clean feed: the
+                // first tap only brings the controls back, so waking is
+                // never also a focus pull at wherever your thumb landed
+                // — and the letterbox bars, which the preview's own
+                // recognizer never sees, wake it too.
+                Color.clear
+                    .contentShape(Rectangle())
+                    .ignoresSafeArea()
+                    // Touch-down, not tap: a pinch starting on the clean
+                    // feed must wake it too, and a tap gesture fails the
+                    // moment the fingers move. Safe here where a drag
+                    // would not be on the settings form (#96/#97) — this
+                    // layer covers no controls and is gone the instant
+                    // it fires.
+                    .gesture(DragGesture(minimumDistance: 0)
+                        .onChanged { _ in touched() })
             }
 
             // Above the dim overlay on purpose: a phone mounted out of
@@ -80,33 +115,67 @@ struct StreamingView: View {
         .task {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
-                if streamer.dimWhileStreaming && !dimmed &&
-                    Date().timeIntervalSince(lastInteraction) > Self.dimAfterSeconds {
-                    dim()
+                if streamer.idleAppearance != .standard && !idle &&
+                    Date().timeIntervalSince(lastInteraction)
+                        > Self.idleAfterSeconds {
+                    goIdle()
                 }
             }
         }
+        // The preference is only reachable from the Setup screen today,
+        // but a change arriving under a live idle view (an App Intent, a
+        // future remote command) must not strand the screen dark or
+        // control-less in a mode that no longer applies.
+        .onChange(of: streamer.idleAppearance) { _ in wake() }
         .onDisappear {
-            if dimmed {
-                UIScreen.main.brightness = previousBrightness
-            }
+            restoreBrightness()
         }
     }
 
+    /// True while the controls are on screen: always in Standard, and in
+    /// the other modes until the fuse burns down.
+    private var showsControls: Bool { !idle }
+
+    /// The clean feed is up — preview (plus tally, plus the health pill
+    /// if Stats is on) and nothing else.
+    private var cleanFeed: Bool { idle && streamer.idleAppearance == .clean }
+
+    /// The dim overlay is up.
+    private var dimmed: Bool { idle && streamer.idleAppearance == .dim }
+
+    /// Any interaction restarts the fuse and, if an idle view is up,
+    /// brings the controls back.
     private func touched() {
+        lastInteraction = Date()
+        if idle { wake() }
+    }
+
+    /// Engages the chosen idle view. Standard has none, so this is a
+    /// no-op there (its idle button isn't drawn either).
+    private func goIdle() {
+        guard streamer.idleAppearance != .standard else { return }
+        if streamer.idleAppearance == .dim && !brightnessLowered {
+            previousBrightness = UIScreen.main.brightness
+            brightnessLowered = true
+            UIScreen.main.brightness = 0.05
+        }
+        withAnimation { idle = true }
+    }
+
+    /// Back to the controls.
+    private func wake() {
+        restoreBrightness()
+        withAnimation { idle = false }
         lastInteraction = Date()
     }
 
-    private func dim() {
-        previousBrightness = UIScreen.main.brightness
-        UIScreen.main.brightness = 0.05
-        withAnimation { dimmed = true }
-    }
-
-    private func undim() {
+    /// Puts the brightness back exactly once, and only if we lowered it —
+    /// writing a stale level over one the user (or iOS auto-brightness)
+    /// has since changed is its own bug.
+    private func restoreBrightness() {
+        guard brightnessLowered else { return }
+        brightnessLowered = false
         UIScreen.main.brightness = previousBrightness
-        withAnimation { dimmed = false }
-        touched()
     }
 
     private var dimOverlay: some View {
@@ -123,7 +192,7 @@ struct StreamingView: View {
             }
         }
         .contentShape(Rectangle())
-        .onTapGesture { undim() }
+        .onTapGesture { wake() }
     }
 
     /// Tally: a border round the whole screen, readable at arm's length
@@ -219,9 +288,13 @@ struct StreamingView: View {
                 showHealth.toggle()
             }
 
-            ControlButton(systemImage: "moon.fill") {
-                touched()
-                dim()
+            // Skip the fuse and go idle now. Absent in Standard, which
+            // has no idle view to go to.
+            if streamer.idleAppearance != .standard {
+                ControlButton(systemImage: streamer.idleAppearance == .clean
+                                ? "eye.slash" : "moon.fill") {
+                    goIdle()
+                }
             }
 
             Button {


### PR DESCRIPTION
## What & why

The Live screen had one idle behaviour — dim to near-black after 10 s, on or off. That is the right answer for a phone on a stand in the dark and the wrong one for a phone being used as a monitor, where the wanted idle state is the picture with nothing on top of it.

Options → "Dim screen to save battery" becomes **Idle view**, with three choices for what the screen becomes 10 s after the last touch:

- **Standard** — controls stay up all stream (what turning the old switch off did).
- **Clean feed** — status pill, sync pill and control panel fade out; the preview, the tally border and (with Stats on) the health pill stay. Stats is the "clean, but keep the numbers" switch, so no second setting exists for it.
- **Dim screen** — the old behaviour, unchanged, and still the only choice that dims remote-start standby on the Setup screen (a clean feed means nothing on a settings form).

Any touch brings the controls back and restarts the fuse. The top-bar Dim button becomes an Idle button carrying the chosen view's icon (`eye.slash` / `moon.fill`) and is absent in Standard, which has no idle view to go to. The clean feed gets a transparent touch-down catcher, so the waking touch is only a wake — never also a focus pull at wherever your thumb landed — and so the letterbox bars and the start of a pinch wake it too.

Two details worth a reviewer's eye:

- The stored `dimWhileStreaming` switch migrates: on (the default) → Dim screen, off → Standard, so nobody's preference resets.
- Brightness restore is now tracked by a flag rather than derived from the current mode, so a mode change while dimmed can't strand the screen at 5%.

Docs updated in the same change, per the repo's rule that a control without a Documentation entry doesn't exist: `docs/UI_DESIGN.md` §6.1/§6.2 and the in-app Documentation entry.

## How it was tested

`ios-app/syntax-check.sh` passes (parse-only — this was developed on Linux, so type checking and iOS 15 availability are the macOS CI job). No device test yet: the fade, the wake-on-touch behaviour and the brightness restore want a real phone before release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjhjLUXKo5ZcicDL92EcgY)_