### PR TITLE
Site: review round — panel fixes, camera frame, and a guided setup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ phone.
 
 - **OBS Studio 32** or newer, on Windows, macOS, or Linux.
 - An **iPhone or iPad on iOS/iPadOS 15 or later**.
-- For **USB**: iTunes installed on Windows (it provides Apple's device
-  driver); nothing extra on macOS.
+- For **USB**: iTunes on Windows (it provides Apple's device driver), or
+  the **`usbmuxd`** daemon on Linux — most desktop distributions ship it
+  for phone access. Nothing extra on macOS, and Wi-Fi needs none of it.
 
 ## Install
 
@@ -302,9 +303,14 @@ are the places to watch.
 
 ## Tips & troubleshooting
 
-- **USB device not found (Windows):** make sure iTunes is installed — it
-  provides the driver the plugin needs — and tap **Trust** on the phone
-  when prompted.
+- **USB device not found:** tap **Trust** on the phone when prompted, and
+  use a data cable rather than a charge-only one. The plugin reaches the
+  phone through Apple's usbmuxd protocol, which comes from a different
+  place on each system: on **Windows** it is the Apple Mobile Device
+  Service, installed with iTunes; on **Linux** it is the `usbmuxd` daemon
+  at `/var/run/usbmuxd`, which most desktop distributions ship but some
+  do not (install the `usbmuxd` package); on **macOS** it is part of the
+  OS and needs nothing.
 - **Source shows as "iOS Camera" / updates don't seem to apply:** an old
   pre-1.0 copy of the plugin (`ios-camera-source.dll`) is still installed
   and wins over the current one (the OBS log shows *"Source

--- a/site/README.md
+++ b/site/README.md
@@ -60,15 +60,19 @@ browser panel. Notably:
 - The home page's device panel is the app's Live screen rebuilt from those
   tokens — not a screenshot, so it can never drift out of date silently.
   If the app's control layout changes, update it here too.
-- **The camera still behind it.** Drop a landscape image at
-  `static/img/hero-feed.jpg` and `build.py` puts it behind that panel, the
-  way the app draws its controls over live video; with no such file the
-  panel keeps its tinted-glow background and the page requests nothing
-  extra. Ideally a real frame from a LensLink camera. Aim for 1600px wide
-  or more, and keep the interesting part of the picture out of the bottom
-  third and the top-left corner — the control panel and the Live pill sit
-  there. A scrim is applied automatically so white controls stay legible
-  over any photo.
+- **The camera stills behind it.** Drop either or both of
+  `static/img/hero-feed-landscape.*` and `static/img/hero-feed-portrait.*`
+  into `static/img/` and `build.py` puts them behind that panel, the way
+  the app draws its controls over live video. The stylesheet picks by
+  viewport — portrait below 470px, where the panel drops 16:10 and stands
+  tall, landscape above it — and either orientation stands in for a missing
+  one. Only the one in use is downloaded. With neither file the panel keeps
+  its tinted-glow background and the page requests nothing extra.
+
+  Ideally real frames from a LensLink camera. Keep the subject out of the
+  bottom third and the top-left corner, where the control panel and the
+  Live pill sit; a scrim is applied automatically so white controls stay
+  legible over any photo.
 
 Copy follows the same rules as the app: American English, sentence case,
 no exclamation marks, "Flashlight" not "Torch", "Green screen" not "chroma

--- a/site/README.md
+++ b/site/README.md
@@ -60,6 +60,15 @@ browser panel. Notably:
 - The home page's device panel is the app's Live screen rebuilt from those
   tokens — not a screenshot, so it can never drift out of date silently.
   If the app's control layout changes, update it here too.
+- **The camera still behind it.** Drop a landscape image at
+  `static/img/hero-feed.jpg` and `build.py` puts it behind that panel, the
+  way the app draws its controls over live video; with no such file the
+  panel keeps its tinted-glow background and the page requests nothing
+  extra. Ideally a real frame from a LensLink camera. Aim for 1600px wide
+  or more, and keep the interesting part of the picture out of the bottom
+  third and the top-left corner — the control panel and the Live pill sit
+  there. A scrim is applied automatically so white controls stay legible
+  over any photo.
 
 Copy follows the same rules as the app: American English, sentence case,
 no exclamation marks, "Flashlight" not "Torch", "Green screen" not "chroma

--- a/site/build.py
+++ b/site/build.py
@@ -17,6 +17,7 @@ Run from this directory:
     python3 build.py --serve    # writes dist/ and serves it on :8000
 """
 
+import glob
 import hashlib
 import html
 import os
@@ -36,12 +37,18 @@ SITE_URL = "https://lenslink.cam"
 REPO_URL = "https://github.com/MyNamesEMurray/LensLink"
 TESTFLIGHT_URL = "https://testflight.apple.com/join/N7Rth6m3"
 
-# A still from a real LensLink camera, shown behind the home page's control
-# panel the way the app draws its controls over live video. Optional: with no
-# such file the panel keeps its tinted-glow background, and the page asks the
-# browser for nothing that isn't there. Any web image format works — name it
-# to match.
-FEED_IMAGE = "img/hero-feed.jpg"
+# Stills from a real LensLink camera, shown behind the home page's control
+# panel the way the app draws its controls over live video. Both are
+# optional and either can stand in for the other; with neither, the panel
+# keeps its tinted-glow background and the page asks the browser for nothing
+# that isn't there. Any web image format works — match the stem, keep the
+# extension.
+#
+# Two, because the panel already changes shape: below the breakpoint in
+# site.css it drops 16:10 and stands tall, which is a portrait frame's
+# aspect, and above it it is a wide screen, which is a landscape frame's.
+FEED_STEMS = {"landscape": "img/hero-feed-landscape",
+              "portrait": "img/hero-feed-portrait"}
 
 # Documentation order. The sidebar, the previous/next footer links and
 # the sitemap all read this one list, so a new page is added once.
@@ -324,13 +331,17 @@ def build():
 
     assets = fingerprint_assets()
 
-    # The optional camera still behind the hero panel.
-    feed = os.path.join(DIST, FEED_IMAGE)
-    if os.path.exists(feed):
-        feed_class = " has-feed"
-        feed_style = " style=\"--feed:url('/%s')\"" % FEED_IMAGE
-    else:
-        feed_class = feed_style = ""
+    # The optional camera stills behind the hero panel: whichever of the two
+    # orientations exist, declared as custom properties the stylesheet picks
+    # between by viewport.
+    props = []
+    for name, stem in sorted(FEED_STEMS.items()):
+        found = glob.glob(os.path.join(DIST, stem + ".*"))
+        if found:
+            rel = os.path.relpath(found[0], DIST).replace(os.sep, "/")
+            props.append("--feed-%s:url('/%s')" % (name, rel))
+    feed_class = " has-feed" if props else ""
+    feed_style = (' style="%s"' % ";".join(props)) if props else ""
 
     urls = []
     for rel in collect_pages():

--- a/site/build.py
+++ b/site/build.py
@@ -36,6 +36,13 @@ SITE_URL = "https://lenslink.cam"
 REPO_URL = "https://github.com/MyNamesEMurray/LensLink"
 TESTFLIGHT_URL = "https://testflight.apple.com/join/N7Rth6m3"
 
+# A still from a real LensLink camera, shown behind the home page's control
+# panel the way the app draws its controls over live video. Optional: with no
+# such file the panel keeps its tinted-glow background, and the page asks the
+# browser for nothing that isn't there. Any web image format works — name it
+# to match.
+FEED_IMAGE = "img/hero-feed.jpg"
+
 # Documentation order. The sidebar, the previous/next footer links and
 # the sitemap all read this one list, so a new page is added once.
 DOC_ORDER = [
@@ -317,12 +324,22 @@ def build():
 
     assets = fingerprint_assets()
 
+    # The optional camera still behind the hero panel.
+    feed = os.path.join(DIST, FEED_IMAGE)
+    if os.path.exists(feed):
+        feed_class = " has-feed"
+        feed_style = " style=\"--feed:url('/%s')\"" % FEED_IMAGE
+    else:
+        feed_class = feed_style = ""
+
     urls = []
     for rel in collect_pages():
         meta, body = read_page(os.path.join(PAGES, rel))
         body, toc = add_heading_ids(body)
         body = (body.replace("{{TESTFLIGHT}}", TESTFLIGHT_URL)
-                    .replace("{{REPO}}", REPO_URL))
+                    .replace("{{REPO}}", REPO_URL)
+                    .replace("{{FEED}}", feed_class)
+                    .replace("{{FEED_STYLE}}", feed_style))
         out = shell(meta, body, rel, toc)
         for old, new in assets.items():
             out = out.replace(old, new)

--- a/site/build.py
+++ b/site/build.py
@@ -110,8 +110,13 @@ def url_for(page_path):
     return "/%s/" % rel
 
 
-def add_heading_ids(body):
-    """Give every h2/h3 an id, and collect the h2s for the contents list."""
+def add_heading_ids(body, anchors=True):
+    """Give every h2/h3 an id, and collect the h2s for the contents list.
+
+    `anchors` adds the hover-revealed # link beside each heading. That earns
+    its place in the documentation, where headings are destinations people
+    link each other to; on the marketing pages the headings are copy, and a
+    stray # on hover is just noise."""
     toc = []
 
     def repl(match):
@@ -122,7 +127,8 @@ def add_heading_ids(body):
             attrs = ' id="%s"%s' % (ident, attrs)
         if level == "2":
             toc.append((ident, re.sub(r"<[^>]+>", "", text)))
-        anchor = '<a class="anchor" href="#%s" aria-label="Link to this section">#</a>' % ident
+        anchor = ('<a class="anchor" href="#%s" aria-label="Link to this section">#</a>'
+                  % ident) if anchors else ""
         return "<h%s%s>%s%s</h%s>" % (level, attrs, text, anchor, level)
 
     body = re.sub(r"<h([23])([^>]*)>(.*?)</h\1>", repl, body, flags=re.S)
@@ -132,6 +138,7 @@ def add_heading_ids(body):
 def nav_html(active):
     items = [("/", "home", "Home"),
              ("/download/", "download", "Download"),
+             ("/setup/", "setup", "Setup guide"),
              ("/docs/", "docs", "Documentation")]
     out = []
     for href, key, label in items:
@@ -191,7 +198,7 @@ def wordmark(suffix):
             % mark_svg(suffix))
 
 FOOTER_COLS = [
-    ("Product", [("/download/", "Download"), ("/docs/install/", "Install guide"),
+    ("Product", [("/download/", "Download"), ("/setup/", "Setup guide"),
                  ("/docs/connect/", "Connect"), ("/docs/faq/", "FAQ")]),
     ("Documentation", [("/docs/camera/", "Camera and image"),
                        ("/docs/screen-mirroring/", "Screen mirroring"),
@@ -278,7 +285,7 @@ def shell(meta, body, page_path, toc):
 # can be deployed and still not reach anyone until the old copy expires. A
 # hashed name changes with the content, so a deploy is picked up immediately
 # and the old URL is never requested again.
-FINGERPRINT = ["css/site.css", "js/site.js", "js/download.js"]
+FINGERPRINT = ["css/site.css", "js/site.js", "js/download.js", "js/setup.js"]
 
 
 def fingerprint_assets():
@@ -346,7 +353,7 @@ def build():
     urls = []
     for rel in collect_pages():
         meta, body = read_page(os.path.join(PAGES, rel))
-        body, toc = add_heading_ids(body)
+        body, toc = add_heading_ids(body, anchors=rel.startswith("docs/"))
         body = (body.replace("{{TESTFLIGHT}}", TESTFLIGHT_URL)
                     .replace("{{REPO}}", REPO_URL)
                     .replace("{{FEED}}", feed_class)

--- a/site/pages/docs/index.html
+++ b/site/pages/docs/index.html
@@ -9,9 +9,10 @@ description: Everything about installing, connecting and running LensLink — th
 </p>
 
 <div class="callout">
-  <p><strong>In a hurry?</strong> <a href="/docs/install/">Install</a>, then
-  <a href="/docs/connect/">Connect</a>. That's the whole setup; the rest is
-  optional.</p>
+  <p><strong>In a hurry?</strong> The <a href="/setup/">setup guide</a> asks four
+  questions and gives you only the steps that match your answers. Or read
+  <a href="/docs/install/">Install</a> then <a href="/docs/connect/">Connect</a>,
+  which is the same material in full.</p>
 </div>
 
 <h2>How it fits together</h2>

--- a/site/pages/docs/install.html
+++ b/site/pages/docs/install.html
@@ -3,7 +3,8 @@ description: Install the LensLink plugin into OBS Studio on Windows, macOS or Li
 ---
 <h1>Install</h1>
 <p class="lede">
-  Both halves are required: the plugin in OBS, the app on the phone.
+  Both halves are required: the plugin in OBS, the app on the phone. For just
+  the steps that match your setup, use the <a href="/setup/">setup guide</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/site/pages/docs/install.html
+++ b/site/pages/docs/install.html
@@ -11,7 +11,7 @@ description: Install the LensLink plugin into OBS Studio on Windows, macOS or Li
 <ul>
   <li><strong>OBS Studio 32 or newer</strong> (<strong>Help → About</strong>). Older versions will not load the plugin.</li>
   <li><strong>iOS or iPadOS 15 or later.</strong></li>
-  <li><strong>iTunes, for USB on Windows only</strong> — it supplies Apple's device driver. Wi-Fi doesn't need it; macOS and Linux need nothing.</li>
+  <li><strong>For USB:</strong> iTunes on Windows (it supplies Apple's device driver), or the <code>usbmuxd</code> daemon on Linux. macOS has it built in, and Wi-Fi needs none of it.</li>
 </ul>
 <p><a class="btn small ghost" href="/download/">Download page</a></p>
 
@@ -95,6 +95,47 @@ cmake --build build</code></pre>
 cd ios-app && xcodegen generate && open LensLink.xcodeproj</code></pre>
 <p>Signing and older-Xcode notes:
 <a href="{{REPO}}/blob/main/ios-app/BUILDING.md"><code>ios-app/BUILDING.md</code></a>.</p>
+
+<h2>What differs by operating system</h2>
+<p>
+  The app, the protocol and every camera feature are identical wherever OBS
+  runs. What changes is how the plugin reaches the phone over USB and how it
+  gets decoded frames onto the GPU.
+</p>
+<table>
+  <thead><tr><th></th><th>Windows</th><th>macOS</th><th>Linux</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>USB needs</td>
+      <td>iTunes, for the Apple Mobile Device Service</td>
+      <td>Nothing — built into the OS</td>
+      <td>The <code>usbmuxd</code> daemon. Most desktop distributions ship it for phone access; install the <code>usbmuxd</code> package if the source reports no device.</td>
+    </tr>
+    <tr>
+      <td>Hardware decoding</td>
+      <td>D3D11VA, then DXVA2</td>
+      <td>VideoToolbox</td>
+      <td>VAAPI, then VDPAU</td>
+    </tr>
+    <tr>
+      <td><a href="/docs/performance/#the-gpu-decode-pipeline-beta">GPU pipeline</a> needs</td>
+      <td>Windows 10 1909+</td>
+      <td>macOS 13+</td>
+      <td>OBS on EGL, plus a VAAPI driver</td>
+    </tr>
+    <tr>
+      <td>10-bit on the GPU pipeline</td>
+      <td>Yes, as P010</td>
+      <td>No — VideoToolbox converts to 8-bit itself, so HDR renders through the standard path</td>
+      <td>Yes, as P010</td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  Everything else — resolutions, codecs, HDR and Apple Log capture, the green
+  screen, lip sync, remote start, the browser panel — is decided on the phone
+  or in shared code, and behaves the same on all three.
+</p>
 
 <h2>Updating</h2>
 <p>

--- a/site/pages/docs/performance.html
+++ b/site/pages/docs/performance.html
@@ -96,6 +96,35 @@ description: What LensLink's latency is made of, how to measure it, how to lower
   pipeline, with a log line saying why.
 </p>
 
+<h3>Does the GPU brand matter?</h3>
+<p>
+  Less than the operating system does. Decoding is a fixed-function block on
+  every modern GPU, and the plugin asks the platform's own API for it rather
+  than anything vendor-specific.
+</p>
+<table>
+  <tbody>
+    <tr><td>Windows</td><td>Vendor-agnostic. D3D11VA on any current GPU, DXVA2 as the fallback.</td></tr>
+    <tr><td>macOS</td><td>VideoToolbox, on Apple silicon and Intel Macs alike.</td></tr>
+    <tr><td>Linux, Intel or AMD</td><td>VAAPI is in Mesa already — nothing to install.</td></tr>
+    <tr><td>Linux, NVIDIA</td><td>Needs <code>nvidia-vaapi-driver</code>; VDPAU is the fallback. This is the one place the brand decides whether the GPU pipeline engages at all.</td></tr>
+    <tr><td>Laptops with two GPUs</td><td>If decoding lands on one and OBS renders on the other, textures can't be shared and the source falls back on its own.</td></tr>
+    <tr><td>Older GPUs</td><td>A GPU with no HEVC Main10 decoder falls back to software for 10-bit streams; 8-bit is unaffected.</td></tr>
+  </tbody>
+</table>
+<div class="callout">
+  <p><strong>Several phones at once is a decode workload, not an encode one.</strong>
+  NVIDIA's limit on simultaneous NVENC sessions doesn't apply — nothing here
+  encodes on the computer. What limits you is decode throughput and memory
+  bandwidth, which is exactly what the GPU pipeline saves.</p>
+</div>
+<p>
+  The measurements above come from one Windows machine with an NVIDIA card.
+  The pipeline is beta partly because the other combinations — macOS
+  IOSurface, Mesa VAAPI, <code>nvidia-vaapi-driver</code>, and the multi-GPU
+  fallback — want field reports more than they want more code.
+</p>
+
 <h2>Measuring it yourself</h2>
 <p>
   <strong>Tools → LensLink Settings → Record pipeline benchmark</strong> writes

--- a/site/pages/docs/performance.html
+++ b/site/pages/docs/performance.html
@@ -86,7 +86,7 @@ description: What LensLink's latency is made of, how to measure it, how to lower
 <table>
   <tbody>
     <tr><td>Windows</td><td>Any OBS 32-supported system (Windows 10 1909+), using shared D3D11 textures.</td></tr>
-    <tr><td>macOS</td><td>Any OBS 32-supported system (macOS 13+), via IOSurface.</td></tr>
+    <tr><td>macOS</td><td>Any OBS 32-supported system (macOS 13+), via IOSurface. 10-bit streams are the exception: VideoToolbox converts them to 8-bit itself, so HDR and Apple Log render through the standard path rather than this one.</td></tr>
     <tr><td>Linux</td><td>Needs OBS on <strong>EGL</strong> (the default on Wayland and current X11 builds) and a <strong>VAAPI</strong> driver — built into Mesa for Intel and AMD; NVIDIA needs <code>nvidia-vaapi-driver</code>.</td></tr>
     <tr><td>Multi-GPU</td><td>Decoding and rendering on different GPUs can't share textures; the source falls back automatically.</td></tr>
   </tbody>

--- a/site/pages/download.html
+++ b/site/pages/download.html
@@ -110,9 +110,10 @@ script: /js/download.js
           <td><strong>Help → About</strong>. Older versions won't load the plugin.</td>
         </tr>
         <tr>
-          <td>iTunes on Windows, for USB</td>
-          <td>Apple's device driver ships with iTunes. Wi-Fi works without it, USB
-          doesn't. Nothing extra on macOS or Linux.</td>
+          <td>A USB helper, for USB only</td>
+          <td>Apple's device driver ships with iTunes. Linux needs the
+          <code>usbmuxd</code> daemon instead; macOS has it built in. Wi-Fi
+          needs none of them.</td>
         </tr>
       </tbody>
     </table>

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -28,7 +28,7 @@ nav: home
       <!-- The app's Live screen, rebuilt from the same design tokens the
            app and the plugin's browser panel use. -->
       <div class="device">
-        <div class="screen">
+        <div class="screen{{FEED}}"{{FEED_STYLE}}>
           <div class="topgroup">
             <div class="toprow">
             <span class="pill"><span class="dot live"></span>Live</span>

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -17,7 +17,7 @@ nav: home
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="m7 11 5 5 5-5"/><path d="M4 19h16"/></svg>
           Download
         </a>
-        <a class="btn ghost" href="/docs/">Read the documentation</a>
+        <a class="btn ghost" href="/setup/">Guided setup</a>
       </div>
       <p class="meta">
         <span>OBS Studio 32+</span><span>Windows, macOS, Linux</span><span>iOS/iPadOS 15+</span>
@@ -89,8 +89,8 @@ nav: home
       </li>
     </ol>
     <div class="cta">
+      <a class="btn ghost small" href="/setup/">Answer four questions instead</a>
       <a class="btn ghost small" href="/docs/install/">Full install guide</a>
-      <a class="btn ghost small" href="/docs/connect/">Connecting over Wi-Fi or USB</a>
     </div>
   </div>
 </section>

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -38,8 +38,8 @@ script: /js/setup.js
       <fieldset>
         <legend>What you want in OBS</legend>
         <div class="seg-choice">
-          <label><input type="radio" name="mode" value="camera" checked><span>The camera</span></label>
-          <label><input type="radio" name="mode" value="screen"><span>The phone's screen</span></label>
+          <label><input type="radio" name="mode" value="camera" checked><span>Phone camera</span></label>
+          <label><input type="radio" name="mode" value="screen"><span>Phone screen</span></label>
         </div>
       </fieldset>
 

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -120,6 +120,11 @@ cd ios-app &amp;&amp; xcodegen generate &amp;&amp; open LensLink.xcodeproj</code
         <p>Apple's device driver ships with iTunes, and the plugin needs it to see the phone over USB. There's no way around this on Windows. (Wi-Fi doesn't need it.)</p>
       </li>
 
+      <li data-link="usb" data-os="linux">
+        <h2>Check usbmuxd is installed <span class="tag">Linux</span> <span class="tag">USB</span></h2>
+        <p>The plugin talks to the phone through the <code>usbmuxd</code> daemon at <code>/var/run/usbmuxd</code>. Most desktop distributions ship it for phone access already; if the source reports no device, install the <code>usbmuxd</code> package.</p>
+      </li>
+
       <li data-link="usb">
         <h2>Plug in and tap Trust <span class="tag">USB</span></h2>
         <p>Unlock the phone first, or the prompt never appears. It must be a <strong>data</strong> cable — nothing in the interface can tell you a charge-only one apart.</p>

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -33,12 +33,10 @@ script: /js/setup.js
           <label><input type="radio" name="link" value="wifi"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 11.5a12 12 0 0 1 16 0"/><path d="M7.5 15a7 7 0 0 1 9 0"/><circle cx="12" cy="18.6" r="1.2" fill="currentColor" stroke="none"/></svg> Wi-Fi</span></label>
           <label><input type="radio" name="link" value="unsure"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9.6 9.4a2.5 2.5 0 0 1 4.9.6c0 1.7-2.5 2-2.5 3.6"/><circle cx="12" cy="17" r="1" fill="currentColor" stroke="none"/></svg> Not sure</span></label>
         </div>
-        <p class="q-note" id="link-note">No network involved, the steadiest latency, and the phone charges as it streams. Pick Wi-Fi when the cable can't reach.</p>
         <p class="q-answer" id="unsure-note" hidden>
-          Then use the cable. The steps below are the USB ones — it needs no
-          network at all, so there is nothing to configure and nothing to go
-          wrong on someone else's Wi-Fi. Switch to <strong>Wi-Fi</strong> above
-          if the phone has to sit somewhere a cable can't reach.
+          Use the cable — the steps below are the USB ones. Switch to
+          <strong>Wi-Fi</strong> if the phone has to sit somewhere a cable
+          can't reach.
         </p>
       </fieldset>
 

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -31,8 +31,15 @@ script: /js/setup.js
         <div class="seg-choice">
           <label><input type="radio" name="link" value="usb" checked><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V7"/><circle cx="12" cy="4" r="1.6"/><path d="M12 13l4-3 .8 2.4"/><path d="M12 16l-4-3v-2.2"/></svg> USB cable <em class="rec">Recommended</em></span></label>
           <label><input type="radio" name="link" value="wifi"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 11.5a12 12 0 0 1 16 0"/><path d="M7.5 15a7 7 0 0 1 9 0"/><circle cx="12" cy="18.6" r="1.2" fill="currentColor" stroke="none"/></svg> Wi-Fi</span></label>
+          <label><input type="radio" name="link" value="unsure"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9.6 9.4a2.5 2.5 0 0 1 4.9.6c0 1.7-2.5 2-2.5 3.6"/><circle cx="12" cy="17" r="1" fill="currentColor" stroke="none"/></svg> Not sure</span></label>
         </div>
-        <p class="q-note">No network involved, the steadiest latency, and the phone charges as it streams. Pick Wi-Fi when the cable can't reach.</p>
+        <p class="q-note" id="link-note">No network involved, the steadiest latency, and the phone charges as it streams. Pick Wi-Fi when the cable can't reach.</p>
+        <p class="q-answer" id="unsure-note" hidden>
+          Then use the cable. The steps below are the USB ones — it needs no
+          network at all, so there is nothing to configure and nothing to go
+          wrong on someone else's Wi-Fi. Switch to <strong>Wi-Fi</strong> above
+          if the phone has to sit somewhere a cable can't reach.
+        </p>
       </fieldset>
 
       <fieldset>

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -29,26 +29,26 @@ script: /js/setup.js
       <fieldset>
         <legend>How the phone connects</legend>
         <div class="seg-choice">
-          <label><input type="radio" name="link" value="usb" checked><span>USB cable</span></label>
-          <label><input type="radio" name="link" value="wifi"><span>Wi-Fi</span></label>
+          <label><input type="radio" name="link" value="usb" checked><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V7"/><circle cx="12" cy="4" r="1.6"/><path d="M12 13l4-3 .8 2.4"/><path d="M12 16l-4-3v-2.2"/></svg> USB cable <em class="rec">Recommended</em></span></label>
+          <label><input type="radio" name="link" value="wifi"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 11.5a12 12 0 0 1 16 0"/><path d="M7.5 15a7 7 0 0 1 9 0"/><circle cx="12" cy="18.6" r="1.2" fill="currentColor" stroke="none"/></svg> Wi-Fi</span></label>
         </div>
-        <p class="q-note">USB needs no network, holds the steadiest latency, and charges the phone as it streams.</p>
+        <p class="q-note">No network involved, the steadiest latency, and the phone charges as it streams. Pick Wi-Fi when the cable can't reach.</p>
       </fieldset>
 
       <fieldset>
         <legend>What you want in OBS</legend>
         <div class="seg-choice">
-          <label><input type="radio" name="mode" value="camera" checked><span>Phone camera</span></label>
-          <label><input type="radio" name="mode" value="screen"><span>Phone screen</span></label>
+          <label><input type="radio" name="mode" value="camera" checked><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2.5" y="6.5" width="13" height="11" rx="2.5"/><path d="M15.5 11.5l6-3.2v7.4l-6-3.2z"/></svg> Phone camera</span></label>
+          <label><input type="radio" name="mode" value="screen"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="6.5" y="2.5" width="11" height="19" rx="2.5"/><path d="M10.5 18.5h3"/></svg> Phone screen</span></label>
         </div>
       </fieldset>
 
       <fieldset>
         <legend>How you'll install the app</legend>
         <div class="seg-choice">
-          <label><input type="radio" name="app" value="testflight" checked><span>TestFlight</span></label>
-          <label><input type="radio" name="app" value="sideload"><span>Sideload</span></label>
-          <label><input type="radio" name="app" value="xcode"><span>Xcode</span></label>
+          <label><input type="radio" name="app" value="testflight" checked><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v11"/><path d="M8 10.5l4 4 4-4"/><path d="M4.5 18.5h15"/></svg> TestFlight <em class="rec">Recommended</em></span></label>
+          <label><input type="radio" name="app" value="sideload"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="6.5" y="2.5" width="11" height="19" rx="2.5"/><path d="M12 8v6"/><path d="M9.5 11.5L12 14l2.5-2.5"/></svg> Sideload</span></label>
+          <label><input type="radio" name="app" value="xcode"><span><svg class="opt-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.5 4.5l5 5-8.5 8.5H6v-5z"/><path d="M12.5 6.5l5 5"/></svg> Xcode</span></label>
         </div>
       </fieldset>
     </form>

--- a/site/pages/setup.html
+++ b/site/pages/setup.html
@@ -1,0 +1,195 @@
+title: Set up LensLink
+description: Answer four questions and get the exact setup steps for your computer, your connection and what you want in OBS — no steps that do not apply to you.
+nav: setup
+script: /js/setup.js
+---
+<section class="dl-hero">
+  <div class="wrap">
+    <h1>Set up LensLink</h1>
+    <p>
+      Four questions, then the steps for <em>your</em> setup — and none of the
+      ones that do not apply. Every answer is also in the address bar, so you
+      can send someone a link to exactly this configuration.
+    </p>
+  </div>
+</section>
+
+<section class="tight">
+  <div class="wrap">
+    <form class="wizard" id="wizard">
+      <fieldset>
+        <legend>Your computer</legend>
+        <div class="seg-choice">
+          <label><input type="radio" name="os" value="windows" checked><span>Windows</span></label>
+          <label><input type="radio" name="os" value="macos"><span>macOS</span></label>
+          <label><input type="radio" name="os" value="linux"><span>Linux</span></label>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>How the phone connects</legend>
+        <div class="seg-choice">
+          <label><input type="radio" name="link" value="usb" checked><span>USB cable</span></label>
+          <label><input type="radio" name="link" value="wifi"><span>Wi-Fi</span></label>
+        </div>
+        <p class="q-note">USB needs no network, holds the steadiest latency, and charges the phone as it streams.</p>
+      </fieldset>
+
+      <fieldset>
+        <legend>What you want in OBS</legend>
+        <div class="seg-choice">
+          <label><input type="radio" name="mode" value="camera" checked><span>The camera</span></label>
+          <label><input type="radio" name="mode" value="screen"><span>The phone's screen</span></label>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>How you'll install the app</legend>
+        <div class="seg-choice">
+          <label><input type="radio" name="app" value="testflight" checked><span>TestFlight</span></label>
+          <label><input type="radio" name="app" value="sideload"><span>Sideload</span></label>
+          <label><input type="radio" name="app" value="xcode"><span>Xcode</span></label>
+        </div>
+      </fieldset>
+    </form>
+
+    <p class="nojs" id="nojs">
+      Every step below is shown, each tagged with the setup it belongs to.
+      Turn on JavaScript and the questions above will hide the ones that
+      do not apply to you.
+    </p>
+
+    <div class="needs" id="needs" hidden>
+      <p>What you'll need</p>
+      <ul id="needs-list"></ul>
+    </div>
+
+    <ol class="guide" id="guide">
+
+      <li>
+        <h2>Check your OBS version</h2>
+        <p><strong>Help → About</strong>. LensLink needs <strong>OBS Studio 32 or newer</strong> — older versions won't load the plugin at all.</p>
+      </li>
+
+      <li data-os="windows">
+        <h2>Install the plugin <span class="tag">Windows</span></h2>
+        <p>Download and run <code>LensLink-installer-windows-x64.exe</code> from the <a href="/download/">download page</a>. It finds your OBS folder and clears out any pre-1.0 copy.</p>
+        <p class="alt">Prefer it by hand? Unzip <code>lenslink-windows-x64.zip</code> into <code>C:\Program Files\obs-studio\</code>, merging the <code>obs-plugins</code> and <code>data</code> folders.</p>
+      </li>
+
+      <li data-os="macos">
+        <h2>Install the plugin <span class="tag">macOS</span></h2>
+        <p>Download <code>LensLink-installer-macos-universal.pkg</code> from the <a href="/download/">download page</a> and open it with <strong>right-click → Open</strong> — the package isn't notarized, so a double-click is refused the first time.</p>
+      </li>
+
+      <li data-os="linux">
+        <h2>Install the plugin <span class="tag">Linux</span></h2>
+        <pre><code>tar -xzf lenslink-linux-x86_64.tar.gz -C ~/.config/obs-studio/plugins/</code></pre>
+      </li>
+
+      <li>
+        <h2>Restart OBS</h2>
+        <p><strong>Sources → +</strong> should now list <strong>LensLink Camera</strong> and <strong>LensLink Screen</strong>. If it doesn't, see <a href="/docs/troubleshooting/#the-sources-do-not-appear-in-obs">the sources don't appear</a>.</p>
+      </li>
+
+      <li data-app="testflight">
+        <h2>Install the app <span class="tag">TestFlight</span></h2>
+        <p>Join the beta at <a href="{{TESTFLIGHT}}">testflight.apple.com/join/N7Rth6m3</a> and install from Apple's TestFlight app. Updates then arrive on their own.</p>
+      </li>
+
+      <li data-app="sideload">
+        <h2>Install the app <span class="tag">Sideload</span></h2>
+        <p>Download <code>LensLink-unsigned.ipa</code> from the <a href="{{REPO}}/releases/latest">latest release</a> and install it with <a href="https://sideloadly.io">Sideloadly</a>.</p>
+        <p class="warn"><strong>Two Apple limits come with this route.</strong> A free Apple ID expires the app after <strong>7 days</strong> — re-install to refresh, your settings are kept. Re-signing also breaks the Siri phrases; use <code>lenslink://start</code> in a Shortcut instead.</p>
+      </li>
+
+      <li data-app="xcode">
+        <h2>Build the app <span class="tag">Xcode</span></h2>
+        <pre><code>brew install xcodegen
+cd ios-app &amp;&amp; xcodegen generate &amp;&amp; open LensLink.xcodeproj</code></pre>
+        <p>Signing details are in <a href="{{REPO}}/blob/main/ios-app/BUILDING.md"><code>ios-app/BUILDING.md</code></a>.</p>
+      </li>
+
+      <li data-link="usb" data-os="windows">
+        <h2>Install iTunes <span class="tag">Windows</span> <span class="tag">USB</span></h2>
+        <p>Apple's device driver ships with iTunes, and the plugin needs it to see the phone over USB. There's no way around this on Windows. (Wi-Fi doesn't need it.)</p>
+      </li>
+
+      <li data-link="usb">
+        <h2>Plug in and tap Trust <span class="tag">USB</span></h2>
+        <p>Unlock the phone first, or the prompt never appears. It must be a <strong>data</strong> cable — nothing in the interface can tell you a charge-only one apart.</p>
+      </li>
+
+      <li data-link="wifi">
+        <h2>Put both devices on the same network <span class="tag">Wi-Fi</span></h2>
+        <p>It has to allow device-to-device traffic: guest networks and access points with client isolation block it. A phone hotspot with the computer joined to it works fine.</p>
+      </li>
+
+      <li>
+        <h2>Open LensLink on the phone</h2>
+        <p data-mode="camera">Choose your lens, resolution, frame rate and codec. The pickers only offer combinations your camera really supports.</p>
+        <p data-mode="screen">You'll start the broadcast in a moment — leave the app open for now.</p>
+        <p data-link="wifi">The Setup screen shows the phone's Wi-Fi address next to the status dot. Tap it to copy.</p>
+      </li>
+
+      <li data-link="wifi">
+        <h2>Allow the Local Network permission <span class="tag">Wi-Fi</span></h2>
+        <p>iOS needs it for the phone to appear by name in OBS. Allow it when asked, or turn it on in <strong>Settings → Privacy &amp; Security → Local Network → LensLink</strong>. Typing the IP address works either way.</p>
+      </li>
+
+      <li data-mode="camera">
+        <h2>Add the source in OBS <span class="tag">Camera</span></h2>
+        <p><strong>Sources → + → LensLink Camera</strong>. One source per phone.</p>
+      </li>
+
+      <li data-mode="screen">
+        <h2>Add the source in OBS <span class="tag">Screen</span></h2>
+        <p><strong>Sources → + → LensLink Screen</strong>. A Screen source only accepts a broadcast, and a Camera source only accepts the camera — each says so if it's fed the other.</p>
+      </li>
+
+      <li data-link="usb">
+        <h2>Point it at the phone <span class="tag">USB</span></h2>
+        <p>Set <strong>Connection</strong> to <strong>USB cable</strong>. Leave <strong>USB device</strong> on <strong>Auto</strong> unless you're running more than one phone.</p>
+      </li>
+
+      <li data-link="wifi">
+        <h2>Point it at the phone <span class="tag">Wi-Fi</span></h2>
+        <p>Open the <strong>Phone</strong> dropdown and pick your device, or type the IP the app is showing.</p>
+      </li>
+
+      <li data-mode="camera">
+        <h2>Start the camera <span class="tag">Camera</span></h2>
+        <p>Tap <strong>Start camera stream</strong> on the phone — or don't: with <strong>Remote start from OBS</strong> on (the default), leaving the app open and idle is enough and OBS starts it for you. Video appears in a second or two.</p>
+      </li>
+
+      <li data-mode="screen">
+        <h2>Start the broadcast <span class="tag">Screen</span></h2>
+        <p>In the app, tap <strong>Start screen broadcast</strong>, choose <strong>LensLink Screen</strong> in the system picker, then <strong>Start Broadcast</strong>. You can leave the app afterwards — a broadcast keeps running across apps.</p>
+      </li>
+
+      <li data-mode="screen">
+        <h2>Pin the source size <span class="tag">Screen</span></h2>
+        <p>A mirror reports whatever resolution iOS is broadcasting, which changes between apps. Right-click the source → <strong>Transform → Edit Transform…</strong> and set <strong>Bounding Box Type</strong> to <strong>Scale to inner bounds</strong>, so switching apps can't resize your layout.</p>
+      </li>
+
+      <li data-mode="camera">
+        <h2>Line up your microphone <span class="tag">Camera</span></h2>
+        <p>Optional, and worth it if you use your own mic. In the source properties pick it under <strong>Lip-sync audio source</strong>, enable the delay and <strong>Auto-calibrate</strong>, then turn on <strong>Auto lip-sync reference</strong> in the app's Options and talk for fifteen seconds. Full detail: <a href="/docs/audio/">audio and lip sync</a>.</p>
+      </li>
+
+      <li>
+        <h2>You're set</h2>
+        <p data-mode="camera">Control the camera from the computer at <a href="http://localhost:9980"><code>localhost:9980</code></a>, or read up on <a href="/docs/camera/">lenses, formats and image settings</a>.</p>
+        <p data-mode="screen">More on broadcasts, audio and DRM: <a href="/docs/screen-mirroring/">screen mirroring</a>.</p>
+        <p>If something's wrong, the source's <strong>Status</strong> line names the stage that's failing — <a href="/docs/connect/#reading-the-status-field">what each message means</a>.</p>
+      </li>
+
+    </ol>
+
+    <p class="guide-foot">
+      This is the same material as the <a href="/docs/install/">install</a> and
+      <a href="/docs/connect/">connect</a> pages, narrowed to your answers.
+      Those pages carry the parts a guide has to leave out.
+    </p>
+  </div>
+</section>

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -200,13 +200,33 @@ kbd {
 	   the controls need there, and this box hides its overflow. */
 	aspect-ratio: 16 / 10;
 	display: flex; flex-direction: column; justify-content: space-between;
-	/* A defocused scene rather than a fake screenshot: soft light where a
-	   window would be, warmth on the subject side. */
-	background-image:
+	background-position: center; background-size: cover;
+}
+
+/* The camera feed behind the controls, exactly as the app draws them over
+   live video. build.py adds `has-feed` only when the file is actually
+   present (see FEED_IMAGE), so a missing photo costs no failed request —
+   the panel just falls back to the tinted glow below. */
+.device .screen.has-feed { background-image: var(--feed); }
+
+/* Without a photo: a defocused scene rather than a fake screenshot — soft
+   light where a window would be, warmth on the subject side. With one, the
+   same layer becomes the scrim that keeps white controls legible over
+   whatever the photo happens to be doing. */
+.device .screen::before {
+	content: ""; position: absolute; inset: 0; pointer-events: none;
+	background:
 		radial-gradient(60% 55% at 74% 22%, rgba(143, 180, 255, 0.20), transparent 70%),
 		radial-gradient(45% 40% at 30% 74%, rgba(255, 176, 120, 0.10), transparent 70%),
 		radial-gradient(120% 100% at 50% 50%, rgba(61, 123, 255, 0.10), transparent 75%);
 }
+.device .screen.has-feed::before {
+	background:
+		linear-gradient(180deg, rgba(6, 7, 10, 0.45), rgba(6, 7, 10, 0.30) 45%, rgba(6, 7, 10, 0.60));
+}
+
+/* Both the control panel and the pills sit above the scrim. */
+.device .topgroup, .device .panelmock { position: relative; z-index: 1; }
 .device .screen::after {
 	/* Tally: on air, the app's heaviest state. */
 	content: ""; position: absolute; inset: 0; border: 3px solid #FF3B30;

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -194,7 +194,11 @@ kbd {
 }
 .device .screen {
 	position: relative; border-radius: 18px; overflow: hidden;
-	background: #06070A; aspect-ratio: 16 / 10; padding: 14px; gap: 10px;
+	background: #06070A; padding: 14px; gap: 10px;
+	/* 16:10 gives it the shape of a screen wherever there is room for one.
+	   Narrow viewports are handled below — the ratio computes shorter than
+	   the controls need there, and this box hides its overflow. */
+	aspect-ratio: 16 / 10;
 	display: flex; flex-direction: column; justify-content: space-between;
 	/* A defocused scene rather than a fake screenshot: soft light where a
 	   window would be, warmth on the subject side. */
@@ -208,7 +212,7 @@ kbd {
 	content: ""; position: absolute; inset: 0; border: 3px solid #FF3B30;
 	border-radius: 18px; pointer-events: none;
 }
-.device .topgroup { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
+.device .topgroup { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; flex: none; }
 .device .toprow { display: flex; align-items: center; gap: 8px; align-self: stretch; }
 .pill {
 	display: inline-flex; align-items: center; gap: 8px;
@@ -232,7 +236,7 @@ kbd {
 .device .toprow .chip:first-of-type { margin-left: auto; }
 
 .panelmock {
-	background: var(--glass); border: 1px solid var(--hair);
+	background: var(--glass); border: 1px solid var(--hair); flex: none;
 	border-radius: var(--r-panel); padding: 14px; backdrop-filter: blur(20px);
 }
 .panelmock .row { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
@@ -249,6 +253,14 @@ kbd {
 .panelmock .seg span { font-size: 12px; padding: 4px 12px; border-radius: 10px; color: var(--txt2); }
 .panelmock .seg span.on { background: var(--accent); color: #fff; }
 .panelmock .chips { display: flex; gap: 8px; margin-left: auto; }
+
+/* The control panel is a fixed ~239px stack of rows, so 16:10 is shorter
+   than the content until the screen is about 382px wide — a ~470px
+   viewport. Below that the ratio gives way rather than clip the last row;
+   above it, nothing changes. */
+@media (max-width: 470px) {
+	.device .screen { aspect-ratio: auto; }
+}
 
 .caption { color: var(--txt3); font-size: 13px; margin-top: 14px; text-align: center; }
 

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -539,7 +539,6 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 	padding: 0; margin-bottom: 10px; font-size: 13px; font-weight: 600;
 	letter-spacing: 0.06em; text-transform: uppercase; color: var(--txt3);
 }
-.q-note { color: var(--txt3); font-size: 14px; margin: 10px 0 0; }
 /* Shown when the reader says they do not know: the guide has made the
    choice for them, so it says so rather than quietly picking. */
 .q-answer {

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -549,8 +549,26 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 .seg-choice label { position: relative; }
 .seg-choice input { position: absolute; opacity: 0; inset: 0; width: 100%; height: 100%; margin: 0; cursor: pointer; }
 .seg-choice span {
-	display: block; padding: 9px 18px; border-radius: 10px; font-size: 15px;
+	display: flex; align-items: center; gap: 9px;
+	padding: 9px 16px; border-radius: 10px; font-size: 15px;
 	color: var(--txt2); transition: background .15s ease, color .15s ease;
+}
+/* Icons only where they carry meaning — a cable, a Wi-Fi fan, a lens. The
+   operating systems get none: there is nothing to draw for them but
+   trademarks. */
+.opt-ic { width: 17px; height: 17px; flex: none; opacity: 0.85; }
+
+/* "Recommended" is a claim the docs make in prose; here it is a quiet
+   marker, not a second accent competing with the selected state. It has to
+   stay legible both on the panel and on the accent fill. */
+.rec {
+	font-style: normal; font-size: 10.5px; font-weight: 600;
+	letter-spacing: 0.05em; text-transform: uppercase;
+	color: var(--accent-light); background: rgba(61, 123, 255, 0.14);
+	border-radius: 999px; padding: 2px 7px; margin-left: 1px; white-space: nowrap;
+}
+.seg-choice input:checked + span .rec {
+	color: #fff; background: rgba(255, 255, 255, 0.22);
 }
 .seg-choice input:checked + span { background: var(--accent); color: #fff; font-weight: 600; }
 .seg-choice input:focus-visible + span { outline: 2px solid var(--accent-light); outline-offset: 2px; }
@@ -604,5 +622,21 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 @media (max-width: 560px) {
 	.seg-choice { display: flex; width: 100%; }
 	.seg-choice label { flex: 1; }
-	.seg-choice span { text-align: center; padding: 9px 10px; font-size: 14px; }
+	.seg-choice span { justify-content: center; padding: 9px 8px; font-size: 14px; gap: 6px; }
+	/* Three options plus a badge cannot share a phone's width. The
+	   recommendation survives as the accent dot the badge collapses to,
+	   with the word still there for a screen reader. */
+	.rec {
+		width: 6px; height: 6px; padding: 0; margin: 0; border-radius: 50%;
+		background: var(--accent-light); overflow: hidden; text-indent: -99em;
+	}
+	.seg-choice input:checked + span .rec { background: #fff; }
+}
+
+/* On the narrowest phones the icons are what pushes a label onto a second
+   line. They are decorative — the words are the control — so they go first
+   and the recommendation dot stays. */
+@media (max-width: 400px) {
+	.opt-ic { display: none; }
+	.seg-choice span { white-space: nowrap; }
 }

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -204,10 +204,14 @@ kbd {
 }
 
 /* The camera feed behind the controls, exactly as the app draws them over
-   live video. build.py adds `has-feed` only when the file is actually
-   present (see FEED_IMAGE), so a missing photo costs no failed request —
-   the panel just falls back to the tinted glow below. */
-.device .screen.has-feed { background-image: var(--feed); }
+   live video. build.py adds `has-feed`, and the --feed-* properties, only
+   for files that are actually present (see FEED_STEMS), so a missing photo
+   costs no failed request — the panel falls back to the tinted glow below.
+   Landscape by default; the narrow-viewport rule further down swaps in the
+   portrait frame, and either orientation stands in for a missing one. */
+.device .screen.has-feed {
+	background-image: var(--feed-landscape, var(--feed-portrait));
+}
 
 /* Without a photo: a defocused scene rather than a fake screenshot — soft
    light where a window would be, warmth on the subject side. With one, the
@@ -280,6 +284,11 @@ kbd {
    above it, nothing changes. */
 @media (max-width: 470px) {
 	.device .screen { aspect-ratio: auto; }
+	/* Standing tall, the panel is a portrait frame's shape — and a phone
+	   held upright is what the app looks like there anyway. */
+	.device .screen.has-feed {
+		background-image: var(--feed-portrait, var(--feed-landscape));
+	}
 }
 
 .caption { color: var(--txt3); font-size: 13px; margin-top: 14px; text-align: center; }

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -530,3 +530,79 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 .notfound .num { font-size: 15px; color: var(--accent); letter-spacing: 0.1em; }
 .notfound h1 { font-size: clamp(2rem, 4vw, 2.6rem); margin: 12px 0 16px; }
 .notfound p { color: var(--txt2); max-width: 34em; margin: 0 auto 28px; }
+
+/* ----------------------------------------------------------- setup guide */
+
+.wizard { border: 0; padding: 0; margin: 0 0 40px; display: grid; gap: 24px; }
+.wizard fieldset { border: 0; margin: 0; padding: 0; }
+.wizard legend {
+	padding: 0; margin-bottom: 10px; font-size: 13px; font-weight: 600;
+	letter-spacing: 0.06em; text-transform: uppercase; color: var(--txt3);
+}
+.q-note { color: var(--txt3); font-size: 14px; margin: 10px 0 0; }
+
+/* Segmented control, same metaphor as the app's Live panel. Real radios
+   underneath, so it is keyboard- and screen-reader-native and still works
+   with JavaScript off. */
+.seg-choice { display: inline-flex; flex-wrap: wrap; gap: 4px; background: rgba(255, 255, 255, 0.06);
+	border: 1px solid var(--hair); border-radius: 14px; padding: 4px; }
+.seg-choice label { position: relative; }
+.seg-choice input { position: absolute; opacity: 0; inset: 0; width: 100%; height: 100%; margin: 0; cursor: pointer; }
+.seg-choice span {
+	display: block; padding: 9px 18px; border-radius: 10px; font-size: 15px;
+	color: var(--txt2); transition: background .15s ease, color .15s ease;
+}
+.seg-choice input:checked + span { background: var(--accent); color: #fff; font-weight: 600; }
+.seg-choice input:focus-visible + span { outline: 2px solid var(--accent-light); outline-offset: 2px; }
+.seg-choice label:hover input:not(:checked) + span { background: rgba(255, 255, 255, 0.08); color: var(--txt); }
+
+.nojs { color: var(--txt3); font-size: 14.5px; margin: 0 0 32px; }
+
+.needs {
+	background: var(--bg-raised); border: 1px solid var(--hair);
+	border-radius: var(--r-panel); padding: 20px 24px; margin: 0 0 40px;
+}
+.needs > p {
+	margin: 0 0 10px; font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+	text-transform: uppercase; color: var(--txt3);
+}
+.needs ul { margin: 0; padding-left: 20px; color: var(--txt2); font-size: 15.5px; }
+.needs li { margin: 5px 0; }
+
+/* Steps renumber themselves: a hidden <li> takes no counter, so filtering
+   never leaves a gap in the sequence. */
+.guide { counter-reset: step; list-style: none; padding: 0; margin: 0; }
+.guide > li {
+	counter-increment: step; position: relative;
+	padding: 0 0 32px 52px; border-left: 1px solid var(--hair); margin-left: 15px;
+}
+.guide > li:last-child { border-left-color: transparent; padding-bottom: 0; }
+.guide > li::before {
+	content: counter(step); position: absolute; left: -16px; top: -4px;
+	width: 31px; height: 31px; border-radius: 50%;
+	background: var(--bg-raised); border: 1px solid var(--hair);
+	color: var(--accent-light); font-family: var(--mono); font-size: 14px;
+	display: flex; align-items: center; justify-content: center;
+}
+.guide h2 { font-size: 1.05rem; margin: 0 0 8px; font-weight: 600; }
+.guide p { margin: 8px 0; color: rgba(235, 235, 245, 0.78); font-size: 16px; }
+.guide pre { margin: 12px 0; font-size: 13.5px; }
+.guide .alt { color: var(--txt3); font-size: 14.5px; }
+.guide .warn {
+	border-left: 3px solid var(--amber); background: rgba(255, 159, 10, 0.06);
+	border-radius: 0 var(--r-chip) var(--r-chip) 0; padding: 12px 16px; font-size: 15px;
+}
+.guide .tag {
+	display: inline-block; vertical-align: middle; margin-left: 8px;
+	font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+	color: var(--txt2); background: rgba(255, 255, 255, 0.08);
+	border: 1px solid var(--hair); border-radius: 999px; padding: 2px 9px;
+}
+
+.guide-foot { color: var(--txt3); font-size: 14.5px; margin: 40px 0 0; }
+
+@media (max-width: 560px) {
+	.seg-choice { display: flex; width: 100%; }
+	.seg-choice label { flex: 1; }
+	.seg-choice span { text-align: center; padding: 9px 10px; font-size: 14px; }
+}

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -540,6 +540,13 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 	letter-spacing: 0.06em; text-transform: uppercase; color: var(--txt3);
 }
 .q-note { color: var(--txt3); font-size: 14px; margin: 10px 0 0; }
+/* Shown when the reader says they do not know: the guide has made the
+   choice for them, so it says so rather than quietly picking. */
+.q-answer {
+	color: var(--txt2); font-size: 14.5px; margin: 12px 0 0; max-width: 60ch;
+	border-left: 3px solid var(--accent); background: rgba(61, 123, 255, 0.06);
+	border-radius: 0 var(--r-chip) var(--r-chip) 0; padding: 12px 16px;
+}
 
 /* Segmented control, same metaphor as the app's Live panel. Real radios
    underneath, so it is keyboard- and screen-reader-native and still works
@@ -633,10 +640,11 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 	.seg-choice input:checked + span .rec { background: #fff; }
 }
 
-/* On the narrowest phones the icons are what pushes a label onto a second
-   line. They are decorative — the words are the control — so they go first
-   and the recommendation dot stays. */
-@media (max-width: 400px) {
+/* On a phone the icons are what push a label onto a second line — three
+   options plus a cable glyph do not fit a 430px row. They are decorative,
+   the words are the control, so they go first and the recommendation dot
+   stays. */
+@media (max-width: 479px) {
 	.opt-ic { display: none; }
 	.seg-choice span { white-space: nowrap; }
 }

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -552,11 +552,16 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
    with JavaScript off. */
 .seg-choice { display: inline-flex; flex-wrap: wrap; gap: 4px; background: rgba(255, 255, 255, 0.06);
 	border: 1px solid var(--hair); border-radius: 14px; padding: 4px; }
-.seg-choice label { position: relative; }
+.seg-choice label { position: relative; display: flex; }
 .seg-choice input { position: absolute; opacity: 0; inset: 0; width: 100%; height: 100%; margin: 0; cursor: pointer; }
+/* The recommendation sits on its own line under the label — flex-basis
+   pushes it there — so the options stay the same shape whether or not one
+   of them carries it. Spans fill their label so every pill in a row
+   matches height. */
 .seg-choice span {
-	display: flex; align-items: center; gap: 9px;
-	padding: 9px 16px; border-radius: 10px; font-size: 15px;
+	display: flex; flex: 1; flex-wrap: wrap;
+	align-items: center; justify-content: center; text-align: center;
+	gap: 2px 9px; padding: 8px 16px; border-radius: 10px; font-size: 15px;
 	color: var(--txt2); transition: background .15s ease, color .15s ease;
 }
 /* Icons only where they carry meaning — a cable, a Wi-Fi fan, a lens. The
@@ -565,17 +570,15 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 .opt-ic { width: 17px; height: 17px; flex: none; opacity: 0.85; }
 
 /* "Recommended" is a claim the docs make in prose; here it is a quiet
-   marker, not a second accent competing with the selected state. It has to
-   stay legible both on the panel and on the accent fill. */
+   marker, not a second accent competing with the selected state, and not a
+   pill inside a pill. It has to stay legible both on the panel and on the
+   accent fill. */
 .rec {
-	font-style: normal; font-size: 10.5px; font-weight: 600;
-	letter-spacing: 0.05em; text-transform: uppercase;
-	color: var(--accent-light); background: rgba(61, 123, 255, 0.14);
-	border-radius: 999px; padding: 2px 7px; margin-left: 1px; white-space: nowrap;
+	flex-basis: 100%; font-style: normal; font-size: 9.5px; font-weight: 600;
+	letter-spacing: 0.07em; text-transform: uppercase; white-space: nowrap;
+	color: var(--accent-light); opacity: 0.9;
 }
-.seg-choice input:checked + span .rec {
-	color: #fff; background: rgba(255, 255, 255, 0.22);
-}
+.seg-choice input:checked + span .rec { color: #fff; opacity: 0.85; }
 .seg-choice input:checked + span { background: var(--accent); color: #fff; font-weight: 600; }
 .seg-choice input:focus-visible + span { outline: 2px solid var(--accent-light); outline-offset: 2px; }
 .seg-choice label:hover input:not(:checked) + span { background: rgba(255, 255, 255, 0.08); color: var(--txt); }
@@ -628,15 +631,7 @@ h2:hover .anchor, h3:hover .anchor, .anchor:focus { opacity: 1; text-decoration:
 @media (max-width: 560px) {
 	.seg-choice { display: flex; width: 100%; }
 	.seg-choice label { flex: 1; }
-	.seg-choice span { justify-content: center; padding: 9px 8px; font-size: 14px; gap: 6px; }
-	/* Three options plus a badge cannot share a phone's width. The
-	   recommendation survives as the accent dot the badge collapses to,
-	   with the word still there for a screen reader. */
-	.rec {
-		width: 6px; height: 6px; padding: 0; margin: 0; border-radius: 50%;
-		background: var(--accent-light); overflow: hidden; text-indent: -99em;
-	}
-	.seg-choice input:checked + span .rec { background: #fff; }
+	.seg-choice span { padding: 8px 8px; font-size: 14px; gap: 2px 6px; }
 }
 
 /* On a phone the icons are what push a label onto a second line — three

--- a/site/static/js/setup.js
+++ b/site/static/js/setup.js
@@ -33,6 +33,7 @@
 		if (a.link === "usb") {
 			list.push("A USB data cable — not a charge-only one");
 			if (a.os === "windows") list.push("iTunes, for Apple's device driver");
+			if (a.os === "linux") list.push("The usbmuxd daemon, which most desktops already ship");
 		} else {
 			list.push("Both devices on the same network, without client isolation");
 		}

--- a/site/static/js/setup.js
+++ b/site/static/js/setup.js
@@ -64,13 +64,8 @@
 		var picked = answers();
 		var a = resolve(picked);
 
-		/* The general note argues for USB; the answer box says the guide has
-		   already chosen it. Showing both says the same thing twice. */
-		var unsure = picked.link === "unsure";
 		var note = document.getElementById("unsure-note");
-		if (note) note.hidden = !unsure;
-		var general = document.getElementById("link-note");
-		if (general) general.hidden = unsure;
+		if (note) note.hidden = picked.link !== "unsure";
 
 		var conditional = guide.querySelectorAll("[data-os], [data-link], [data-mode], [data-app]");
 		Array.prototype.forEach.call(conditional, function (el) {

--- a/site/static/js/setup.js
+++ b/site/static/js/setup.js
@@ -1,0 +1,90 @@
+/* The setup guide filters steps rather than generating them: every step is
+   in the HTML, tagged with the setups it belongs to, and answering a
+   question hides the ones that don't match. With JavaScript off nothing is
+   hidden and the page is still a complete, correctly ordered guide — which
+   is also what search engines index.
+
+   Answers live in the query string, so a configuration is a link. */
+(function () {
+	"use strict";
+
+	var FACETS = ["os", "link", "mode", "app"];
+
+	var form = document.getElementById("wizard");
+	var guide = document.getElementById("guide");
+	if (!form || !guide) return;
+
+	var nojs = document.getElementById("nojs");
+	if (nojs) nojs.hidden = true;
+
+	/* What the chosen setup requires, beyond the obvious. */
+	function needs(a) {
+		var list = ["OBS Studio 32 or newer", "An iPhone or iPad on iOS 15 or later"];
+		if (a.link === "usb") {
+			list.push("A USB data cable — not a charge-only one");
+			if (a.os === "windows") list.push("iTunes, for Apple's device driver");
+		} else {
+			list.push("Both devices on the same network, without client isolation");
+		}
+		if (a.app === "sideload") list.push("Sideloadly and an Apple ID — re-install weekly");
+		if (a.app === "xcode") list.push("A Mac with Xcode and XcodeGen");
+		return list;
+	}
+
+	function answers() {
+		var a = {};
+		FACETS.forEach(function (f) {
+			var picked = form.querySelector('input[name="' + f + '"]:checked');
+			if (picked) a[f] = picked.value;
+		});
+		return a;
+	}
+
+	/* An element is shown unless it names a facet and disagrees with the
+	   answer. Steps and the paragraphs inside them are filtered alike. */
+	function matches(el, a) {
+		for (var i = 0; i < FACETS.length; i++) {
+			var want = el.getAttribute("data-" + FACETS[i]);
+			if (want && want !== a[FACETS[i]]) return false;
+		}
+		return true;
+	}
+
+	function apply(push) {
+		var a = answers();
+
+		var conditional = guide.querySelectorAll("[data-os], [data-link], [data-mode], [data-app]");
+		Array.prototype.forEach.call(conditional, function (el) {
+			el.hidden = !matches(el, a);
+		});
+
+		var box = document.getElementById("needs");
+		var list = document.getElementById("needs-list");
+		if (box && list) {
+			list.textContent = "";
+			needs(a).forEach(function (text) {
+				var li = document.createElement("li");
+				li.textContent = text;
+				list.appendChild(li);
+			});
+			box.hidden = false;
+		}
+
+		if (push && window.history && window.history.replaceState) {
+			var q = FACETS.map(function (f) { return f + "=" + a[f]; }).join("&");
+			window.history.replaceState(null, "", "?" + q);
+		}
+	}
+
+	/* Restore a shared or bookmarked configuration. */
+	var params = new URLSearchParams(window.location.search);
+	FACETS.forEach(function (f) {
+		var value = params.get(f);
+		if (!value) return;
+		var input = form.querySelector('input[name="' + f + '"][value="' + value + '"]');
+		if (input) input.checked = true;
+	});
+
+	form.addEventListener("change", function () { apply(true); });
+	apply(params.toString().length > 0);
+})();

--- a/site/static/js/setup.js
+++ b/site/static/js/setup.js
@@ -17,6 +17,16 @@
 	var nojs = document.getElementById("nojs");
 	if (nojs) nojs.hidden = true;
 
+	/* "Not sure" is an answer, not a missing one: it takes the USB path,
+	   which is what the documentation recommends and what needs the least
+	   from the reader's network. Everything downstream sees "usb". */
+	function resolve(a) {
+		var out = {}, k;
+		for (k in a) { if (a.hasOwnProperty(k)) out[k] = a[k]; }
+		if (out.link === "unsure") out.link = "usb";
+		return out;
+	}
+
 	/* What the chosen setup requires, beyond the obvious. */
 	function needs(a) {
 		var list = ["OBS Studio 32 or newer", "An iPhone or iPad on iOS 15 or later"];
@@ -51,7 +61,16 @@
 	}
 
 	function apply(push) {
-		var a = answers();
+		var picked = answers();
+		var a = resolve(picked);
+
+		/* The general note argues for USB; the answer box says the guide has
+		   already chosen it. Showing both says the same thing twice. */
+		var unsure = picked.link === "unsure";
+		var note = document.getElementById("unsure-note");
+		if (note) note.hidden = !unsure;
+		var general = document.getElementById("link-note");
+		if (general) general.hidden = unsure;
 
 		var conditional = guide.querySelectorAll("[data-os], [data-link], [data-mode], [data-app]");
 		Array.prototype.forEach.call(conditional, function (el) {
@@ -71,7 +90,7 @@
 		}
 
 		if (push && window.history && window.history.replaceState) {
-			var q = FACETS.map(function (f) { return f + "=" + a[f]; }).join("&");
+			var q = FACETS.map(function (f) { return f + "=" + picked[f]; }).join("&");
 			window.history.replaceState(null, "", "?" + q);
 		}
 	}


### PR DESCRIPTION
## What & why

A running branch for the site review. **Not to be merged until the round is
done** — commits get added as each item is settled, and this description tracks
them.

### 1. The hero device panel clipped on phones

The panel is not a screenshot: it's the app's Live screen rebuilt from the
design tokens in `docs/UI_DESIGN.md`, so it stays crisp at any size and can't
drift out of date. It was laid out wrong on a narrow screen, though — the box
was pinned to `aspect-ratio: 16 / 10`, which at phone widths computes shorter
than the control rows need, and the box hides its overflow. The AF / Lock row
was sliced in half: **44px of overflow at 390px**, none at 768px and above,
which is why desktop checks never caught it.

16:10 only has room for the controls once the screen is ~382px wide (a ~470px
viewport), so below that the ratio gives way and content sets the height. The
children are `flex: none` so a future squeeze can't be absorbed by silently
shrinking a row. Verified across 18 widths from 320 to 1920: no clipping, and
the crossover is 1.64 → 1.60.

### 2. A camera frame behind the panel, chosen by orientation

The controls looked like a widget rather than a camera app with nothing behind
them. Now: drop `static/img/hero-feed-landscape.*` and/or
`hero-feed-portrait.*` into `static/img/` and the build puts them behind the
panel, the way the app draws controls over live video.

The stylesheet picks by viewport, on a seam that already exists — portrait
below 470px, where the panel drops 16:10 and stands tall (and where a phone
held upright is what the app looks like anyway); landscape above it. Either
orientation stands in for a missing one, and **only the one in use is
downloaded**. With neither file the panel keeps its tinted glow and the page
requests nothing extra — which is the state this PR ships in, pending real
frames.

The gradient layer doubles as a scrim when a photo is present, so white
controls stay legible over any image.

### 3. A setup guide that filters itself

Setup branches more than a linear page can serve: 3 operating systems × 2
transports × 3 app-install routes × camera-or-screen = 36 combinations, of
which any one reader needs about a dozen steps and has to skip the rest.

`/setup/` asks those four questions and shows only the matching steps. The
design choice worth keeping: it **filters rather than generates**. Every step is
in the HTML with its conditions attached, so with JavaScript off nothing is
hidden and the page is still a complete, correctly ordered guide — which is
also what search engines index. There's no template to drift from the docs, and
steps renumber themselves because a hidden `<li>` takes no CSS counter.

- Answers live in the query string, so a configuration is a shareable link:
  `/setup/?os=macos&link=wifi&mode=screen&app=sideload`.
- A "what you'll need" box names what's easy to discover too late — a data
  cable rather than charge-only, iTunes on Windows, the weekly re-install a
  sideload costs.
- The questions are real radio inputs styled as the app's segmented control, so
  the page is keyboard- and screen-reader-native and works unstyled.
- Linked from the home hero, the docs index and the install page.

Also in this commit: heading anchors are now documentation-only. They earn
their place where headings are destinations people link to; on the marketing
pages they were a stray `#` on hover.

## How it was tested

- `python3 build.py` → 16 pages; `python3 check-links.py` → 0 broken links.
- Two full configurations walked end to end (Windows/USB/camera/TestFlight and
  macOS/Wi-Fi/screen/sideload): correct steps, correct order, correct
  "what you'll need", no page errors, and the URL round-trips.
- JavaScript disabled: all 22 steps present, the explanatory notice visible,
  the radios still usable.
- Feed layer verified in all three states — both images, one image, neither —
  checking which file each viewport actually fetches.
- Rendered at 390px and 1280px: no horizontal overflow.

`Release-Skip: true`; `site/` matches none of the release paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSuQicA9NrKWwpgzY6SvhA