### PR TITLE
Camera presets, battery visibility while dimmed, and a release-version guard

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -137,6 +137,38 @@ jobs:
 
           tag="v$major.$minor.$patch"
 
+          # An in-flight beta line outranks a lower computed version.
+          #
+          # Betas lead up to the stable they are a beta *of*, and merging
+          # without the trailer is documented to cut it. That holds by
+          # itself only for a patch beta: v1.8.1 -> v1.8.2-beta.1 -> a
+          # plain merge computes v1.8.2 and lands on it. A beta created
+          # with a bump trailer does not — v1.9.0 + minor + beta gives
+          # v1.10.0-beta.1, and the next plain merge computes v1.9.1,
+          # BELOW the beta line. That shipped: v1.10.0-beta.2 was public
+          # and on TestFlight when v1.9.2 was cut underneath it, so
+          # testers watched the version go backwards.
+          #
+          # So: take the highest version any pre-release is a beta of, and
+          # if the computed tag is below it, cut that version instead. The
+          # bases are compared with sort -V after stripping the suffix —
+          # comparing the suffixed tags directly is what git's version sort
+          # gets wrong (see the stable-only filter above). Self-limiting:
+          # once a line is cut, the stable tag seeds the next number and
+          # every later version is already above it, so this never fires
+          # twice for the same line, and it can only ever move the version
+          # UP.
+          pre_base=$(git tag --list 'v*-beta.*' \
+                     | grep -xE 'v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+' \
+                     | sed -E 's/-beta\.[0-9]+$//' | sort -uV | tail -1)
+          if [ -n "$pre_base" ] && [ "$pre_base" != "$tag" ] \
+             && [ "$(printf '%s\n%s\n' "$tag" "$pre_base" \
+                     | sort -V | tail -1)" = "$pre_base" ]; then
+            echo "::notice::$tag would land below the in-flight" \
+                 "$pre_base beta line; releasing $pre_base instead."
+            tag="$pre_base"
+          fi
+
           # Beta: same version, suffixed, counting up within it. Probing for
           # the first free suffix (rather than counting existing ones) keeps
           # numbering right even if a beta tag was deleted by hand.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,6 +105,18 @@ v1.8.2                    merge without it — the beta becomes the release
 Combine it with a bump trailer to beta a bigger version:
 `Release-Bump: minor` + `Release-Beta: true` → `v1.9.0-beta.1`.
 
+A beta line made that way needs no second bump trailer to land. "Merge
+without it and the beta becomes the release" used to be true only for a
+*patch* beta, where the plain merge happens to compute the same number.
+A bumped line sat above what the next plain merge would compute, so the
+stable was cut **underneath** it — `v1.10.0-beta.2` was public and on
+TestFlight when `v1.9.2` was cut, and testers watched the version go
+backwards. Now the highest version any pre-release is a beta of is
+treated as a floor: a computed version below it is replaced by it, and
+that line gets cut as documented. It can only move a version up, and it
+goes quiet once the line is cut, since the new stable tag then seeds
+everything after it.
+
 A `-beta.` tag publishes as a pre-release however it was created, so a
 hand-pushed `v1.8.0-beta.1` doesn't become a stable release just because
 it arrived without the flag set. (A hand-pushed tag still won't upload to
@@ -115,7 +127,10 @@ Dispatch `testflight.yml` with the tag if you need that.)
 Two details worth knowing. The next version is computed from **stable tags
 only** — git's version sort puts `v1.9.0-beta.2` *above* `v1.9.0`, and the
 patch field would read `0-beta.2`, which the shell can't add 1 to, so an
-unfiltered list would fail the next stable release outright. And the
+unfiltered list would fail the next stable release outright. (Pre-releases
+still get a say afterwards, as the floor described above; they are read by
+stripping the suffix and comparing with `sort -V`, never by asking git to
+order the suffixed tags.) And the
 TestFlight "What to Test" notes are looked up **by tag**, because the
 `/releases/latest` endpoint is defined as the newest non-pre-release and
 would otherwise hand testers the previous stable release's changelog with

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -312,7 +312,8 @@ most a sentence or two, so the form stays close to one screenful.
 
 **Options sheet.** The behaviour toggles live in a sheet (`OptionsView`)
 so the main screen stays short: **Remote start from OBS**, **Idle view**
-(Standard / Clean feed / Dim screen), and a **Microphone** group (**Send phone mic to OBS** /
+(Standard / Clean feed / Dim screen), pushed screens for **Tally light**
+and **Presets**, and a **Microphone** group (**Send phone mic to OBS** /
 **Auto lip-sync reference** — mutually exclusive; turning one on turns the
 other off). Each toggle sits in its own section with a short footer
 directly beneath it — never one combined wall-of-text footer for all of
@@ -355,6 +356,27 @@ Full-screen black; camera preview `resizeAspect`; content over it:
     answer. Nothing renders where iOS reports no level (Simulator). The
     only idle view that also applies to the Setup screen, which dims a
     minute into remote-start standby.
+
+### 6.2.1 Presets
+
+Saved camera looks (Options → Presets): a name, any subset of
+**Exposure / White balance / Zoom / Focus**, and optionally a camera it
+belongs to. A group left out is not stored, so it can never be applied by
+mistake — "not included" and "included but unchanged" are the same thing
+to the user and must be the same thing in the model.
+
+- A preset applies when its camera starts (stream start, or a live lens
+  switch); the **default** covers any camera without one of its own.
+- Changing a covered setting **by hand pauses auto-apply** — from the Live
+  screen or a remote `CONTROL` command, which are the same intent. A
+  **Presets paused** pill (amber dot, `arrow.clockwise`, the sync pill's
+  anatomy) appears on the Live screen and resumes on tap, applying the
+  matching preset immediately. Never a restart, never stopping the stream.
+- The pill appears only where resuming would do something: paused, the
+  master switch on, and a preset that matches this camera.
+- Presets are phone-local. They move the same properties the Live screen
+  and `CONTROL` do, so the `STATE` snapshot follows for free — no
+  protocol change.
 
 ### 6.3 Web control panel
 Dark page (`pageBg`), single centered column (max ~440 px):

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -65,11 +65,11 @@ While remote start is armed the phone holds its idle timer (auto-lock
 would suspend the listener and kill remote start), so the Setup screen
 reuses the Live screen's near-black tap-to-wake dim overlay — on a
 60-second fuse instead of 10, with the icon in `connectAmber` rather
-than `liveGreen` (armed, not live). Both dims answer to the one "Dim
-screen to save battery" toggle, and the standby dim never fires while
-the user is interacting: any touch resets the fuse, and it can't trigger
-while a sheet is open (the overlay would sit behind the sheet with its
-tap-to-wake unreachable).
+than `liveGreen` (armed, not live). The standby dim runs only when the
+idle view is **Dim screen** (§6.2 — a clean feed means nothing on a
+settings form), and it never fires while the user is interacting: any
+touch resets the fuse, and it can't trigger while a sheet is open (the
+overlay would sit behind the sheet with its tap-to-wake unreachable).
 
 The status **word and colour are defined once** (`Streamer.Status.displayName`
 / `.tint` in the app) and reused by every view; the web panel maps the
@@ -97,9 +97,11 @@ defaults reproduce the pre-customization behaviour exactly. On air keeps
 the heaviest stroke (6 pt vs 4 pt) whatever its colour, so live stays
 the most emphatic state.
 
-Any lit status can also **pulse** instead of holding steady (the button
-beside its colour): a 0.9 s ease between full and 30% opacity — never to
-zero, so a glance during the dark half still finds a border. Motion is
+Any lit status can also **pulse** instead of holding steady — off by
+default on every status, so the calm-by-default principle holds until
+somebody asks for motion (the button beside its colour): a 0.9 s ease
+between full and 30% opacity — never to zero, so a glance during the
+dark half still finds a border. Motion is
 for a status you are meant to notice without watching for it, low battery
 being the case it was added for. `accessibilityReduceMotion` turns every
 pulse into a steady border of the same colour: less motion, never less
@@ -255,7 +257,8 @@ surfaces.
 | Lens        | `camera.aperture` menu                     | Menu of the device's real lenses; check on the active one |
 | Flip        | `arrow.triangle.2.circlepath.camera`      | Quick front/back |
 | Stop        | `stop.fill`                                | Red chip; the only destructive control |
-| Dim (app)   | `moon.fill`                                | App-only battery saver |
+| Idle (app)  | `moon.fill` (Dim screen) / `eye.slash` (Clean feed) | App-only; engages the chosen idle view now instead of waiting out the 10 s fuse. Absent in Standard |
+| Pulse (app) | `waveform.path`                            | App-only, in Options → Tally light: one glyph, `accent` when that status pulses and secondary when steady — the active-chip language, not a swapped icon |
 | Stats (app) | `gauge`                                    | App-only toggle; shows a health pill (`60 fps · 11.9 Mb/s · 0 dropped`, monospaced) under the status bar |
 | Green screen | `person.fill.viewfinder`                  | **Always "Green screen"** (never "chroma key", "background removal", or "matte" in UI copy). Armed from the Setup screen; while live **with depth assist**, a "Subject distance" slider row (0.5–5.0 m, readout `2.5 m` monospaced) appears on the Live panel and the web panel, same position both surfaces. Dragging always sets a real cutoff — full-left = tightest (0.5 m); **"All" (no cutoff) is entered by tapping the readout**, and while "All" the thumb parks at the far (5.0) end. Identical on both surfaces |
 
@@ -315,15 +318,15 @@ so the main screen stays short: **Remote start from OBS**, **Idle view**
 (Standard / Clean feed / Dim screen), pushed screens for **Tally light**
 and **Presets**, and a **Microphone** group (**Send phone mic to OBS** /
 **Auto lip-sync reference** — mutually exclusive; turning one on turns the
-other off). Each toggle sits in its own section with a short footer
-directly beneath it — never one combined wall-of-text footer for all of
-them.
+other off). Pure controls, no footers: every explanation lives in the
+Documentation screen (§3), which is also why the pushed screens carry
+none.
 
 ### 6.2 App — Live screen
 Full-screen black; camera preview `resizeAspect`; content over it:
 
-- **Top bar:** status pill (dot + word, left) · Stats button · Idle button ·
-  Stop button (red). Glass chips. With Stats on, a health pill (fps ·
+- **Top bar:** status pill (dot + word, left) · Stats button · Idle
+  button · Stop button (red). Glass chips. With Stats on, a health pill (fps ·
   Mb/s · dropped) sits under the bar, leading-aligned. The Idle button
   engages the idle view now instead of waiting out the fuse, and carries
   that view's icon (`eye.slash` for Clean feed, `moon.fill` for Dim
@@ -350,12 +353,15 @@ Full-screen black; camera preview `resizeAspect`; content over it:
   - **Dim screen** — near-black overlay with a small "Streaming — tap to
     wake" hint, brightness at 5%, and preview rendering stopped. Under the
     hint sits a **battery readout** (level glyph + monospaced percentage,
-    a bolt while charging), grey normally and `errorRed` when low — the
-    answer to "do I need to plug this in?" without waking the screen,
-    which is the one question a dimmed phone on a stand can't otherwise
-    answer. Nothing renders where iOS reports no level (Simulator). The
-    only idle view that also applies to the Setup screen, which dims a
-    minute into remote-start standby.
+    a bolt while charging). It answers "do I need to plug this in?"
+    without waking the screen — the one question a dimmed phone on a
+    stand cannot otherwise answer. Grey normally, `connectAmber` in Low
+    Power Mode, `errorRed` at 20% or below, and grey again whenever
+    charging: Low Power Mode can be switched on at 80%, and one colour
+    for both would be a warning you learn to ignore. Nothing renders
+    where iOS reports no level (Simulator). This is the only idle view
+    that also applies to the Setup screen, which dims a minute into
+    remote-start standby.
 
 ### 6.2.1 Presets
 
@@ -374,6 +380,16 @@ to the user and must be the same thing in the model.
   matching preset immediately. Never a restart, never stopping the stream.
 - The pill appears only where resuming would do something: paused, the
   master switch on, and a preset that matches this camera.
+- **Options → Presets** is a plain list — the master switch, the presets,
+  and New preset — with no hand-apply action: the screen is reachable
+  only from Setup, where no camera is running, so an "apply now" button
+  could never do anything visible.
+- The **editor** builds each group out of the same segmented controls and
+  slider rows as the Live screen (AE/Manual, AWB/Lock, AF/Lock; the same
+  icons, the same 44 pt monospaced readout), so the preset you are
+  writing looks like the panel it will drive. Its ranges come from the
+  running camera where there is one and from the format-independent
+  fallbacks otherwise; values are clamped again on apply.
 - Presets are phone-local. They move the same properties the Live screen
   and `CONTROL` do, so the `STATE` snapshot follows for free — no
   protocol change.

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -89,12 +89,21 @@ in the list that is currently true and has a colour lights the border.
 | Connection lost | Off | streaming, link to OBS dropped |
 | Calibrating lip-sync | Off | measuring / re-measuring |
 | Lip-sync locked | Off | calibration locked on |
+| Low battery | Off | Low Power Mode, or ≤ 20%, while unplugged |
 
 Assignable colours: Red `#FF3B30`, Amber `#FF9F0A`, Green `#30D158`,
 Blue `#3D7BFF`, Purple `tallyPurple` `#BF5AF2`, White, or Off. The
 defaults reproduce the pre-customization behaviour exactly. On air keeps
 the heaviest stroke (6 pt vs 4 pt) whatever its colour, so live stays
 the most emphatic state.
+
+Any lit status can also **pulse** instead of holding steady (the button
+beside its colour): a 0.9 s ease between full and 30% opacity — never to
+zero, so a glance during the dark half still finds a border. Motion is
+for a status you are meant to notice without watching for it, low battery
+being the case it was added for. `accessibilityReduceMotion` turns every
+pulse into a steady border of the same colour: less motion, never less
+warning.
 
 The tally's core answer — *am I on air?* — must never be ambiguous, so
 it is **its own indicator**, not a mode of the status dot. It's a border
@@ -338,9 +347,14 @@ Full-screen black; camera preview `resizeAspect`; content over it:
     the screen, so the waking tap is only a wake (never also a focus pull)
     and the letterbox bars wake it too.
   - **Dim screen** — near-black overlay with a small "Streaming — tap to
-    wake" hint, brightness at 5%, and preview rendering stopped. The only
-    idle view that also applies to the Setup screen, which dims a minute
-    into remote-start standby.
+    wake" hint, brightness at 5%, and preview rendering stopped. Under the
+    hint sits a **battery readout** (level glyph + monospaced percentage,
+    a bolt while charging), grey normally and `errorRed` when low — the
+    answer to "do I need to plug this in?" without waking the screen,
+    which is the one question a dimmed phone on a stand can't otherwise
+    answer. Nothing renders where iOS reports no level (Simulator). The
+    only idle view that also applies to the Setup screen, which dims a
+    minute into remote-start standby.
 
 ### 6.3 Web control panel
 Dark page (`pageBg`), single centered column (max ~440 px):

--- a/ios-app/Sources/BatteryMonitor.swift
+++ b/ios-app/Sources/BatteryMonitor.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import UIKit
+
+/// Battery level, charging state and Low Power Mode, published for the
+/// Live screen's dim readout and the low-battery tally status.
+///
+/// Notification-driven, never polled: iOS posts a level change every 5%
+/// (that is the granularity `UIDevice` offers — a percentage that moves in
+/// steps of five is expected, not a bug) and a state change whenever the
+/// cable comes and goes. A timer here would burn wakeups during exactly
+/// the long unattended streams this readout exists for
+/// (docs/PERFORMANCE.md: no extra threads or timers).
+///
+/// Monitoring is refcounted rather than left on for the app's life: it is
+/// a device-wide flag, and only the Live screen has anything to show.
+@MainActor
+final class BatteryMonitor: ObservableObject {
+    static let shared = BatteryMonitor()
+
+    /// 0–100, or nil when iOS won't say (Simulator, or monitoring off).
+    @Published private(set) var percent: Int?
+    @Published private(set) var isCharging = false
+    @Published private(set) var lowPowerMode = ProcessInfo.processInfo
+        .isLowPowerModeEnabled
+
+    /// Below this, the phone is "low" even without Low Power Mode — iOS
+    /// offers its own prompt at the same 20%, so the two agree in the
+    /// common case and this still fires for someone who declined it.
+    private static let lowPercent = 20
+
+    /// The condition the tally light and the readout's colour both key
+    /// off. Charging clears it: a phone on a cable is not a problem to
+    /// warn about, however empty it is right now.
+    var isLow: Bool {
+        guard !isCharging else { return false }
+        return lowPowerMode || (percent.map { $0 <= Self.lowPercent } ?? false)
+    }
+
+    private var observers: [NSObjectProtocol] = []
+    private var users = 0
+
+    private init() {}
+
+    /// Starts monitoring for one screen; balance with `release()`.
+    func retain() {
+        users += 1
+        guard users == 1 else { return }
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        read()
+        let center = NotificationCenter.default
+        for name: NSNotification.Name in [
+            UIDevice.batteryLevelDidChangeNotification,
+            UIDevice.batteryStateDidChangeNotification,
+            .NSProcessInfoPowerStateDidChange,
+        ] {
+            observers.append(center.addObserver(
+                forName: name, object: nil, queue: .main) { [weak self] _ in
+                // The notifications are posted on the main queue, but
+                // `self` is main-actor isolated and the closure isn't, so
+                // hop explicitly rather than assert.
+                Task { @MainActor [weak self] in self?.read() }
+            })
+        }
+    }
+
+    func release() {
+        users = max(0, users - 1)
+        guard users == 0 else { return }
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+        UIDevice.current.isBatteryMonitoringEnabled = false
+    }
+
+    private func read() {
+        let device = UIDevice.current
+        // -1 means unknown; a percentage of "-100%" would be worse than
+        // showing nothing at all.
+        percent = device.batteryLevel < 0
+            ? nil : Int((device.batteryLevel * 100).rounded())
+        isCharging = device.batteryState == .charging
+            || device.batteryState == .full
+        lowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+    }
+}

--- a/ios-app/Sources/BatteryMonitor.swift
+++ b/ios-app/Sources/BatteryMonitor.swift
@@ -13,7 +13,11 @@ import UIKit
 ///
 /// Monitoring is refcounted rather than left on for the app's life: it is
 /// a device-wide flag, and only the Live screen has anything to show.
-@MainActor
+///
+/// Not @MainActor, for the same reason as `TallySettings`: it is reached
+/// from a view property initializer, which isn't isolated. Every mutation
+/// still happens on the main queue — the observers below are registered
+/// with `queue: .main` and nothing else writes.
 final class BatteryMonitor: ObservableObject {
     static let shared = BatteryMonitor()
 
@@ -53,12 +57,11 @@ final class BatteryMonitor: ObservableObject {
             UIDevice.batteryStateDidChangeNotification,
             .NSProcessInfoPowerStateDidChange,
         ] {
+            // queue: .main is what keeps the @Published writes on the
+            // main queue — battery notifications are not posted there.
             observers.append(center.addObserver(
                 forName: name, object: nil, queue: .main) { [weak self] _ in
-                // The notifications are posted on the main queue, but
-                // `self` is main-actor isolated and the closure isn't, so
-                // hop explicitly rather than assert.
-                Task { @MainActor [weak self] in self?.read() }
+                self?.read()
             })
         }
     }

--- a/ios-app/Sources/CameraPreset.swift
+++ b/ios-app/Sources/CameraPreset.swift
@@ -1,0 +1,151 @@
+import Foundation
+import SwiftUI
+
+/// A saved set of camera looks — the manual exposure, white balance, zoom
+/// and focus values that someone shooting in the same room under the same
+/// lights re-dials every single session (#107).
+///
+/// Every group is optional and `nil` means *not included*: a preset that
+/// carries only white balance leaves your exposure exactly where it is
+/// wherever it applies. That is the "choose which settings are included"
+/// half of the feature, and it is why these are optionals rather than a
+/// flat struct with `include` flags — a value that isn't included can't be
+/// stored, so it can't be applied by mistake.
+struct CameraPreset: Codable, Identifiable, Equatable {
+    var id = UUID()
+    var name: String
+
+    /// AE bias, or the full manual triple. Stored together because
+    /// applying an ISO without saying whether the camera is in manual
+    /// exposure is meaningless.
+    struct Exposure: Codable, Equatable {
+        var manual: Bool
+        var bias: Float
+        var iso: Float
+        var shutterSeconds: Double
+    }
+    struct WhiteBalance: Codable, Equatable {
+        var locked: Bool
+        var temperature: Float
+    }
+    struct Focus: Codable, Equatable {
+        var locked: Bool
+        var lensPosition: Float
+    }
+
+    var exposure: Exposure? = nil
+    var whiteBalance: WhiteBalance? = nil
+    var zoom: Double? = nil
+    var focus: Focus? = nil
+
+    /// `CameraManager.Lens.id` this preset belongs to, applied whenever
+    /// that camera comes up. nil = applies to no camera on its own (still
+    /// usable as the default, or by hand).
+    var lensID: String? = nil
+
+    /// A preset holding nothing would apply nothing — refuse to save one
+    /// rather than leave a row that does nothing when tapped.
+    var isEmpty: Bool {
+        exposure == nil && whiteBalance == nil && zoom == nil && focus == nil
+    }
+
+    /// One line naming what this preset carries, for the list row.
+    var summary: String {
+        var parts: [String] = []
+        if let exposure {
+            parts.append(exposure.manual ? "Manual exposure" : "Auto exposure")
+        }
+        if whiteBalance != nil { parts.append("White balance") }
+        if zoom != nil { parts.append("Zoom") }
+        if focus != nil { parts.append("Focus") }
+        return parts.isEmpty ? "Nothing saved" : parts.joined(separator: " · ")
+    }
+}
+
+/// Stores the presets, which one is the default, and whether presets are
+/// allowed to apply themselves at all.
+///
+/// Same shape as `TallySettings`: a JSON blob in `UserDefaults`, not
+/// @MainActor so view property initializers can reach it.
+final class PresetManager: ObservableObject {
+    static let shared = PresetManager()
+
+    private static let presetsKey = "cameraPresets"
+    private static let defaultKey = "defaultPresetID"
+    private static let autoApplyKey = "presetsAutoApply"
+
+    @Published var presets: [CameraPreset] {
+        didSet { save() }
+    }
+
+    /// The preset applied at stream start for a camera that has none of
+    /// its own. Held here rather than as an `isDefault` flag on each
+    /// preset so "two defaults" is unrepresentable.
+    @Published var defaultPresetID: UUID? {
+        didSet {
+            UserDefaults.standard.set(defaultPresetID?.uuidString,
+                                      forKey: Self.defaultKey)
+        }
+    }
+
+    /// The master switch (Options → Presets). Off means nothing applies
+    /// itself; presets can still be applied by hand from the list.
+    @Published var autoApplyEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(autoApplyEnabled,
+                                      forKey: Self.autoApplyKey)
+        }
+    }
+
+    private init() {
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: Self.presetsKey),
+           let saved = try? JSONDecoder().decode([CameraPreset].self,
+                                                 from: data) {
+            presets = saved
+        } else {
+            presets = []
+        }
+        defaultPresetID = defaults.string(forKey: Self.defaultKey)
+            .flatMap(UUID.init(uuidString:))
+        autoApplyEnabled = defaults.object(forKey: Self.autoApplyKey)
+            as? Bool ?? true
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(presets) {
+            UserDefaults.standard.set(data, forKey: Self.presetsKey)
+        }
+        // A deleted preset must not stay the default: the id would dangle
+        // and stream start would silently apply nothing.
+        if let id = defaultPresetID, !presets.contains(where: { $0.id == id }) {
+            defaultPresetID = nil
+        }
+    }
+
+    var defaultPreset: CameraPreset? {
+        presets.first { $0.id == defaultPresetID }
+    }
+
+    /// What should apply when this camera comes up: the camera's own
+    /// preset, or the default when it has none.
+    func preset(forLens lensID: String) -> CameraPreset? {
+        presets.first { $0.lensID == lensID } ?? defaultPreset
+    }
+
+    /// Assigning a camera takes it off whichever preset had it — one
+    /// camera can't auto-apply two presets, and the last edit wins.
+    func upsert(_ preset: CameraPreset) {
+        if let lens = preset.lensID {
+            for index in presets.indices
+            where presets[index].lensID == lens && presets[index].id != preset.id {
+                presets[index].lensID = nil
+            }
+        }
+        if let index = presets.firstIndex(where: { $0.id == preset.id }) {
+            presets[index] = preset
+        } else {
+            presets.append(preset)
+        }
+    }
+}

--- a/ios-app/Sources/DocumentationView.swift
+++ b/ios-app/Sources/DocumentationView.swift
@@ -53,7 +53,8 @@ struct DocumentationView: View {
             }
 
             Section {
-                Text("The colored border around the Live screen while streaming. Colors, priority order, and per-status off switches are customizable in Options → Tally light.")
+                Text("The colored border around the Live screen while streaming. Colors, priority order, and per-status off switches are customizable in Options → Tally light, and any status can pulse instead of holding steady.")
+                Text("**Low battery** is one of the statuses you can light: it turns on with iOS Low Power Mode, or at 20% and below, and clears the moment you plug in. While the screen is dimmed the battery level also shows as a percentage under the wake hint — so a phone across the room can be checked without touching it.")
             } header: {
                 Text("Tally light")
             }

--- a/ios-app/Sources/DocumentationView.swift
+++ b/ios-app/Sources/DocumentationView.swift
@@ -54,14 +54,14 @@ struct DocumentationView: View {
 
             Section {
                 Text("A **preset** saves the camera settings you re-dial every session — exposure, white balance, zoom, focus — and you choose which of those it carries. Everything it leaves out stays where it is.")
-                Text("Give a preset a **camera** and it applies whenever that camera starts; mark one as the **default** and it covers any camera without its own. Options → Presets, where you can also apply one by hand.")
+                Text("Give a preset a **camera** and it applies whenever that camera starts; mark one as the **default** and it covers any camera without its own. Options → Presets.")
                 Text("Changing any of those settings by hand pauses automatic presets, so one can never overwrite an adjustment you just made — a **Presets paused** pill appears on the Live screen, and tapping it resumes and re-applies without stopping the stream.")
             } header: {
                 Text("Presets")
             }
 
             Section {
-                Text("The colored border around the Live screen while streaming. Colors, priority order, and per-status off switches are customizable in Options → Tally light, and any status can pulse instead of holding steady.")
+                Text("The colored border around the Live screen while streaming. Colors, priority order, and per-status off switches are customizable in Options → Tally light. The wave button beside a color makes that status pulse instead of holding steady — motion catches the eye for something you're meant to notice without watching for it.")
                 Text("**Low battery** is one of the statuses you can light: it turns on with iOS Low Power Mode, or at 20% and below, and clears the moment you plug in. While the screen is dimmed the battery level also shows as a percentage under the wake hint — so a phone across the room can be checked without touching it.")
             } header: {
                 Text("Tally light")

--- a/ios-app/Sources/DocumentationView.swift
+++ b/ios-app/Sources/DocumentationView.swift
@@ -53,6 +53,14 @@ struct DocumentationView: View {
             }
 
             Section {
+                Text("A **preset** saves the camera settings you re-dial every session — exposure, white balance, zoom, focus — and you choose which of those it carries. Everything it leaves out stays where it is.")
+                Text("Give a preset a **camera** and it applies whenever that camera starts; mark one as the **default** and it covers any camera without its own. Options → Presets, where you can also apply one by hand.")
+                Text("Changing any of those settings by hand pauses automatic presets, so one can never overwrite an adjustment you just made — a **Presets paused** pill appears on the Live screen, and tapping it resumes and re-applies without stopping the stream.")
+            } header: {
+                Text("Presets")
+            }
+
+            Section {
                 Text("The colored border around the Live screen while streaming. Colors, priority order, and per-status off switches are customizable in Options → Tally light, and any status can pulse instead of holding steady.")
                 Text("**Low battery** is one of the statuses you can light: it turns on with iOS Low Power Mode, or at 20% and below, and clears the moment you plug in. While the screen is dimmed the battery level also shows as a percentage under the wake hint — so a phone across the room can be checked without touching it.")
             } header: {

--- a/ios-app/Sources/OptionsView.swift
+++ b/ios-app/Sources/OptionsView.swift
@@ -36,6 +36,9 @@ struct OptionsView: View {
                     NavigationLink(destination: TallyLightOptionsView()) {
                         Text("Tally light")
                     }
+                    NavigationLink(destination: PresetsView()) {
+                        Text("Presets")
+                    }
                 }
 
                 Section {

--- a/ios-app/Sources/PresetsView.swift
+++ b/ios-app/Sources/PresetsView.swift
@@ -13,8 +13,6 @@ struct PresetsView: View {
             Section {
                 Toggle("Apply presets automatically",
                        isOn: $manager.autoApplyEnabled)
-            } footer: {
-                Text("A preset applies when its camera starts, and the default applies to any camera without one. Changing a setting by hand pauses this until you resume it from the Live screen.")
             }
 
             Section {
@@ -36,26 +34,11 @@ struct PresetsView: View {
                 }
 
                 Button("New preset") {
-                    editing = CameraPreset(name: "", lensID: streamer.selectedLens.id)
+                    editing = CameraPreset(name: "",
+                                           lensID: streamer.selectedLens.id)
                 }
             } header: {
                 Text("Presets")
-            }
-
-            if !manager.presets.isEmpty {
-                Section {
-                    // Applying by hand works whatever the master switch
-                    // says — it is an explicit act, not an automatic one.
-                    ForEach(manager.presets) { preset in
-                        Button("Apply \(preset.name)") {
-                            streamer.apply(preset)
-                        }
-                    }
-                } header: {
-                    Text("Apply now")
-                } footer: {
-                    Text("Applies to the running camera immediately.")
-                }
             }
         }
         .navigationTitle("Presets")
@@ -67,14 +50,14 @@ struct PresetsView: View {
     }
 
     private func row(_ preset: CameraPreset) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: Theme.Space.xs) {
             HStack {
                 Text(preset.name)
                 if preset.id == manager.defaultPresetID {
                     Text("Default")
-                        .font(.caption2)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .font(.caption)
+                        .padding(.horizontal, Theme.Space.s)
+                        .padding(.vertical, Theme.Space.xs)
                         .background(Theme.accent.opacity(0.2), in: Capsule())
                 }
             }
@@ -129,23 +112,23 @@ struct PresetEditorView: View {
                 Section {
                     Toggle("Exposure", isOn: exposureIncluded)
                     if let exposure = draft.exposure {
-                        Picker("Mode", selection: exposureMode) {
-                            Text("Auto").tag(false)
+                        Picker("Exposure", selection: exposureMode) {
+                            Text("AE").tag(false)
                             Text("Manual").tag(true)
                         }
                         .pickerStyle(.segmented)
                         if exposure.manual {
-                            slider("ISO", value: isoBinding,
-                                   range: isoRange,
-                                   readout: "\(Int(draft.exposure?.iso ?? 0))")
-                            slider("Shutter", value: shutterBinding,
-                                   range: 0...1,
-                                   readout: shutterReadout)
+                            sliderRow("dial.min", "dial.max",
+                                      value: isoBinding, range: isoRange,
+                                      readout: "\(Int(draft.exposure?.iso ?? 0))")
+                            sliderRow("tortoise", "hare",
+                                      value: shutterBinding, range: 0...1,
+                                      readout: shutterReadout)
                         } else {
-                            slider("Bias", value: biasBinding,
-                                   range: biasRange,
-                                   readout: String(format: "%+.1f",
-                                                   exposure.bias))
+                            sliderRow("sun.min", "sun.max",
+                                      value: biasBinding, range: biasRange,
+                                      readout: String(format: "%+.1f",
+                                                      exposure.bias))
                         }
                     }
                 } header: {
@@ -155,15 +138,18 @@ struct PresetEditorView: View {
                 Section {
                     Toggle("White balance", isOn: whiteBalanceIncluded)
                     if let wb = draft.whiteBalance {
-                        Picker("Mode", selection: whiteBalanceMode) {
-                            Text("Auto").tag(false)
-                            Text("Locked").tag(true)
+                        Picker("White balance", selection: whiteBalanceMode) {
+                            Text("AWB").tag(false)
+                            Text("Lock").tag(true)
                         }
                         .pickerStyle(.segmented)
                         if wb.locked {
-                            slider("Temperature", value: temperatureBinding,
-                                   range: 2500...8000,
-                                   readout: "\(Int(wb.temperature))K")
+                            // No icons, exactly as on the Live screen:
+                            // the segmented control above names the row.
+                            sliderRow(nil, nil,
+                                      value: temperatureBinding,
+                                      range: 2500...8000,
+                                      readout: "\(Int(wb.temperature))K")
                         }
                     }
                 }
@@ -171,27 +157,31 @@ struct PresetEditorView: View {
                 Section {
                     Toggle("Zoom", isOn: zoomIncluded)
                     if draft.zoom != nil {
-                        slider("Zoom", value: zoomBinding,
-                               range: 1...max(streamer.camera.maxZoomFactor,
-                                              1.1),
-                               readout: String(format: "%.1f×",
-                                               draft.zoom ?? 1))
+                        sliderRow("minus.magnifyingglass",
+                                  "plus.magnifyingglass",
+                                  value: zoomBinding,
+                                  range: 1...max(
+                                    Double(streamer.camera.maxZoomFactor),
+                                    1.1),
+                                  readout: String(format: "%.1f×",
+                                                  draft.zoom ?? 1))
                     }
                 }
 
                 Section {
                     Toggle("Focus", isOn: focusIncluded)
                     if let focus = draft.focus {
-                        Picker("Mode", selection: focusMode) {
-                            Text("Auto").tag(false)
-                            Text("Locked").tag(true)
+                        Picker("Focus", selection: focusMode) {
+                            Text("AF").tag(false)
+                            Text("Lock").tag(true)
                         }
                         .pickerStyle(.segmented)
                         if focus.locked {
-                            slider("Position", value: lensPositionBinding,
-                                   range: 0...1,
-                                   readout: String(format: "%.2f",
-                                                   focus.lensPosition))
+                            sliderRow(nil, nil,
+                                      value: lensPositionBinding,
+                                      range: 0...1,
+                                      readout: String(format: "%.2f",
+                                                      focus.lensPosition))
                         }
                     }
                 }
@@ -362,20 +352,27 @@ struct PresetEditorView: View {
         return Double(range.lowerBound)...Double(range.upperBound)
     }
 
-    /// Form-shaped slider row: label, slider, monospaced readout — the
-    /// Live screen's anatomy (docs/UI_DESIGN.md §4) minus the icons,
-    /// which have no room in a Form row.
-    private func slider(_ label: String, value: Binding<Double>,
-                        range: ClosedRange<Double>,
-                        readout: String) -> some View {
-        HStack {
-            Text(label)
-                .frame(width: 92, alignment: .leading)
+    /// The product's slider row (docs/UI_DESIGN.md §4): leading icon ·
+    /// slider · trailing icon · monospaced readout in a fixed 44 pt
+    /// column. Same icons as the Live screen's rows, so a preset's
+    /// exposure looks like the exposure you set live — the icons are
+    /// dropped for white balance and focus, which have none there either.
+    private func sliderRow(_ minIcon: String?, _ maxIcon: String?,
+                           value: Binding<Double>,
+                           range: ClosedRange<Double>,
+                           readout: String) -> some View {
+        HStack(spacing: Theme.Space.m) {
+            if let minIcon {
+                Image(systemName: minIcon).foregroundColor(.secondary)
+            }
             Slider(value: value, in: range)
+            if let maxIcon {
+                Image(systemName: maxIcon).foregroundColor(.secondary)
+            }
             Text(readout)
                 .font(.caption.monospacedDigit())
                 .foregroundColor(.secondary)
-                .frame(width: 56, alignment: .trailing)
+                .frame(width: 44, alignment: .trailing)
         }
     }
 }

--- a/ios-app/Sources/PresetsView.swift
+++ b/ios-app/Sources/PresetsView.swift
@@ -1,0 +1,381 @@
+import SwiftUI
+
+/// Options → Presets: the saved camera looks, which camera each one comes
+/// up on, and the master switch for applying them automatically (#107).
+struct PresetsView: View {
+    @EnvironmentObject private var streamer: Streamer
+    @ObservedObject private var manager = PresetManager.shared
+
+    @State private var editing: CameraPreset?
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Apply presets automatically",
+                       isOn: $manager.autoApplyEnabled)
+            } footer: {
+                Text("A preset applies when its camera starts, and the default applies to any camera without one. Changing a setting by hand pauses this until you resume it from the Live screen.")
+            }
+
+            Section {
+                if manager.presets.isEmpty {
+                    Text("No presets yet")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(manager.presets) { preset in
+                        Button {
+                            editing = preset
+                        } label: {
+                            row(preset)
+                        }
+                        .foregroundColor(.primary)
+                    }
+                    .onDelete { offsets in
+                        manager.presets.remove(atOffsets: offsets)
+                    }
+                }
+
+                Button("New preset") {
+                    editing = CameraPreset(name: "", lensID: streamer.selectedLens.id)
+                }
+            } header: {
+                Text("Presets")
+            }
+
+            if !manager.presets.isEmpty {
+                Section {
+                    // Applying by hand works whatever the master switch
+                    // says — it is an explicit act, not an automatic one.
+                    ForEach(manager.presets) { preset in
+                        Button("Apply \(preset.name)") {
+                            streamer.apply(preset)
+                        }
+                    }
+                } header: {
+                    Text("Apply now")
+                } footer: {
+                    Text("Applies to the running camera immediately.")
+                }
+            }
+        }
+        .navigationTitle("Presets")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $editing) { preset in
+            PresetEditorView(preset: preset)
+                .environmentObject(streamer)
+        }
+    }
+
+    private func row(_ preset: CameraPreset) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(preset.name)
+                if preset.id == manager.defaultPresetID {
+                    Text("Default")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Theme.accent.opacity(0.2), in: Capsule())
+                }
+            }
+            Text(subtitle(preset))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func subtitle(_ preset: CameraPreset) -> String {
+        guard let lensID = preset.lensID,
+              let lens = streamer.availableLenses.first(where: {
+                  $0.id == lensID
+              }) else {
+            return preset.summary
+        }
+        return "\(lens.label) · \(preset.summary)"
+    }
+}
+
+/// Create or edit one preset: its name, which groups of settings it
+/// carries, the values themselves, and the camera it comes up on.
+///
+/// The values are editable here rather than only captured from the live
+/// camera, because Options is reachable only from the Setup screen — you
+/// cannot be looking at the Live screen's sliders and this form at the
+/// same time. **Fill from current settings** covers the other direction:
+/// dial the look in on the Live screen, stop, and copy it in (stopping a
+/// stream doesn't reset the camera values).
+struct PresetEditorView: View {
+    @EnvironmentObject private var streamer: Streamer
+    @ObservedObject private var manager = PresetManager.shared
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: CameraPreset
+    @State private var isDefault: Bool
+
+    init(preset: CameraPreset) {
+        _draft = State(initialValue: preset)
+        _isDefault = State(
+            initialValue: preset.id == PresetManager.shared.defaultPresetID)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    TextField("Name", text: $draft.name)
+                    Button("Fill from current settings") { fillFromCurrent() }
+                }
+
+                Section {
+                    Toggle("Exposure", isOn: exposureIncluded)
+                    if let exposure = draft.exposure {
+                        Picker("Mode", selection: exposureMode) {
+                            Text("Auto").tag(false)
+                            Text("Manual").tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        if exposure.manual {
+                            slider("ISO", value: isoBinding,
+                                   range: isoRange,
+                                   readout: "\(Int(draft.exposure?.iso ?? 0))")
+                            slider("Shutter", value: shutterBinding,
+                                   range: 0...1,
+                                   readout: shutterReadout)
+                        } else {
+                            slider("Bias", value: biasBinding,
+                                   range: biasRange,
+                                   readout: String(format: "%+.1f",
+                                                   exposure.bias))
+                        }
+                    }
+                } header: {
+                    Text("Included settings")
+                }
+
+                Section {
+                    Toggle("White balance", isOn: whiteBalanceIncluded)
+                    if let wb = draft.whiteBalance {
+                        Picker("Mode", selection: whiteBalanceMode) {
+                            Text("Auto").tag(false)
+                            Text("Locked").tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        if wb.locked {
+                            slider("Temperature", value: temperatureBinding,
+                                   range: 2500...8000,
+                                   readout: "\(Int(wb.temperature))K")
+                        }
+                    }
+                }
+
+                Section {
+                    Toggle("Zoom", isOn: zoomIncluded)
+                    if draft.zoom != nil {
+                        slider("Zoom", value: zoomBinding,
+                               range: 1...max(streamer.camera.maxZoomFactor,
+                                              1.1),
+                               readout: String(format: "%.1f×",
+                                               draft.zoom ?? 1))
+                    }
+                }
+
+                Section {
+                    Toggle("Focus", isOn: focusIncluded)
+                    if let focus = draft.focus {
+                        Picker("Mode", selection: focusMode) {
+                            Text("Auto").tag(false)
+                            Text("Locked").tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        if focus.locked {
+                            slider("Position", value: lensPositionBinding,
+                                   range: 0...1,
+                                   readout: String(format: "%.2f",
+                                                   focus.lensPosition))
+                        }
+                    }
+                }
+
+                Section {
+                    Picker("Camera", selection: lensBinding) {
+                        Text("None").tag("")
+                        ForEach(streamer.availableLenses) { lens in
+                            Text(lens.label).tag(lens.id)
+                        }
+                    }
+                    Toggle("Use as default", isOn: $isDefault)
+                } header: {
+                    Text("Applies to")
+                }
+            }
+            .navigationTitle(draft.name.isEmpty ? "New preset" : draft.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        // A nameless preset can't be told apart in the
+                        // list, and an empty one would apply nothing.
+                        .disabled(trimmedName.isEmpty || draft.isEmpty)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .tint(Theme.accent)
+    }
+
+    private var trimmedName: String {
+        draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func save() {
+        draft.name = trimmedName
+        manager.upsert(draft)
+        if isDefault {
+            manager.defaultPresetID = draft.id
+        } else if manager.defaultPresetID == draft.id {
+            manager.defaultPresetID = nil
+        }
+        dismiss()
+    }
+
+    private func fillFromCurrent() {
+        let current = streamer.currentPresetValues()
+        // Only the groups already included are overwritten: "fill" means
+        // fill what this preset carries, not turn everything on.
+        if draft.exposure != nil { draft.exposure = current.exposure }
+        if draft.whiteBalance != nil { draft.whiteBalance = current.whiteBalance }
+        if draft.zoom != nil { draft.zoom = current.zoom }
+        if draft.focus != nil { draft.focus = current.focus }
+        // A brand-new preset has nothing on yet, so fill would do nothing
+        // and read as broken — take everything instead.
+        if draft.isEmpty {
+            draft.exposure = current.exposure
+            draft.whiteBalance = current.whiteBalance
+            draft.zoom = current.zoom
+            draft.focus = current.focus
+        }
+    }
+
+    // MARK: - Bindings
+    //
+    // Each group's toggle turns its optional on with the camera's current
+    // values (so a freshly included group is never a meaningless zero) and
+    // off by clearing it, which is what "not included" means on the wire.
+
+    private var exposureIncluded: Binding<Bool> {
+        Binding(get: { draft.exposure != nil },
+                set: { draft.exposure = $0
+                        ? streamer.currentPresetValues().exposure : nil })
+    }
+    private var whiteBalanceIncluded: Binding<Bool> {
+        Binding(get: { draft.whiteBalance != nil },
+                set: { draft.whiteBalance = $0
+                        ? streamer.currentPresetValues().whiteBalance : nil })
+    }
+    private var zoomIncluded: Binding<Bool> {
+        Binding(get: { draft.zoom != nil },
+                set: { draft.zoom = $0
+                        ? streamer.currentPresetValues().zoom : nil })
+    }
+    private var focusIncluded: Binding<Bool> {
+        Binding(get: { draft.focus != nil },
+                set: { draft.focus = $0
+                        ? streamer.currentPresetValues().focus : nil })
+    }
+
+    private var exposureMode: Binding<Bool> {
+        Binding(get: { draft.exposure?.manual ?? false },
+                set: { draft.exposure?.manual = $0 })
+    }
+    private var whiteBalanceMode: Binding<Bool> {
+        Binding(get: { draft.whiteBalance?.locked ?? false },
+                set: { draft.whiteBalance?.locked = $0 })
+    }
+    private var focusMode: Binding<Bool> {
+        Binding(get: { draft.focus?.locked ?? false },
+                set: { draft.focus?.locked = $0 })
+    }
+
+    private var isoBinding: Binding<Double> {
+        Binding(get: { Double(draft.exposure?.iso ?? 0) },
+                set: { draft.exposure?.iso = Float($0) })
+    }
+    private var biasBinding: Binding<Double> {
+        Binding(get: { Double(draft.exposure?.bias ?? 0) },
+                set: { draft.exposure?.bias = Float($0) })
+    }
+    private var temperatureBinding: Binding<Double> {
+        Binding(get: { Double(draft.whiteBalance?.temperature ?? 5000) },
+                set: { draft.whiteBalance?.temperature = Float($0) })
+    }
+    private var zoomBinding: Binding<Double> {
+        Binding(get: { draft.zoom ?? 1 }, set: { draft.zoom = $0 })
+    }
+    private var lensPositionBinding: Binding<Double> {
+        Binding(get: { Double(draft.focus?.lensPosition ?? 0.5) },
+                set: { draft.focus?.lensPosition = Float($0) })
+    }
+    private var lensBinding: Binding<String> {
+        Binding(get: { draft.lensID ?? "" },
+                set: { draft.lensID = $0.isEmpty ? nil : $0 })
+    }
+
+    /// Log scale, matching the Live screen's shutter row: shutter steps
+    /// are multiplicative, and a linear slider crams everything usable
+    /// into its first pixels.
+    private var shutterBinding: Binding<Double> {
+        let minSeconds = max(streamer.camera.minShutterSeconds, 1.0 / 8000)
+        let maxSeconds = max(
+            streamer.camera.maxShutterSeconds(fps: Int32(streamer.fps)),
+            minSeconds * 2)
+        let logMin = log(minSeconds)
+        let logMax = log(maxSeconds)
+        return Binding(
+            get: {
+                let seconds = min(max(draft.exposure?.shutterSeconds
+                                        ?? minSeconds, minSeconds),
+                                  maxSeconds)
+                return 1 - (log(seconds) - logMin) / (logMax - logMin)
+            },
+            set: { position in
+                draft.exposure?.shutterSeconds =
+                    exp(logMax - position * (logMax - logMin))
+            })
+    }
+
+    private var shutterReadout: String {
+        let seconds = draft.exposure?.shutterSeconds ?? 0
+        guard seconds > 0 else { return "—" }
+        guard seconds < 1 else { return String(format: "%.0fs", seconds) }
+        return "1/\(Int((1 / seconds).rounded()))"
+    }
+
+    private var isoRange: ClosedRange<Double> {
+        let range = streamer.camera.isoRange
+        return Double(range.lowerBound)...Double(range.upperBound)
+    }
+    private var biasRange: ClosedRange<Double> {
+        let range = streamer.camera.exposureBiasRange
+        return Double(range.lowerBound)...Double(range.upperBound)
+    }
+
+    /// Form-shaped slider row: label, slider, monospaced readout — the
+    /// Live screen's anatomy (docs/UI_DESIGN.md §4) minus the icons,
+    /// which have no room in a Form row.
+    private func slider(_ label: String, value: Binding<Double>,
+                        range: ClosedRange<Double>,
+                        readout: String) -> some View {
+        HStack {
+            Text(label)
+                .frame(width: 92, alignment: .leading)
+            Slider(value: value, in: range)
+            Text(readout)
+                .font(.caption.monospacedDigit())
+                .foregroundColor(.secondary)
+                .frame(width: 56, alignment: .trailing)
+        }
+    }
+}

--- a/ios-app/Sources/Streamer.swift
+++ b/ios-app/Sources/Streamer.swift
@@ -163,6 +163,12 @@ final class Streamer: ObservableObject {
             wireCameraToEncoder(encoder, color: color)
         }
 
+        // Re-dress the camera: this path runs for a lens switch (the
+        // "launch the front camera and it comes up configured" case) and
+        // for any live format/colour change, all of which have just reset
+        // the controls above. The preset overrides that reset.
+        autoApplyPreset()
+
         encoder?.requestKeyframe()
         scheduleStateSend()
     }
@@ -457,12 +463,14 @@ final class Streamer: ObservableObject {
     @Published var zoom: CGFloat = 1 {
         didSet {
             camera.setZoom(zoom)
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
     @Published var exposureBias: Float = 0 {
         didSet {
             camera.setExposureBias(exposureBias)
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
@@ -473,12 +481,14 @@ final class Streamer: ObservableObject {
     @Published var focusSetting: FocusSetting = .auto {
         didSet {
             applyFocus()
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
     @Published var lensPosition: Float = 0.5 {
         didSet {
             if focusSetting == .locked { applyFocus() }
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
@@ -495,6 +505,7 @@ final class Streamer: ObservableObject {
     @Published var whiteBalanceSetting: WhiteBalanceSetting = .auto {
         didSet {
             applyWhiteBalance()
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
@@ -502,6 +513,7 @@ final class Streamer: ObservableObject {
     @Published var whiteBalanceTemperature: Float = 5000 {
         didSet {
             if whiteBalanceSetting == .locked { applyWhiteBalance() }
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
@@ -512,20 +524,121 @@ final class Streamer: ObservableObject {
     @Published var exposureSetting: ExposureSetting = .auto {
         didSet {
             applyExposure()
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
     @Published var iso: Float = 200 {
         didSet {
             if exposureSetting == .manual { applyExposure() }
+            noteManualCameraChange()
             scheduleStateSend()
         }
     }
     @Published var shutterSeconds: Double = 1.0 / 60 {
         didSet {
             if exposureSetting == .manual { applyExposure() }
+            noteManualCameraChange()
             scheduleStateSend()
         }
+    }
+
+    // MARK: - Camera presets (#107)
+
+    /// Auto-apply is on hold because a setting was changed by hand — from
+    /// the Live screen or a remote CONTROL command, which reach the same
+    /// properties and are the same intent: whoever just dialled this in
+    /// meant it, and a preset must not overwrite it a moment later.
+    /// Runtime-only: a fresh launch starts armed. Turning the feature off
+    /// entirely is the persisted switch in PresetManager.
+    @Published private(set) var presetsPaused = false
+
+    /// Depth counter, not a Bool: applying a preset writes several
+    /// properties, and `resetCameraControls` can run inside that. A Bool
+    /// would be cleared by the inner scope while the outer one still has
+    /// writes to make, and those writes would disarm presets.
+    private var presetWritesInFlight = 0
+
+    /// Called from every preset-covered control's didSet.
+    private func noteManualCameraChange() {
+        guard presetWritesInFlight == 0,
+              PresetManager.shared.autoApplyEnabled else { return }
+        presetsPaused = true
+    }
+
+    /// Writes a preset's values onto the camera. Only the groups it
+    /// carries are touched — everything else keeps whatever it had.
+    func apply(_ preset: CameraPreset) {
+        presetWritesInFlight += 1
+        defer { presetWritesInFlight -= 1 }
+
+        if let exposure = preset.exposure {
+            // Values before the mode: the mode's didSet is what pushes
+            // them to the device, so setting it last applies the pair in
+            // one go instead of briefly running the old ISO.
+            exposureBias = exposure.bias
+            iso = exposure.iso
+            shutterSeconds = exposure.shutterSeconds
+            exposureSetting = exposure.manual ? .manual : .auto
+        }
+        if let whiteBalance = preset.whiteBalance {
+            whiteBalanceTemperature = whiteBalance.temperature
+            whiteBalanceSetting = whiteBalance.locked ? .locked : .auto
+        }
+        if let zoomValue = preset.zoom {
+            zoom = min(max(CGFloat(zoomValue), 1), camera.maxZoomFactor)
+        }
+        if let focus = preset.focus {
+            lensPosition = focus.lensPosition
+            focusSetting = focus.locked ? .locked : .auto
+        }
+        scheduleStateSend()
+    }
+
+    /// Applies whatever the current camera should be wearing — its own
+    /// preset, or the default. Called at stream start and after a live
+    /// lens switch; silent when auto-apply is off, paused, or nothing
+    /// matches.
+    private func autoApplyPreset() {
+        let manager = PresetManager.shared
+        guard manager.autoApplyEnabled, !presetsPaused,
+              let preset = manager.preset(forLens: selectedLens.id) else {
+            return
+        }
+        apply(preset)
+    }
+
+    /// Re-arms auto-apply after a manual change put it on hold, and
+    /// applies the matching preset straight away so the tap does
+    /// something visible. Mid-stream, no restart — this is what the
+    /// "Presets paused" pill on the Live screen calls.
+    func resumePresets() {
+        presetsPaused = false
+        autoApplyPreset()
+    }
+
+    /// Whether the Live screen should offer the resume pill: only where
+    /// re-arming would actually do something.
+    var canResumePresets: Bool {
+        let manager = PresetManager.shared
+        return presetsPaused && manager.autoApplyEnabled
+            && manager.preset(forLens: selectedLens.id) != nil
+    }
+
+    /// The current camera values, for "save these as a preset".
+    func currentPresetValues() -> (exposure: CameraPreset.Exposure,
+                                   whiteBalance: CameraPreset.WhiteBalance,
+                                   zoom: Double,
+                                   focus: CameraPreset.Focus) {
+        (CameraPreset.Exposure(manual: exposureSetting == .manual,
+                               bias: exposureBias,
+                               iso: iso,
+                               shutterSeconds: shutterSeconds),
+         CameraPreset.WhiteBalance(locked: whiteBalanceSetting == .locked,
+                                   temperature: whiteBalanceTemperature),
+         Double(zoom),
+         CameraPreset.Focus(locked: focusSetting == .locked,
+                            lensPosition: lensPosition))
     }
 
     private func applyWhiteBalance() {
@@ -700,6 +813,11 @@ final class Streamer: ObservableObject {
     }
 
     private func resetCameraControls() {
+        // Not a manual change: this is the app rebuilding the camera, and
+        // letting it trip the pause would disarm presets on every lens
+        // switch — including the switch that is about to apply one.
+        presetWritesInFlight += 1
+        defer { presetWritesInFlight -= 1 }
         zoom = 1
         exposureBias = 0
         focusSetting = .auto
@@ -1260,6 +1378,10 @@ final class Streamer: ObservableObject {
 
         camera.start()
         resetCameraControls()
+        // Fresh stream, fresh arming: whatever was dialled in by hand last
+        // session shouldn't keep presets on hold forever.
+        presetsPaused = false
+        autoApplyPreset()
         healthDroppedBaseline = client.statsSnapshot().framesDropped
         startAdaptiveBitrate(target: resolution.bitrate(for: activeCodec,
                                                         color: encoder.color))

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -223,8 +223,20 @@ struct StreamingView: View {
                         .font(.caption2)
                 }
             }
-            .foregroundColor(battery.isLow ? Theme.errorRed : .gray)
+            .foregroundColor(batteryTint)
         }
+    }
+
+    /// Red means low, amber means the OS is throttling, grey means fine —
+    /// the palette's own reading of each (docs/UI_DESIGN.md §2). Splitting
+    /// them matters: Low Power Mode can be switched on at 80%, and a red
+    /// readout there would be a lie you learn to ignore.
+    private var batteryTint: Color {
+        guard !battery.isCharging else { return .gray }
+        if let percent = battery.percent, percent <= 20 {
+            return Theme.errorRed
+        }
+        return battery.lowPowerMode ? Theme.connectAmber : .gray
     }
 
     /// The system battery glyph nearest the real level, so the icon reads

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -23,6 +23,9 @@ struct StreamingView: View {
     /// turns it on is debugging and wants it next stream too. The streamer
     /// reads the same key to decide whether to sample health at all.
     @AppStorage(StreamerDefaults.showHealth) private var showHealth = false
+    /// Battery level for the dim readout and the low-battery tally.
+    /// Monitoring runs only while this screen is up (see .task below).
+    @ObservedObject private var battery = BatteryMonitor.shared
 
     private static let idleAfterSeconds: TimeInterval = 10
 
@@ -127,7 +130,11 @@ struct StreamingView: View {
         // future remote command) must not strand the screen dark or
         // control-less in a mode that no longer applies.
         .onChange(of: streamer.idleAppearance) { _ in wake() }
+        // Battery monitoring is a device-wide flag, so it is held only
+        // while this screen exists — the Setup screen has nothing to show.
+        .onAppear { battery.retain() }
         .onDisappear {
+            battery.release()
             restoreBrightness()
         }
     }
@@ -189,10 +196,44 @@ struct StreamingView: View {
                 Text("Streaming — tap to wake")
                     .font(.footnote)
                     .foregroundColor(.gray)
+                batteryReadout
             }
         }
         .contentShape(Rectangle())
         .onTapGesture { wake() }
+    }
+
+    /// "Do I need to plug this in?" answered without waking the screen —
+    /// the whole point of a phone that dims itself on a stand for an hour.
+    /// Charging shows a bolt; low (Low Power Mode, or 20% and falling)
+    /// turns it red. Monospaced digits so a 5% step doesn't shuffle the
+    /// row. Nothing renders where iOS won't report a level, rather than a
+    /// placeholder that looks like a fault.
+    @ViewBuilder private var batteryReadout: some View {
+        if let percent = battery.percent {
+            HStack(spacing: Theme.Space.xs) {
+                Image(systemName: batterySymbol(percent))
+                Text("\(percent)%")
+                    .font(.footnote.monospacedDigit())
+                if battery.isCharging {
+                    Image(systemName: "bolt.fill")
+                        .font(.caption2)
+                }
+            }
+            .foregroundColor(battery.isLow ? Theme.errorRed : .gray)
+        }
+    }
+
+    /// The system battery glyph nearest the real level, so the icon reads
+    /// at a glance from across the room even before the number does.
+    private func batterySymbol(_ percent: Int) -> String {
+        switch percent {
+        case ..<13: return "battery.0"
+        case ..<38: return "battery.25"
+        case ..<63: return "battery.50"
+        case ..<88: return "battery.75"
+        default: return "battery.100"
+        }
     }
 
     /// Tally: a border round the whole screen, readable at arm's length
@@ -228,6 +269,13 @@ struct StreamingView: View {
         case .locked: active.insert(.syncLocked)
         case .off: break
         }
+        // The stream outliving the battery is a production failure like
+        // any other, and the phone is usually out of reach when it starts
+        // going wrong — so it gets the same border vocabulary, off by
+        // default like every other informational status.
+        if battery.isLow {
+            active.insert(.lowBattery)
+        }
         return active
     }
 
@@ -236,7 +284,9 @@ struct StreamingView: View {
             // On air keeps the heaviest stroke; everything informational
             // stays lighter so live remains the most emphatic state even
             // in user-chosen colours.
-            tallyEdge(light.color, width: light.status == .onAir ? 6 : 4)
+            tallyEdge(light.color,
+                      width: light.entry.status == .onAir ? 6 : 4,
+                      pulse: light.entry.pulse)
         } else {
             EmptyView()
         }
@@ -257,16 +307,10 @@ struct StreamingView: View {
         return bottomInset > 0 ? 58 : 0
     }()
 
-    private func tallyEdge(_ colour: Color, width: CGFloat) -> some View {
-        // allowsHitTesting(false): the border sits over the preview, and
-        // tap-to-focus near the screen edge must still reach it.
-        RoundedRectangle(cornerRadius: Self.tallyCornerRadius,
-                         style: .continuous)
-            .strokeBorder(colour, lineWidth: width)
-            .ignoresSafeArea()
-            .allowsHitTesting(false)
-            .transition(.opacity)
-            .animation(.easeInOut(duration: 0.15), value: colour)
+    private func tallyEdge(_ colour: Color, width: CGFloat,
+                           pulse: Bool) -> some View {
+        TallyEdge(colour: colour, width: width, pulse: pulse,
+                  cornerRadius: Self.tallyCornerRadius)
     }
 
     private var statusBar: some View {
@@ -694,5 +738,47 @@ struct StreamingView: View {
     private func floatBinding(_ source: Binding<Float>) -> Binding<CGFloat> {
         Binding(get: { CGFloat(source.wrappedValue) },
                 set: { source.wrappedValue = Float($0) })
+    }
+}
+
+/// The tally border itself. A view of its own, not a function, because a
+/// pulse needs somewhere to keep its phase — and re-deriving that phase on
+/// every parent re-render (the Live screen redraws on any published
+/// change) would restart the animation several times a second.
+private struct TallyEdge: View {
+    let colour: Color
+    let width: CGFloat
+    let pulse: Bool
+    let cornerRadius: CGFloat
+
+    /// Honour the system's motion setting: someone who asked for less
+    /// animation gets a steady border in their chosen colour rather than
+    /// no warning at all.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var dimmedPhase = false
+
+    private var pulsing: Bool { pulse && !reduceMotion }
+
+    var body: some View {
+        // allowsHitTesting(false): the border sits over the preview, and
+        // tap-to-focus near the screen edge must still reach it.
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .strokeBorder(colour, lineWidth: width)
+            // Never all the way out: a border that vanishes on the dark
+            // half of its cycle reads as "no tally" to anyone glancing at
+            // the wrong moment.
+            .opacity(dimmedPhase ? 0.3 : 1)
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+            .transition(.opacity)
+            .animation(.easeInOut(duration: 0.15), value: colour)
+            .animation(pulsing
+                       ? .easeInOut(duration: 0.9).repeatForever(
+                            autoreverses: true)
+                       : .easeInOut(duration: 0.2),
+                       value: dimmedPhase)
+            .onAppear { dimmedPhase = pulsing }
+            .onChange(of: pulsing) { on in dimmedPhase = on }
     }
 }

--- a/ios-app/Sources/StreamingView.swift
+++ b/ios-app/Sources/StreamingView.swift
@@ -71,6 +71,9 @@ struct StreamingView: View {
                     if syncLabel != nil {
                         syncPill
                     }
+                    if streamer.canResumePresets {
+                        presetsPausedPill
+                    }
                 }
                 // Survives the clean feed when Stats is on: numbers are a
                 // readout, not a control, and the Stats button is exactly
@@ -397,6 +400,35 @@ struct StreamingView: View {
                 .foregroundColor(Theme.textSecondary)
             }
             .disabled(streamer.syncState != .locked)
+            Spacer()
+        }
+        .padding(.top, Theme.Space.s)
+    }
+
+    /// Auto-apply went on hold because a setting was changed by hand, and
+    /// this camera has a preset that would otherwise be running. Tapping
+    /// re-arms it and applies that preset now — mid-stream, no restart,
+    /// which is the whole point (#107). Same pill anatomy as the sync
+    /// row's, because it is the same kind of thing: a state you can act on.
+    private var presetsPausedPill: some View {
+        HStack {
+            Button {
+                touched()
+                streamer.resumePresets()
+            } label: {
+                HStack(spacing: Theme.Space.s) {
+                    Circle()
+                        .fill(Theme.connectAmber)
+                        .frame(width: 8, height: 8)
+                    Text("Presets paused")
+                        .font(.caption)
+                        .lineLimit(1)
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption2)
+                }
+                .glassPill()
+                .foregroundColor(Theme.textSecondary)
+            }
             Spacer()
         }
         .padding(.top, Theme.Space.s)

--- a/ios-app/Sources/TallyLightOptions.swift
+++ b/ios-app/Sources/TallyLightOptions.swift
@@ -9,6 +9,7 @@ enum TallyStatus: String, Codable, CaseIterable {
     case connectionLost
     case calibrating
     case syncLocked
+    case lowBattery
 
     var displayName: String {
         switch self {
@@ -17,6 +18,7 @@ enum TallyStatus: String, Codable, CaseIterable {
         case .connectionLost: return "Connection lost"
         case .calibrating: return "Calibrating lip-sync"
         case .syncLocked: return "Lip-sync locked"
+        case .lowBattery: return "Low battery"
         }
     }
 
@@ -96,13 +98,33 @@ enum TallyColor: String, Codable, CaseIterable {
     }
 }
 
-/// One row of the tally configuration: a status and the colour it shows.
-/// Array order IS the priority order — first matching row with a colour
-/// wins.
+/// One row of the tally configuration: a status, the colour it shows, and
+/// whether it pulses rather than holding steady. Array order IS the
+/// priority order — first matching row with a colour wins.
 struct TallyEntry: Codable, Equatable, Identifiable {
     var status: TallyStatus
     var color: TallyColor
+    /// Breathe between full and dim instead of holding solid. Motion
+    /// catches peripheral vision, which is the point for something like a
+    /// low battery you are meant to notice without watching for it.
+    var pulse: Bool = false
     var id: String { status.rawValue }
+
+    init(status: TallyStatus, color: TallyColor, pulse: Bool = false) {
+        self.status = status
+        self.color = color
+        self.pulse = pulse
+    }
+
+    /// Hand-written so a config saved before pulses existed still decodes
+    /// — the synthesized initializer treats the missing key as corruption
+    /// and would reset every row to its default.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        status = try c.decode(TallyStatus.self, forKey: .status)
+        color = try c.decode(TallyColor.self, forKey: .color)
+        pulse = try c.decodeIfPresent(Bool.self, forKey: .pulse) ?? false
+    }
 }
 
 /// Persistent tally-light configuration. The defaults reproduce the
@@ -121,6 +143,7 @@ final class TallySettings: ObservableObject {
         TallyEntry(status: .connectionLost, color: .none),
         TallyEntry(status: .calibrating, color: .none),
         TallyEntry(status: .syncLocked, color: .none),
+        TallyEntry(status: .lowBattery, color: .none),
     ]
 
     @Published var entries: [TallyEntry] {
@@ -151,14 +174,15 @@ final class TallySettings: ObservableObject {
         entries = loaded
     }
 
-    /// The border colour for the current conditions: the first (highest
-    /// priority) entry whose status is active and isn't "Off". Also
-    /// reports the winning status, for width decisions.
+    /// The border light for the current conditions: the first (highest
+    /// priority) entry whose status is active and isn't "Off". The whole
+    /// entry comes back — the caller needs its status for the stroke width
+    /// and its pulse flag for the animation.
     func activeLight(for active: Set<TallyStatus>)
-        -> (status: TallyStatus, color: Color)? {
+        -> (entry: TallyEntry, color: Color)? {
         for entry in entries where active.contains(entry.status) {
             if let color = entry.color.color {
-                return (entry.status, color)
+                return (entry, color)
             }
         }
         return nil
@@ -189,6 +213,23 @@ struct TallyLightOptionsView: View {
                         .pickerStyle(.menu)
                         .labelsHidden()
                         .fixedSize()
+
+                        // Only where there is a border to animate: a
+                        // pulse switch on an Off row controls nothing.
+                        if entry.color != .none {
+                            Button {
+                                entry.pulse.toggle()
+                            } label: {
+                                Image(systemName: entry.pulse
+                                        ? "waveform.path" : "minus")
+                                    .frame(width: 28, height: 28)
+                            }
+                            .buttonStyle(.borderless)
+                            .foregroundColor(entry.pulse
+                                             ? Theme.accent : .secondary)
+                            .accessibilityLabel(
+                                entry.pulse ? "Pulsing" : "Steady")
+                        }
                     }
                 }
                 .onMove { from, to in
@@ -197,7 +238,7 @@ struct TallyLightOptionsView: View {
             } header: {
                 Text("Statuses, highest priority first")
             } footer: {
-                Text("The highest status here that's currently true sets the border color; Off skips it. Tap Edit to reorder.")
+                Text("The highest status here that's currently true sets the border color; Off skips it. The button beside a color switches that status between a steady border and a pulsing one. Tap Edit to reorder.")
             }
 
             Section {

--- a/ios-app/Sources/TallyLightOptions.swift
+++ b/ios-app/Sources/TallyLightOptions.swift
@@ -220,15 +220,19 @@ struct TallyLightOptionsView: View {
                             Button {
                                 entry.pulse.toggle()
                             } label: {
-                                Image(systemName: entry.pulse
-                                        ? "waveform.path" : "minus")
-                                    .frame(width: 28, height: 28)
+                                // One glyph, state in the colour — the
+                                // Live screen's active-chip language. An
+                                // icon that swaps to a dash would read as
+                                // "remove" in a swipe-to-delete list.
+                                Image(systemName: "waveform.path")
+                                    .frame(width: Theme.controlButton,
+                                           height: Theme.controlButton)
                             }
                             .buttonStyle(.borderless)
                             .foregroundColor(entry.pulse
                                              ? Theme.accent : .secondary)
-                            .accessibilityLabel(
-                                entry.pulse ? "Pulsing" : "Steady")
+                            .accessibilityLabel("Pulse")
+                            .accessibilityValue(entry.pulse ? "On" : "Off")
                         }
                     }
                 }
@@ -238,7 +242,7 @@ struct TallyLightOptionsView: View {
             } header: {
                 Text("Statuses, highest priority first")
             } footer: {
-                Text("The highest status here that's currently true sets the border color; Off skips it. The button beside a color switches that status between a steady border and a pulsing one. Tap Edit to reorder.")
+                Text("The highest status here that's currently true sets the border color; Off skips it. Tap Edit to reorder.")
             }
 
             Section {


### PR DESCRIPTION
## What & why

Closes #107, and the implementable half of #103. A fourth commit fixes a release-versioning bug the review of this PR turned up.

Both issues had a `@claude` run on 28 Aug that reported finishing the work and then failed to push — `remote: Permission to MyNamesEMurray/LensLink.git denied to github-actions[bot]` (403), on both. That code never reached GitHub, so this is written from scratch. **`claude.yml` needs `permissions: contents: write`** (and `pull-requests: write`) or the next run hits the same wall.

### Presets (#107)

The TestFlight report asked for manual shutter, ISO and white balance to survive between sessions: someone using the phone as a webcam in one room under one set of lights re-dials the same numbers every time the camera reinitializes. The issue comment asked for rather more, and it's all here — Options → Presets:

- A preset carries any subset of **Exposure / White balance / Zoom / Focus**, plus a name. A group that isn't included isn't *stored*, which is why these are optionals rather than include flags: a value that can't be stored can't be applied by mistake.
- Give a preset a **camera** and it applies whenever that camera comes up — stream start, a live lens switch, or any live format change (all of which reset the controls first, which is exactly what a preset is for). One camera can't carry two presets; assigning takes it off the other.
- Mark one preset the **default** and it covers any camera without its own. The default is an id on the manager, not a flag per preset, so "two defaults" is unrepresentable; deleting a preset clears it rather than leaving an id that dangles and silently applies nothing.
- Changing a covered setting **by hand pauses auto-apply** — from the Live screen or a remote `CONTROL` command, which reach the same properties and mean the same thing. A **Presets paused** pill appears on the Live screen and resumes on tap, re-applying the matching preset. No restart, no stopping the stream. It shows only where resuming would do something.

Two implementation points worth a reviewer's eye:

- The pause guard is a **depth counter, not a Bool**: applying a preset writes several properties and `resetCameraControls` runs inside that, so a Bool cleared by the inner scope would disarm presets while the outer scope still had writes to make.
- `apply()` sets **values before modes**, because the mode's `didSet` is what pushes the pair to the device — the other order briefly runs the new mode against the old ISO.

Presets are phone-local and move the same properties the Live screen and `CONTROL` do, so the `STATE` snapshot follows for free. No protocol change.

### Battery visibility (#103)

Taking the issue comment as the spec. A phone streaming unattended dims itself after ten seconds, and from that moment cannot answer the one question that ends streams — checking meant waking the screen, restarting the drain you were asking about.

- **Battery readout on the dim overlay**: level glyph, monospaced percentage, a bolt while charging. Grey normally, `connectAmber` in Low Power Mode, `errorRed` at 20% or below, grey whenever charging — Low Power Mode can be switched on at 80%, and one colour for both would be a warning you learn to ignore. Renders nothing where iOS reports no level, rather than a placeholder that looks like a fault.
- **"Low battery" tally status**, off by default like every other informational one, assignable to any tally colour. True in Low Power Mode or at ≤ 20%, false whenever charging.
- **Any tally status can pulse** instead of holding steady: 0.9 s ease between full and 30% opacity, never to zero, so a glance during the dark half still finds a border. `accessibilityReduceMotion` gives a steady border in the same colour — less motion, never less warning.

`BatteryMonitor` is notification-driven and refcounted to the Live screen: no timer (docs/PERFORMANCE.md) and no device-wide flag left set for the app's life. Tally configs saved before pulses existed still decode — the hand-written `init(from:)` is there because the synthesized one treats the missing key as corruption and would reset every row.

The reporter's other ask on #103 — GoPro Hero 8+ straight into OBS — is not addressed and is not a LensLink change: a different device speaking a different protocol.

### Design-language audit (third commit)

Everything above was then checked against `docs/UI_DESIGN.md`, and the parts that didn't hold up were fixed: section footers removed from the new screens (§3 — setting screens are pure controls), the editor's sliders rebuilt on the product's own slider row and segment words (§4/§5, AE/Manual not Auto/Manual), off-scale spacing and type corrected, a dead "Apply now" section dropped (unreachable while streaming, useless while idle), and the pulse button stopped swapping to a `minus` glyph that read as "remove" in a swipe-to-delete list.

It also turned up three stale spots in the doc itself — two of them from #108, which updated §6.2 and missed the rest: §2 still named the removed "Dim screen to save battery" toggle, §5's icon table still had a Dim button rather than the Idle button, and §6.1 still described a footer under every Options toggle, abolished when the Documentation screen landed.

### Release-version guard (fourth commit)

`v1.10.0-beta.2` was public and on TestFlight when `v1.9.2` was cut underneath it, so testers watched the app's version go backwards.

The docs promise that merging without the trailer turns a beta into its release. That only held for a *patch* beta, where the plain merge happens to compute the same number: `v1.8.1` → `v1.8.2-beta.1` → a plain merge computes `v1.8.2` and lands on it. A line opened with a bump trailer does not — `v1.9.0` + minor + beta gives `v1.10.0-beta.1`, and the next plain merge computes `v1.9.1`, below the line. Nothing was watching for that.

The bump now treats the highest version any pre-release is a beta of as a **floor**: a computed version below it is replaced by it, cutting that line as documented, with a `::notice::` saying so. Bases are compared after stripping the suffix, with `sort -V` — asking git to order suffixed tags is the very thing the stable-only filter exists to avoid. The rule can only move a version up, and it falls silent once a line is cut, because the new stable tag then seeds everything after it.

## How it was tested

**App:** `ios-app/syntax-check.sh` passes — parse-only, since this was developed on Linux; the macOS job here is the real compile and type check.

**Version guard:** the version step's script was extracted straight out of the YAML and run against synthetic tag histories in throwaway repos, 13 cases. The regression itself now yields `v1.10.0` instead of `v1.9.2`; the documented patch-beta flow, an already-cut line, a stale beta below stable, major-outranks-the-line, beta continuation, gap-filling suffixes, skip, last-directive-wins and a first-ever release are all unchanged. `actionlint` runs clean locally with the same flags CI uses.

**Not device-tested**, and three things want a phone before release: the tally pulse and its Reduce Motion path, the battery readout's colour thresholds (Low Power Mode at a high level, then ≤ 20%), and a preset firing on a live lens switch mid-stream. The editor's ISO/shutter ranges fall back to format-independent defaults when no camera is running, which is the state it is normally opened in; values are clamped again on apply.

`Release-Bump: minor` — this merge cuts **v1.10.0**, which is also the version the beta line has been leading up to since July.