### PR TITLE
Site: stop the hero stacking two lots of top padding

### DIFF
--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -119,7 +119,13 @@ kbd {
 
 /* ------------------------------------------------------------------ hero */
 
-.hero { position: relative; overflow: hidden; border-bottom: 1px solid var(--hair-soft); }
+/* The hero is a <section>, but it owns its vertical rhythm through
+   .hero .wrap below — without this reset it inherits the generic section
+   padding as well and the two stack into a ~176px void above the eyebrow. */
+.hero {
+	position: relative; overflow: hidden; padding: 0;
+	border-bottom: 1px solid var(--hair-soft);
+}
 .hero::before {
 	content: ""; position: absolute; inset: -30% 0 auto -10%;
 	height: 720px; pointer-events: none;


### PR DESCRIPTION
## What & why

Reported from a phone: a large empty band between the header and the first
thing on the page.

The hero is a `<section>`, so it was taking the generic
`section { padding: 88px 0 }` *on top of* its own `.hero .wrap` padding. The two
stack:

| Viewport | Section padding | Wrap padding | Gap above the eyebrow |
|---|---|---|---|
| 390px | 88px | 56px | **144px** |
| 1440px | 88px | 88px | **176px** |

At phone width that is most of a screen of nothing, and it reads as the page
having failed to start rather than as deliberate space.

Fix: reset the section padding on `.hero`, which owns its vertical rhythm
through `.hero .wrap`. One rule, with a comment saying why it exists so nobody
"tidies" it away later.

## How it was tested

Measured in headless Chromium, header bottom to eyebrow top:

- **390px:** 144px → **56px**
- **1440px:** 176px → **88px**

Both now match the spacing every other section uses. I also swept every
`section` (plus `.dl-hero`, `.notfound` and `.doclayout`) across the home,
download, docs index, a docs page and the 404 for the same stacking pattern —
no second instance: `.dl-hero` and `.notfound` set their own padding and win on
specificity.

`python3 build.py` → 15 pages, `python3 check-links.py` → 0 broken links. CSS
only; no content or markup changed. `Release-Skip: true`, and `site/` matches
none of the release paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSuQicA9NrKWwpgzY6SvhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSuQicA9NrKWwpgzY6SvhA)_